### PR TITLE
feat(sdk): add parser options metadata API for dynamic dialog configuration

### DIFF
--- a/pj_base/include/pj_base/data_source_protocol.h
+++ b/pj_base/include/pj_base/data_source_protocol.h
@@ -150,7 +150,32 @@ typedef struct PJ_data_source_runtime_host_vtable_t {
    */
   bool (*push_raw_message)(
       void* ctx, PJ_parser_binding_handle_t handle, int64_t host_timestamp_ns, PJ_bytes_view_t payload);
+
+  /**
+   * Query the options metadata for the parser that handles @p encoding.
+   * Returns a WidgetData JSON fragment (same format as optionsMetadata() on
+   * MessageParserPluginBase), or NULL / "{}" if no parser is found.
+   * Mirrors the original PlotJuggler parserFactories()->at(enc)->optionsWidget()
+   * pattern, adapted for the headless SDK.
+   * Plugin-owned string; valid until the next call on the same context.
+   *
+   * @note Added as extension field. Plugin MUST check struct_size before
+   *       accessing this field to maintain backward compatibility with older hosts.
+   */
+  const char* (*query_parser_options_metadata)(void* ctx, PJ_string_view_t encoding);
 } PJ_data_source_runtime_host_vtable_t;
+
+/**
+ * Check if a runtime host vtable supports the query_parser_options_metadata field.
+ * Use this before calling vtable->query_parser_options_metadata() to maintain
+ * backward compatibility with older hosts.
+ */
+static inline bool PJ_runtime_host_has_query_parser_options_metadata(
+    const PJ_data_source_runtime_host_vtable_t* vtable) {
+  return vtable &&
+         vtable->struct_size >= offsetof(PJ_data_source_runtime_host_vtable_t, query_parser_options_metadata) +
+                                    sizeof(vtable->query_parser_options_metadata);
+}
 
 /** Fat pointer pairing a runtime host context with its vtable. */
 typedef struct {

--- a/pj_base/include/pj_base/message_parser_protocol.h
+++ b/pj_base/include/pj_base/message_parser_protocol.h
@@ -87,7 +87,30 @@ typedef struct PJ_message_parser_vtable_t {
 
   /** Return the last error message, or NULL if none. Plugin-owned string. */
   const char* (*get_last_error)(void* ctx);
+
+  /**
+   * Return a WidgetData JSON fragment describing this parser's configurable
+   * options (e.g. checkboxes, spin boxes). The host uses this to dynamically
+   * build a parser-specific options section in a data source dialog.
+   * Mirrors the original PlotJuggler optionsWidget() factory pattern.
+   * Returns a JSON object in WidgetData format, or NULL / "{}" if none.
+   * Plugin-owned string; valid until the next call on the same context.
+   *
+   * @note Added in struct version with size >= 80 bytes (original was 72).
+   *       Host MUST check struct_size before accessing this field.
+   */
+  const char* (*options_metadata)(void* ctx);
 } PJ_message_parser_vtable_t;
+
+/**
+ * Check if a parser vtable supports the options_metadata field.
+ * Use this before calling vtable->options_metadata() to maintain
+ * backward compatibility with older plugins.
+ */
+static inline bool PJ_parser_vtable_has_options_metadata(const PJ_message_parser_vtable_t* vtable) {
+  return vtable && vtable->struct_size >= offsetof(PJ_message_parser_vtable_t, options_metadata) +
+                                              sizeof(vtable->options_metadata);
+}
 
 /** Signature of the exported entry point: `PJ_get_message_parser_vtable`. */
 typedef const PJ_message_parser_vtable_t* (*PJ_get_message_parser_vtable_fn)(void);

--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -174,6 +174,22 @@ class DataSourceRuntimeHostView {
     return okStatus();
   }
 
+  /**
+   * Query the options metadata for the parser that handles @p encoding.
+   * Returns a WidgetData JSON fragment or "{}" if unavailable.
+   * Mirrors the original PlotJuggler parserFactories()->at(enc)->optionsWidget().
+   */
+  [[nodiscard]] std::string queryParserOptionsMetadata(std::string_view encoding) const {
+    // Check struct_size for backward compatibility with older hosts
+    if (!valid() || !PJ_runtime_host_has_query_parser_options_metadata(host_.vtable) ||
+        host_.vtable->query_parser_options_metadata == nullptr) {
+      return "{}";
+    }
+    PJ_string_view_t enc{encoding.data(), encoding.size()};
+    const char* result = host_.vtable->query_parser_options_metadata(host_.ctx, enc);
+    return (result != nullptr && result[0] != '\0') ? std::string(result) : std::string("{}");
+  }
+
   /// Access the underlying C ABI struct.
   [[nodiscard]] const PJ_data_source_runtime_host_t& raw() const {
     return host_;

--- a/pj_base/include/pj_base/sdk/detail/message_parser_trampolines.hpp
+++ b/pj_base/include/pj_base/sdk/detail/message_parser_trampolines.hpp
@@ -116,4 +116,18 @@ inline const char* MessageParserPluginBase::trampoline_get_last_error(void* ctx)
   return self->last_error_.empty() ? nullptr : self->last_error_.c_str();
 }
 
+inline const char* MessageParserPluginBase::trampoline_options_metadata(void* ctx) {
+  auto* self = static_cast<MessageParserPluginBase*>(ctx);
+  try {
+    self->options_buf_ = self->optionsMetadata();
+    return self->options_buf_.c_str();
+  } catch (const std::exception& e) {
+    self->last_error_ = e.what();
+    return "{}";
+  } catch (...) {
+    self->last_error_ = "Unknown exception in options_metadata";
+    return "{}";
+  }
+}
+
 }  // namespace PJ

