### PR TITLE
fix: cross-platform plugin registry scan

### DIFF
--- a/pj_marketplace/include/pj_marketplace/platform_utils.hpp
+++ b/pj_marketplace/include/pj_marketplace/platform_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <string>
 
 namespace PJ {
 
@@ -15,6 +16,12 @@ class PlatformUtils {
   static QString currentPlatform();
 
   static bool isWindows();
+
+  // Returns the shared library extension for the current platform:
+  //   Linux:   ".so"
+  //   Windows: ".dll"
+  //   macOS:   ".dylib"
+  static std::string pluginExtension();
 
   // Root of all PlotJuggler user data, using the OS-standard writable location:
   //   Linux:   ~/.local/share/plotjuggler/

--- a/pj_marketplace/src/core/PlatformUtils.cpp
+++ b/pj_marketplace/src/core/PlatformUtils.cpp
@@ -26,6 +26,16 @@ QString PlatformUtils::currentPlatform() {
   return os + "-" + arch;
 }
 
+std::string PlatformUtils::pluginExtension() {
+#if defined(Q_OS_WIN)
+  return ".dll";
+#elif defined(Q_OS_MACOS)
+  return ".dylib";
+#else
+  return ".so";
+#endif
+}
+
 bool PlatformUtils::isWindows() {
 #ifdef Q_OS_WIN
   return true;

--- a/pj_marketplace/src/core/mock/MockRegistryManager.cpp
+++ b/pj_marketplace/src/core/mock/MockRegistryManager.cpp
@@ -7,8 +7,6 @@ MockRegistryManager::MockRegistryManager(QObject* parent) : RegistryManager(pare
     Extension e;
     e.id = "csv-loader"; e.name = "CSV Loader";
     e.description = "Load CSV/TSV files with automatic column detection and configurable delimiters.";
-
-
     e.author = "PlotJuggler Team"; e.publisher = "PlotJuggler";
     e.license = "MIT"; e.website = "https://github.com/facontidavide/PlotJuggler";
     e.category = "data_loader"; e.tags = {"csv", "tsv", "file"};
@@ -68,8 +66,6 @@ MockRegistryManager::MockRegistryManager(QObject* parent) : RegistryManager(pare
     Extension e;
     e.id = "ros-bundle"; e.name = "ROS Bundle";
     e.description = "All-in-one bundle: ROS 1 bag loader, ROS 2 streaming, and rosout log viewer.";
-
-
     e.author = "PlotJuggler Team"; e.publisher = "PlotJuggler";
     e.license = "LGPL-2.1"; e.website = "https://github.com/facontidavide/PlotJuggler";
     e.category = "bundle"; e.tags = {"ros", "ros2", "bag", "bundle"};

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -566,7 +566,6 @@ void MainWindow::onOpenMarketplace() {
   PJ::MarketplaceWindow window(registry_url, this);
   window.resize(700, 500);
   window.exec();
-
   if (window.installationsChanged()) {
     registry_.reload();
   }

--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -1,5 +1,7 @@
 #include "plugin_registry.hpp"
 
+#include "pj_marketplace/platform_utils.hpp"
+
 #include <filesystem>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -21,7 +23,7 @@ void PluginRegistry::scanDirectory() {
       continue;
     }
     auto path = entry.path().string();
-    if (entry.path().extension() != ".so") {
+    if (entry.path().extension() != PJ::PlatformUtils::pluginExtension()) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Add `PlatformUtils::pluginExtension()` to return the correct shared library extension for the current platform
- Update plugin registry scan to use this helper instead of hardcoding `.so`

## Problem

The plugin registry was hardcoded to scan for `.so` files only, which works on Linux but fails on Windows (`.dll`) and macOS (`.dylib`).

## Solution

Add a cross-platform helper that returns the correct extension based on compile-time platform detection:
- Linux: `.so`
- Windows: `.dll`
- macOS: `.dylib`

## Test plan

- [ ] Run `./build.sh --debug && ./test.sh` — all tests pass
- [ ] On Windows: verify plugins with `.dll` extension are discovered
- [ ] On macOS: verify plugins with `.dylib` extension are discovered
