### PR TITLE
docs(requirements): add F-24/F-25 and registry URL settings feature

### DIFF
--- a/pj_marketplace/documentation/REQUIREMENTS.md
+++ b/pj_marketplace/documentation/REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # PlotJuggler Marketplace — Requirements
 
 > **Version:** 1.0.0
-> **Last Updated:** 2026-03-04
+> **Last Updated:** 2026-03-11
 > **Purpose:** Define WHAT the application should do, not HOW
 
 ---
@@ -42,6 +42,8 @@ PlotJuggler has grown significantly, evolving from an internal tool to a de fact
 | **Management**     | Enable/Disable       | Activate/deactivate extensions without uninstalling           |
 |                    | Rollback             | Automatic restoration if a plugin fails to load               |
 |                    | Persistent state     | Local storage of installed extensions (JSON)                  |
+|                    | Registry URL settings | Configure registry URL at runtime via ⚙ settings dialog; change triggers immediate refresh |
+|                    | Registry URL persistence | Last configured registry URL saved and restored between sessions |
 | **UI/UX**          | Download progress    | Progress bar in status bar                                    |
 |                    | Notifications        | Status messages and available update alerts                   |
 |                    | Context menu         | Quick actions per installed extension                         |
@@ -110,6 +112,8 @@ PlotJuggler has grown significantly, evolving from an internal tool to a de fact
 
 | ID | Requirement | Acceptance Criteria |
 |----|-------------|---------------------|
+| F-24 | Configure registry URL via settings dialog | User can open ⚙ settings, enter a custom URL, and the marketplace immediately fetches from the new URL |
+| F-25 | Persist registry URL between sessions | The last configured registry URL is saved and automatically restored on next launch |
 | F-11 | Local registry cache with TTL | Registry is cached locally, refreshed after expiration |
 | F-12 | Backup previous version on updates | Old version saved before overwriting |
 | F-13 | Automatic rollback if plugin fails | If plugin crashes on load, previous version is restored |


### PR DESCRIPTION
## Summary

Add new functional requirements for configurable registry URL:
- **F-24**: Configurable registry URL in settings
- **F-25**: Registry URL validation

## Changes
- `pj_marketplace/documentation/REQUIREMENTS.md`

## Dependencies
- Builds on top of PR #7