--- a/pj_base/include/pj_base/sdk/message_parser_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/message_parser_plugin_base.hpp
@@ -73,6 +73,17 @@ class MessageParserPluginBase {
     return last_error_;
   }
 
+  /**
+   * Return a WidgetData JSON fragment describing this parser's configurable
+   * options. A data source dialog (e.g. MQTT) calls this at dialog time via
+   * the runtime host to dynamically show parser-specific option widgets.
+   * Mirrors the original PlotJuggler optionsWidget() factory pattern.
+   * Return "{}" if this parser has no configurable options.
+   */
+  virtual std::string optionsMetadata() const {
+    return "{}";
+  }
+
   template <typename CreateFn>
   static const PJ_message_parser_vtable_t* vtableWithCreate(CreateFn create_fn, const char* manifest) {
     PJ_ASSERT(manifest != nullptr && manifest[0] == '{', "manifest must be a JSON object");
@@ -91,6 +102,7 @@ class MessageParserPluginBase {
         trampoline_load_config,
         trampoline_parse,
         trampoline_get_last_error,
+        trampoline_options_metadata,
     };
     return &vt;
   }
@@ -111,6 +123,7 @@ class MessageParserPluginBase {
  private:
   PJ_parser_write_host_t write_host_{};
   std::string config_buf_;
+  mutable std::string options_buf_;
   mutable std::string last_error_;
 
   // C ABI trampolines — exception-safe bridges between host vtable calls and
@@ -122,6 +135,7 @@ class MessageParserPluginBase {
   static bool trampoline_load_config(void* ctx, const char* config_json);
   static bool trampoline_parse(void* ctx, int64_t timestamp_ns, PJ_bytes_view_t payload);
   static const char* trampoline_get_last_error(void* ctx);
+  static const char* trampoline_options_metadata(void* ctx);
 };
 
 }  // namespace PJ

--- a/pj_base/tests/data_source_plugin_base_test.cpp
+++ b/pj_base/tests/data_source_plugin_base_test.cpp
@@ -345,6 +345,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost(RuntimeRecorder* recorder) {
       .request_stop = RuntimeRecorder::requestStop,
       .ensure_parser_binding = RuntimeRecorder::ensureParserBinding,
       .push_raw_message = RuntimeRecorder::pushRawMessage,
+      .query_parser_options_metadata = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = recorder, .vtable = &vtable};
 }

