### PR TITLE
docs: add dummy plugin structure and CI repository strategy

### DIFF
--- a/pj_marketplace/documentation/ARCHITECTURE.md
+++ b/pj_marketplace/documentation/ARCHITECTURE.md
@@ -10,31 +10,37 @@
 
 ### 1.1 High-Level Architecture
 
+![Architecture](diagrams/architecture.png)
+
+<details>
+<summary>PlantUML source</summary>
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+
+title PlotJuggler Marketplace Architecture
+
+rectangle "GitHub" {
+  database "Registry\nregistry.json" as reg
+  rectangle "Extension Repos" as ext
+  ext -right-> reg : Automatic PR
+}
+
+rectangle "PlotJuggler" {
+  component "Marketplace UI" as ui
+  component "Extension Manager" as em
+  database "installed.json" as local
+  ui --> em
+  em --> local
+}
+
+reg ..> ui : HTTPS fetch
+ext ..> em : Download ZIP
+
+@enduml
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           PLOTJUGGLER                                    │
-│  ┌─────────────────────────────────────────────────────────────────┐   │
-│  │                    MARKETPLACE MODULE                            │   │
-│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │   │
-│  │  │ Registry     │  │ Extension    │  │ Download     │          │   │
-│  │  │ Manager      │  │ Manager      │  │ Manager      │          │   │
-│  │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘          │   │
-│  │         │                 │                 │                   │   │
-│  │         └─────────────────┼─────────────────┘                   │   │
-│  │                           │                                      │   │
-│  │  ┌────────────────────────┴────────────────────────────────┐   │   │
-│  │  │                    UI LAYER                              │   │   │
-│  │  │  MarketplaceWindow │ ExtensionList │ ExtensionDetail    │   │   │
-│  │  └─────────────────────────────────────────────────────────┘   │   │
-│  └─────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────┘
-         │                           │                           │
-         ▼                           ▼                           ▼
-┌─────────────────┐      ┌─────────────────┐      ┌─────────────────┐
-│ GitHub Registry │      │ GitHub Releases │      │ Local Storage   │
-│ (JSON file)     │      │ (ZIP artifacts) │      │ (installed.json)│
-└─────────────────┘      └─────────────────┘      └─────────────────┘
-```
+</details>
 
 ### 1.2 Design Principles
 
@@ -69,11 +75,11 @@ marketplace/
 │   │   ├── DownloadManager.h/cpp  # HTTP download with progress
 │   │   └── PlatformUtils.h/cpp    # OS detection, paths
 │   ├── ui/
-│   │   ├── MarketplaceWindow.h/cpp      # Main window/dialog
-│   │   ├── ExtensionListWidget.h/cpp    # Sidebar list
-│   │   ├── ExtensionCardDelegate.h/cpp  # Custom card rendering
-│   │   ├── ExtensionDetailWidget.h/cpp  # Detail panel
-│   │   └── StatusBarManager.h/cpp       # Progress/status
+│   │   ├── MarketplaceWindow.h/cpp       # Main window/dialog
+│   │   ├── ExtensionListWidget.h/cpp     # Extension list (table or list)
+│   │   ├── ExtensionDetailDialog.h/cpp   # Detail dialog (Approach A - POC)
+│   │   ├── ExtensionDetailWidget.h/cpp   # Detail panel (Approach B - future)
+│   │   └── StatusBarManager.h/cpp        # Progress/status
 │   └── utils/
 │       ├── ChecksumVerifier.h/cpp # SHA256 verification
 │       └── ZipExtractor.h/cpp     # ZIP decompression
@@ -101,7 +107,6 @@ struct Extension {
     struct Platform {
         QString url;
         QString checksum;     // sha256:...
-        qint64 size_bytes;
     };
     QMap<QString, Platform> platforms;  // linux-x86_64, windows-x86_64, etc.
 
@@ -138,126 +143,105 @@ struct InstalledExtension {
 
 ### 3.1 Installation Flow
 
+![Installation Flow](diagrams/installation-flow.png)
+
+<details>
+<summary>PlantUML source</summary>
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+title Installation Flow
+
+start
+:Click Install;
+:Detect platform;
+:Download ZIP;
+:Verify SHA256;
+if (Checksum OK?) then (yes)
+  :Extract to temp;
+  :Validate manifest;
+  if (Is update?) then (yes)
+    :Backup current;
+  endif
+  :Move to extensions/;
+  :Update installed.json;
+else (no)
+  :Error: invalid checksum;
+endif
+stop
+@enduml
 ```
-┌────────────┐     ┌────────────────┐     ┌─────────────────┐
-│ User clicks│     │ DownloadManager│     │ ExtensionManager│
-│  "Install" │     │                │     │                 │
-└─────┬──────┘     └───────┬────────┘     └────────┬────────┘
-      │                    │                       │
-      │ install(id)        │                       │
-      │───────────────────────────────────────────>│
-      │                    │                       │
-      │                    │  download(url)        │
-      │                    │<──────────────────────│
-      │                    │                       │
-      │                    │  progress(%)          │
-      │<───────────────────│                       │
-      │                    │                       │
-      │                    │  completed(data)      │
-      │                    │──────────────────────>│
-      │                    │                       │
-      │                    │         verifyChecksum(data, sha256)
-      │                    │                       │
-      │                    │         extract(data, path)
-      │                    │                       │
-      │                    │         updateLocalState()
-      │                    │                       │
-      │ installed(success) │                       │
-      │<───────────────────────────────────────────│
-```
+</details>
 
 ### 3.2 Windows Staging Flow
 
+![Windows Staging Flow](diagrams/windows-staging.png)
+
+<details>
+<summary>PlantUML source</summary>
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+
+title Windows Staging Flow
+
+start
+:Download ZIP;
+:Extract to .pending/{id}/;
+note right: Staging folder
+:Notify "Restart required";
+stop
+
+start
+:PlotJuggler restarts;
+:Move .pending/{id}/ to extensions/{id}/;
+note right: Previous backup in\n.backup/{id}-{ver}/
+:Load plugin;
+if (Load successful?) then (yes)
+  :Plugin active;
+else (no)
+  :Restore from backup;
+  :Notify rollback;
+endif
+stop
+@enduml
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    INSTALL/UPDATE REQUEST                            │
-└─────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-                    ┌─────────────────┐
-                    │ Is Windows?     │
-                    └────────┬────────┘
-                             │
-              ┌──────────────┴──────────────┐
-              │ YES                         │ NO
-              ▼                             ▼
-    ┌─────────────────┐           ┌─────────────────┐
-    │ Download to     │           │ Download and    │
-    │ .pending/       │           │ install directly│
-    └────────┬────────┘           └─────────────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Show "Restart   │
-    │ required"       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────────────────────────────────────────────────────┐
-    │                    ON NEXT STARTUP                               │
-    └─────────────────────────────────────────────────────────────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Check .pending/ │
-    │ for updates     │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Backup current  │
-    │ to .backup/     │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Move .pending/  │
-    │ to extensions/  │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Load plugin     │
-    └────────┬────────┘
-             │
-    ┌────────┴────────┐
-    │ Success?        │
-    └────────┬────────┘
-             │
-    ┌────────┴────────┐
-    │ YES        NO   │
-    ▼                 ▼
-  Done         ┌─────────────────┐
-               │ Restore from    │
-               │ .backup/        │
-               └─────────────────┘
-```
+</details>
 
 ### 3.3 Rollback Flow
 