--- a/pj_plugins/include/pj_plugins/host/message_parser_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/message_parser_handle.hpp
@@ -90,6 +90,14 @@ class MessageParserHandle {
     return safeString(vt_->get_last_error(ctx_));
   }
 
+  [[nodiscard]] std::string optionsMetadata() const {
+    // Check struct_size for backward compatibility with older plugins
+    if (!PJ_parser_vtable_has_options_metadata(vt_) || vt_->options_metadata == nullptr) {
+      return "{}";
+    }
+    return safeString(vt_->options_metadata(ctx_));
+  }
+
   [[nodiscard]] const PJ_message_parser_vtable_t* vtable() const {
     return vt_;
   }

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -97,6 +97,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost() {
       .request_stop = MinimalRuntimeHost::requestStop,
       .ensure_parser_binding = MinimalRuntimeHost::ensureParserBinding,
       .push_raw_message = MinimalRuntimeHost::pushRawMessage,
+      .query_parser_options_metadata = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = reinterpret_cast<void*>(0x2), .vtable = &vtable};
 }

--- a/pj_plugins/tests/delegated_ingest_integration_test.cpp
+++ b/pj_plugins/tests/delegated_ingest_integration_test.cpp
@@ -193,6 +193,7 @@ PJ_data_source_runtime_host_t makeBridgeRuntimeHost(BridgeRuntimeHost* bridge) {
       .request_stop = BridgeRuntimeHost::requestStop,
       .ensure_parser_binding = BridgeRuntimeHost::ensureParserBinding,
       .push_raw_message = BridgeRuntimeHost::pushRawMessage,
+      .query_parser_options_metadata = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = bridge, .vtable = &vtable};
 }

--- a/pj_plugins/tests/file_source_integration_test.cpp
+++ b/pj_plugins/tests/file_source_integration_test.cpp
@@ -153,6 +153,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost(RuntimeHostState* state) {
       .request_stop = rhRequestStop,
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
+      .query_parser_options_metadata = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
 }

--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -131,6 +131,24 @@ bool rhPushRawMessage(void* ctx, PJ_parser_binding_handle_t handle, int64_t time
   return it->second.parser->parse(timestamp_ns, PJ::Span<const uint8_t>(payload.data, payload.size));
 }
 