+![Rollback Flow](diagrams/rollback-flow.png)
+
+<details>
+<summary>PlantUML source</summary>
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+title Rollback Flow
+
+start
+:PlotJuggler starts;
+:Load plugins;
+while (More plugins?) is (yes)
+  :Load next plugin;
+  if (Load OK?) then (yes)
+    :Plugin active;
+  else (no)
+    if (Backup exists?) then (yes)
+      :Restore backup;
+    else (no)
+      :Disable extension;
+    endif
+  endif
+endwhile (no)
+:System ready;
+stop
+@enduml
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  PlotJuggler    │     │ ExtensionManager│     │  Plugin Loader  │
-│    Startup      │     │                 │     │                 │
-└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
-         │                       │                       │
-         │ loadExtensions()      │                       │
-         │──────────────────────>│                       │
-         │                       │                       │
-         │                       │  loadPlugin(path)     │
-         │                       │──────────────────────>│
-         │                       │                       │
-         │                       │  CRASH/FAIL           │
-         │                       │<──────────────────────│
-         │                       │                       │
-         │                       │  hasBackup(id)?       │
-         │                       │                       │
-         │                       │  YES: restore(backup) │
-         │                       │  NO: disable(id)      │
-         │                       │                       │
-         │ rollbackNotification  │                       │
-         │<──────────────────────│                       │
-```
+</details>
 
 ---
 
@@ -528,7 +512,82 @@ jobs:
 
 ## 8. UI Layout
 
-### 8.1 Main Window Structure
+> **Note (2026-03-05 meeting):** Two UI approaches were discussed. For the POC, the simpler approach (Approach A) is recommended. The VS Code-style panel layout (Approach B) can be implemented in future iterations if needed.
+
+### 8.1 Approach A: Simple List + Dialog (POC)
+
+This is the approach shown by Davide in the March 5th meeting mockup. It prioritizes simplicity and fast implementation.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  PlotJuggler Marketplace                              [X]   │
+├─────────────────────────────────────────────────────────────┤
+│ [Buscar...              ] [Categoría ▼] [Refresh]           │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│   CanOpen parser           v1.0.0    [install]              │
+│   Parquet parser           v2.1.0    [installed]            │
+│   FFT Toolbox              v1.3.0    [installed]            │
+│   CSV exporter             v1.0.0    [update] ⬆            │
+│   ROS 2 Streaming          v3.0.0    [install]              │
+│                                                              │
+├─────────────────────────────────────────────────────────────┤
+│  Status: Ready                              [████████] 100% │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Interaction model:**
+- **Mouseover** on item → QToolTip with brief description
+- **Double-click** on item → Opens QDialog with full details (author, URL, changelog)
+- **Click on button** → Executes action (install/uninstall/update)
+
+**Detail dialog (on double-click):**
+
+```
+┌───────────────────────────────────────┐
+│  FFT Toolbox                    [X]   │
+├───────────────────────────────────────┤
+│  Version: 1.3.0                       │
+│  Author: PlotJuggler Team             │
+│  Category: toolbox                    │
+│                                       │
+│  Description:                         │
+│  Fast Fourier Transform toolbox for   │
+│  signal analysis and frequency domain │
+│  visualization.                       │
+│                                       │
+│  Changelog:                           │
+│  v1.3.0 - Added Hamming window        │
+│  v1.2.0 - Performance improvements    │
+│                                       │
+│  [View on GitHub]  [Close]            │
+└───────────────────────────────────────┘
+```
+
+**Qt Widget Hierarchy (Approach A):**
+
+```
+MarketplaceWindow (QDialog)
+├── QVBoxLayout
+│   ├── QHBoxLayout (toolbar)
+│   │   ├── QLineEdit (Search)
+│   │   ├── QComboBox (Category filter)
+│   │   └── QPushButton (Refresh)
+│   ├── QTableWidget or QListWidget (extension list)
+│   │   └── Rows with: Name, Version, Action Button
+│   └── QStatusBar
+│       ├── QLabel (Status message)
+│       └── QProgressBar (Download progress)
+└── ExtensionDetailDialog (QDialog) ← Opens on double-click
+    ├── QLabel (Name, Version, Author)
+    ├── QTextBrowser (Description)
+    ├── QTextBrowser (Changelog)
+    └── QDialogButtonBox
+```
+
+### 8.2 Approach B: VS Code-Style Panel (Future)
+
+This more elaborate approach can be implemented after the POC if a richer UX is desired.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
@@ -555,7 +614,7 @@ jobs:
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-### 8.2 Qt Widget Hierarchy
+**Qt Widget Hierarchy (Approach B):**
 
 ```
 MarketplaceWindow (QMainWindow or QDialog)