+const char* rhQueryParserOptionsMetadata(void* ctx, PJ_string_view_t encoding_view) {
+  auto* state = static_cast<RuntimeHostState*>(ctx);
+  if (state->registry == nullptr) {
+    return nullptr;
+  }
+  std::string_view encoding(encoding_view.data, encoding_view.size);
+  auto* parser_entry = state->registry->findParserByEncoding(encoding);
+  if (parser_entry == nullptr) {
+    return nullptr;
+  }
+  auto handle = parser_entry->library.createHandle();
+  if (!handle.valid()) {
+    return nullptr;
+  }
+  state->options_metadata_buf = handle.optionsMetadata();
+  return state->options_metadata_buf.c_str();
+}
+
 }  // namespace
 
 PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostState* state) {
@@ -147,8 +165,14 @@ PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostStat
       .request_stop = rhRequestStop,
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
+      .query_parser_options_metadata = rhQueryParserOptionsMetadata,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
+}
+
+void DataSourceSession::bindRuntimeHostEarly() {
+  runtime_state_.registry = registry_;
+  (void)handle_.bindRuntimeHost(makeRuntimeHost(&runtime_state_));
 }
 
 DataSourceSession::DataSourceSession(

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -46,6 +46,9 @@ struct RuntimeHostState {
   PluginRegistry* registry = nullptr;
   uint32_t next_binding_id = 1;
   std::unordered_map<uint32_t, ParserBinding> parser_bindings;
+
+  // Scratch buffer for query_parser_options_metadata return value
+  std::string options_metadata_buf;
 };
 
 class DataSourceSession : public QObject {
@@ -55,6 +58,10 @@ class DataSourceSession : public QObject {
   DataSourceSession(
       PJ::DataEngine& engine, PJ::DataSourceLibrary& library, PJ::TimeDomainId td_id, std::string source_name,
       PluginRegistry* registry, QObject* parent = nullptr);
+
+  /// Bind a partial runtime host (registry only) so the dialog can query
+  /// parser options metadata before start(). Must be called before showDialog.
+  void bindRuntimeHostEarly();
 
   bool startFileImport(const std::string& config_json);
   bool startStream(const std::string& config_json);

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -271,6 +271,12 @@ void MainWindow::onStartStream() {
     (void)session->handle().loadConfig(config);
   }
 
+  // Bind a partial runtime host (registry only) before showing the dialog so
+  // that the plugin can query parser options metadata at dialog time.
+  // Mirrors the original PlotJuggler pattern where parserFactories() is
+  // available process-wide before any dialog is shown.
+  session->bindRuntimeHostEarly();
+
   // Dialog flow — use the session's own handle, not a temp handle
   if ((source->capabilities & PJ_DATA_SOURCE_CAPABILITY_HAS_DIALOG) != 0) {
     auto vt_result = source->library.resolveDialogVtable();

--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -76,6 +76,14 @@ void PluginRegistry::scanDirectory() {
             }
           }
         }
+        // "additional_encodings" lists extra encodings handled by the same parser
+        if (manifest.contains("additional_encodings") && manifest["additional_encodings"].is_array()) {
+          for (const auto& e : manifest["additional_encodings"]) {
+            if (e.is_string()) {
+              loaded.encodings.push_back(e.get<std::string>());
+            }
+          }
+        }
       } catch (...) {
         loaded.name = entry.path().stem().string();
       }


### PR DESCRIPTION
## Motivation

Data source plugins that use **delegated ingest** (pushing raw bytes for host-side parsing) often need to show parser-specific configuration options in their dialogs. For example, MQTT and Foxglove Bridge plugins must let users configure options like "max array size" or "use message timestamp" that are specific to JSON, Protobuf, or ROS parsers.

### The Problem (Blocker)

In the current SDK, there is **no way for a data source plugin to query what configuration options a parser supports**. The original PlotJuggler solved this with a process-wide `parserFactories()` registry that plugins could access directly via `parserFactories()->at(encoding)->optionsWidget()`.

Without this capability, plugins are forced to either:
1. **Hardcode** parser options (brittle, breaks when parsers change)
2. **Skip** parser configuration entirely (poor UX)
3. **Duplicate** parser option definitions (maintenance burden)

### The Solution

This PR extends the SDK with a clean, decoupled mechanism:
- Parsers declare their options via `optionsMetadata()` (WidgetData JSON)
- Data sources query parser options via `queryParserOptionsMetadata(encoding)`
- No direct coupling between plugins; the host mediates

## Design Decision: Backward Compatibility

Uses `struct_size` field for extensibility instead of protocol version bump:
- Older plugins continue to work with newer hosts (graceful `"{}"` fallback)
- Newer plugins work with older hosts (check `struct_size` before access)
- **No need to recompile existing plugins in the registry**

## Changes

### SDK Extensions
- `MessageParserPluginBase::optionsMetadata()` - virtual returning WidgetData JSON
- `PJ_message_parser_vtable_t::options_metadata` - new vtable field
- `PJ_data_source_runtime_host_vtable_t::query_parser_options_metadata()` - host callback
- Helper functions: `PJ_parser_vtable_has_options_metadata()`, `PJ_runtime_host_has_query_parser_options_metadata()`

### Host Integration
- `DataSourceSession::bindRuntimeHostEarly()` - pre-dialog registry access
- `MainWindow` calls this before `showDialog()`
- `PluginRegistry` reads `additional_encodings` from parser manifests

## Test Plan

- [x] Existing plugins load without recompilation
- [x] Parsers can expose options via `optionsMetadata()`
- [ ] Data sources can query options via `queryParserOptionsMetadata()`
- [ ] Build passes with no warnings