--- a/pj_marketplace/documentation/ARCHITECTURE.md
+++ b/pj_marketplace/documentation/ARCHITECTURE.md
@@ -376,7 +376,48 @@ target_include_directories(pj_marketplace PUBLIC
 )
 ```
 
-### 6.2 Plugin Template CMakeLists.txt
+### 6.2 Dummy Plugin CMakeLists.txt (POC)
+
+For the POC phase, dummy plugins are extremely simple — no Qt, no SDK, just pure C++:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(dummy_extension VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(dummy_extension SHARED
+    src/dummy_plugin.cpp
+)
+
+set_target_properties(dummy_extension PROPERTIES
+    PREFIX ""
+    POSITION_INDEPENDENT_CODE ON
+)
+
+install(TARGETS dummy_extension DESTINATION .)
+install(FILES manifest.json DESTINATION .)
+```
+
+**dummy_plugin.cpp:**
+```cpp
+extern "C" {
+    const char* getPluginMetadata() {
+        return R"({
+            "id": "dummy-extension",
+            "name": "Dummy Extension",
+            "version": "1.0.0"
+        })";
+    }
+}
+```
+
+> **Note:** Each dummy extension folder is an independent C++ project with its own CMakeLists.txt. No Qt dependency means trivial cross-platform compilation.
+
+### 6.3 Real Plugin Template CMakeLists.txt (Post-POC)
+
+For real plugins that use the PlotJuggler SDK:
 
 ```cmake
 cmake_minimum_required(VERSION 3.16)
@@ -409,6 +450,20 @@ install(FILES README.md LICENSE DESTINATION .)
 ---
 
 ## 7. CI/CD Architecture
+
+### 7.0 Repository Strategy
+
+Extensions can be organized in two ways:
+
+1. **Separate repos** (one repo per extension): Each extension has its own CI, independent versioning, standard tag → release flow.
+
+2. **Mono-repo** (multiple extensions in one repo): A single repository with multiple extension folders, each with its own CMakeLists.txt. Releases are tagged per-component (e.g., `dummy-csv/v1.0.0`, `dummy-parquet/v2.0.0`).
+
+**Reference:** [Foxglove MCAP](https://github.com/foxglove/mcap) uses the mono-repo approach with per-component releases:
+- https://github.com/foxglove/mcap/releases
+- https://github.com/foxglove/mcap/tags
+
+> **Note:** The registry doesn't care which approach is used — it only needs direct URLs to the ZIP artifacts. Both approaches work.
 
 ### 7.1 Release Workflow
 

--- a/pj_marketplace/documentation/PLAN.md
+++ b/pj_marketplace/documentation/PLAN.md
@@ -17,20 +17,23 @@ A working prototype integrated into PlotJuggler is expected by the end of March 
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ WEEK 1 (5-11 March): Standalone MVP                                     │
-│ Deliverable: Qt app that loads registry, shows list, installs dummy    │
+│ WEEK 1 (5-11 March): Standalone POC                                     │
+│ Deliverable: Qt app with dummy plugins, works on Linux AND Windows     │
+│ Note: Dummy plugins only have getMetadata() function                   │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ WEEK 2 (12-18 March): PlotJuggler Integration                           │
 │ Deliverable: Marketplace opens as dialog INSIDE PlotJuggler            │
+│ ★ 16 March: Convergence with Davide on real plugin interfaces          │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ WEEK 3 (19-25 March): Real Plugin End-to-End                            │
 │ Deliverable: Install REAL plugin from marketplace, works in PJ         │
+│ Note: Davide traveling to Japan (work continues autonomously)          │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -74,13 +77,14 @@ A working prototype integrated into PlotJuggler is expected by the end of March 
 |----|-------------|--------|
 | F-11 | Cache with TTL | Direct fetch works |
 | F-12 | Backup on updates | V1 can be simple |
-| F-13 | Automatic rollback | Manual OK for beta |
-| F-14 | Windows staging | Linux-only in March |
+| F-13 | Automatic rollback | NOT PRIORITY per Davide (2026-03-05) |
 | F-15 | Enable/Disable | Uninstall/reinstall |
 | F-16 | Cancel download | Nice-to-have |
 | F-17 | Update All | One by one OK |
 | F-18 | Confirmation dialogs | If time in W4 |
 | F-19-23 | Polish features | Post-MVP |
+
+> **Note (2026-03-05 meeting):** Windows support moved to Week 1. Rollback explicitly deprioritized by Davide.
 
 ---
 

--- a/pj_marketplace/documentation/PLAN.md
+++ b/pj_marketplace/documentation/PLAN.md
@@ -19,7 +19,8 @@ A working prototype integrated into PlotJuggler is expected by the end of March 
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ WEEK 1 (5-11 March): Standalone POC                                     │
 │ Deliverable: Qt app with dummy plugins, works on Linux AND Windows     │
-│ Note: Dummy plugins only have getMetadata() function                   │
+│ Note: Dummy plugins only have getMetadata() function (no Qt, no SDK)   │
+│ CI Reference: Foxglove MCAP (mono-repo with per-component releases)    │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼

--- a/pj_marketplace/documentation/REQUIREMENTS.md
+++ b/pj_marketplace/documentation/REQUIREMENTS.md
@@ -247,6 +247,7 @@ PlotJuggler has grown significantly, evolving from an internal tool to a de fact
 - GitHub raw URLs remain accessible
 - Extensions are < 50MB compressed
 - Registry has < 100 extensions in foreseeable future
+- **POC phase:** Dummy plugins are pure C++ with no Qt dependency (only `getMetadata()` function), simplifying cross-platform CI
 
 ### 8.3 Out of Scope (v1.0)
 

--- a/pj_marketplace/documentation/REQUIREMENTS.md
+++ b/pj_marketplace/documentation/REQUIREMENTS.md
@@ -309,8 +309,7 @@ The minimum viable product is successful if:
       "platforms": {
         "linux-x86_64": {
           "url": "https://...",
-          "checksum": "sha256:...",
-          "size_bytes": 12345
+          "checksum": "sha256:..."
         }
       },
       "changelog": {

--- a/pj_marketplace/documentation/SPRINT_PROPOSAL.md
+++ b/pj_marketplace/documentation/SPRINT_PROPOSAL.md
@@ -25,8 +25,7 @@
 
 | Feature | Why It Can Wait |
 |---------|-----------------|
-| Windows staging | Ship Linux first |
-| Automatic rollback | Nice-to-have, not critical for demo |
+| Automatic rollback | NOT PRIORITY per Davide (2026-03-05 meeting) |
 | Enable/Disable | Can uninstall/reinstall |
 | Local cache with TTL | Direct network fetch works |
 | Backup on updates | First version simple |
@@ -36,26 +35,31 @@
 | Complete GitHub CI Template | Manual is OK for beta |
 | Metrics (downloads, rating) | Later phase |
 
+> **Update (2026-03-05):** Windows support moved to Week 1 per Davide's request. POC must work on both Linux and Windows.
+
 ---
 
 ## 2. High-Level View (4 Weeks)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ WEEK 1 (5-11 March): Standalone MVP                                     │
-│ Deliverable: Qt app that loads registry, shows list, installs dummy    │
+│ WEEK 1 (5-11 March): Standalone POC                                     │
+│ Deliverable: Qt app with dummy plugins, works on Linux AND Windows     │
+│ Note: Dummy plugins only have getMetadata() function                   │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ WEEK 2 (12-18 March): PlotJuggler Integration                           │
 │ Deliverable: Marketplace opens as dialog INSIDE PlotJuggler            │
+│ ★ 16 March: Convergence with Davide on real plugin interfaces          │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ WEEK 3 (19-25 March): Real Plugin End-to-End                            │
 │ Deliverable: Install REAL plugin from marketplace, works in PJ         │
+│ Note: Davide traveling to Japan (work continues autonomously)          │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -99,6 +103,7 @@
 - [ ] Can search "dummy" and find the extension
 - [ ] Click "Install" → downloads → extracts → appears as installed
 - [ ] Click "Uninstall" → removed
+- [ ] **Works on Linux AND Windows** (per Davide 2026-03-05)
 
 ---
 
@@ -263,14 +268,15 @@ MARCH TOTAL:  10/10 P0 (100%)
 
 ## 10. What's NOT in This Plan (and That's OK)
 
-1. **Windows**: Linux only. macOS/Windows in phase 2 (April)
-2. **Automatic rollback**: Manual is OK for v1
+1. ~~**Windows**: Linux only~~ → **UPDATED:** Windows included in Week 1 (2026-03-05)
+2. **Automatic rollback**: NOT PRIORITY per Davide (2026-03-05)
 3. **Enable/Disable**: Uninstall/reinstall works
 4. **Icons**: Text only
 5. **Changelog UI**: README in details panel
 6. **Multiple registries**: One hardcoded registry
 7. **Complete CI Template**: Manual documentation
 8. **Sophisticated cache**: Direct fetch every time
+9. **macOS**: Phase 2 (April)
 
 ---
 

--- a/pj_marketplace/documentation/USER_MANUAL.md
+++ b/pj_marketplace/documentation/USER_MANUAL.md
@@ -43,16 +43,17 @@
 
 ### 2.2 Browsing Extensions
 
-The marketplace window has two panels:
+The marketplace window shows a list of all extensions with their status:
 
-| Panel | Content |
-|-------|---------|
-| **Left sidebar** | List of extensions (installed and available) |
-| **Right panel** | Details of selected extension |
+| Column | Content |
+|--------|---------|
+| **Name** | Extension name |
+| **Version** | Current version |
+| **Status** | `[install]`, `[installed]`, or `[update]` |
 
-**Sections in the sidebar:**
-- **INSTALLED** — Extensions you have installed
-- **AVAILABLE** — Extensions you can install
+**To see extension details:** Double-click on any extension to open a detail dialog with full information (description, author, changelog).
+
+**Quick tip:** Hover over an extension to see a brief description tooltip.
 
 ### 2.3 Searching and Filtering
 
@@ -73,12 +74,12 @@ The marketplace window has two panels:
 
 ### 2.4 Installing an Extension
 
-1. Find the extension in the sidebar
-2. Click on it to see details
-3. Review the description, version, and author
-4. Click **Install**
-5. Wait for download and extraction
-6. See "Installation complete" message
+1. Find the extension in the list
+2. (Optional) Double-click to see details in a dialog
+3. Click the **[install]** button next to the extension
+4. Wait for download and extraction
+5. See "Installation complete" message
+6. Button changes to **[installed]**
 
 **On Windows:** You may see "Restart required to complete installation"
 

--- a/pj_marketplace/documentation/USER_MANUAL.md
+++ b/pj_marketplace/documentation/USER_MANUAL.md
@@ -115,6 +115,14 @@ To re-enable:
 
 ## 3. Developer Guide
 
+> **Note (POC vs Real Plugins):**
+>
+> During the POC phase (March 2026), we use **dummy plugins** that only have a `getMetadata()` function — no Qt, no SDK dependency. This simplifies CI and cross-platform builds.
+>
+> **Real plugins** (post-POC) will use the PlotJuggler SDK and may have Qt UI files. The workflow below describes the full process for real plugins.
+>
+> **CI Options:** Extensions can live in separate repos (one per extension) or in a mono-repo with per-component releases (see [Foxglove MCAP](https://github.com/foxglove/mcap) as reference). The registry supports both approaches.
+
 ### 3.1 Creating a New Extension
 
 **Prerequisites:**

--- a/pj_marketplace/documentation/plotjuggler-marketplace-spec-v1.0.0-en.md
+++ b/pj_marketplace/documentation/plotjuggler-marketplace-spec-v1.0.0-en.md
@@ -661,7 +661,59 @@ The flow is:
 
 ## 12. Graphical Interface
 
-### 12.1 General Layout
+> **Note (2026-03-05 meeting):** Two UI approaches were discussed. For the POC/MVP, the simpler approach (12.1.A) is recommended. The VS Code-style panel layout (12.1.B) can be implemented in future iterations if needed.
+
+### 12.1.A Simple List + Dialog (POC/MVP)
+
+This approach prioritizes simplicity and fast implementation. Shown by Davide in the March 5th meeting.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  PlotJuggler Marketplace                              [X]   │
+├─────────────────────────────────────────────────────────────┤
+│ [Search...              ] [Category ▼] [Refresh]            │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│   CanOpen parser           v1.0.0    [install]              │
+│   Parquet parser           v2.1.0    [installed]            │
+│   FFT Toolbox              v1.3.0    [installed]            │
+│   CSV exporter             v1.0.0    [update] ⬆            │
+│   ROS 2 Streaming          v3.0.0    [install]              │
+│                                                              │
+├─────────────────────────────────────────────────────────────┤
+│  Status: Ready                              [████████] 100% │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Interaction model:**
+- **Mouseover** on item → Tooltip with brief description
+- **Double-click** on item → Opens dialog with full details
+- **Click on button** → Executes action (install/uninstall/update)
+
+**Detail dialog (on double-click):**
+
+```
+┌───────────────────────────────────────┐
+│  FFT Toolbox                    [X]   │
+├───────────────────────────────────────┤
+│  Version: 1.3.0                       │
+│  Author: PlotJuggler Team             │
+│  Category: toolbox                    │
+│                                       │
+│  Description:                         │
+│  Fast Fourier Transform toolbox...    │
+│                                       │
+│  Changelog:                           │
+│  v1.3.0 - Added Hamming window        │
+│  v1.2.0 - Performance improvements    │
+│                                       │
+│  [View on GitHub]  [Close]            │
+└───────────────────────────────────────┘
+```
+
+### 12.1.B VS Code-Style Panel Layout (Future)
+
+This more elaborate approach can be implemented after the POC if a richer UX is desired.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
@@ -713,21 +765,26 @@ The flow is:
 - Category filter (Loader, Streamer, Parser, Toolbox)
 - Quick filters: `@installed`, `@updates`
 
-### 12.3 Detail Panel
+### 12.3 Extension Details
 
-**Header:**
+**For Approach A (dialog):**
 
+The detail dialog shows:
+- Name, version, author
+- Category and tags
+- Description text
+- Changelog
+- Link to repository
+
+**For Approach B (panel):**
+
+The detail panel includes:
 - Icon (64x64)
 - Name and publisher
 - Metrics (downloads, rating)
 - Action buttons (Install/Update/Disable/Uninstall)
 - Metadata (category, tags, platforms, minimum version)
-
-**Tabs:**
-
-- Details: Description/README
-- Changelog: Version history
-- Dependencies: Required extensions
+- Tabs: Details (README), Changelog, Dependencies
 
 ### 12.4 Management Controls
 


### PR DESCRIPTION
## Summary

Follow-up documentation clarifications after review discussion.

### Changes:
- Add CMakeLists.txt example for dummy plugins (no Qt, no SDK dependency)
- Add section 7.0 Repository Strategy explaining mono-repo vs separate repos
- Reference Foxglove MCAP as CI model for per-component releases
- Add developer guide note distinguishing POC (dummy) vs real plugins
- Add assumption about dummy plugins in requirements

### Files:
- pj_marketplace/documentation/ARCHITECTURE.md
- pj_marketplace/documentation/PLAN.md
- pj_marketplace/documentation/REQUIREMENTS.md
- pj_marketplace/documentation/USER_MANUAL.md