### PR TITLE
refactor(plugin_registry): smart incremental reload

### DIFF
--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -1,5 +1,6 @@
 #include "plugin_registry.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -7,6 +8,67 @@
 namespace proto {
 
 PluginRegistry::PluginRegistry(std::string_view plugin_dir) : plugin_dir_(plugin_dir) {}
+
+std::optional<LoadedDataSource> PluginRegistry::tryLoadDataSource(const std::filesystem::path& so_path) {
+  auto result = PJ::DataSourceLibrary::load(so_path.string());
+  if (!result) {
+    return std::nullopt;
+  }
+  LoadedDataSource loaded;
+  loaded.library = std::move(*result);
+  loaded.path = so_path.string();
+  loaded.loaded_mtime = std::filesystem::last_write_time(so_path);
+
+  auto handle = loaded.library.createHandle();
+  loaded.capabilities = handle.capabilities();
+  try {
+    auto manifest = nlohmann::json::parse(handle.manifest());
+    loaded.name = manifest.value("name", so_path.stem().string());
+    if (manifest.contains("file_extensions")) {
+      for (const auto& ext : manifest["file_extensions"]) {
+        loaded.file_extensions.push_back(ext.get<std::string>());
+      }
+    }
+  } catch (...) {
+    loaded.name = so_path.stem().string();
+  }
+  std::cerr << "Loaded DataSource: " << loaded.name << " from " << loaded.path << "\n";
+  return loaded;
+}
+
+std::optional<LoadedMessageParser> PluginRegistry::tryLoadMessageParser(const std::filesystem::path& so_path) {
+  auto result = PJ::MessageParserLibrary::load(so_path.string());
+  if (!result) {
+    return std::nullopt;
+  }
+  LoadedMessageParser loaded;
+  loaded.library = std::move(*result);
+  loaded.path = so_path.string();
+  loaded.loaded_mtime = std::filesystem::last_write_time(so_path);
+
+  auto handle = loaded.library.createHandle();
+  try {
+    auto manifest = nlohmann::json::parse(handle.manifest());
+    loaded.name = manifest.value("name", so_path.stem().string());
+    // "encoding" can be a string or an array of strings
+    if (manifest.contains("encoding")) {
+      const auto& enc = manifest["encoding"];
+      if (enc.is_string()) {
+        loaded.encodings.push_back(enc.get<std::string>());
+      } else if (enc.is_array()) {
+        for (const auto& e : enc) {
+          if (e.is_string()) {
+            loaded.encodings.push_back(e.get<std::string>());
+          }
+        }
+      }
+    }
+  } catch (...) {
+    loaded.name = so_path.stem().string();
+  }
+  std::cerr << "Loaded MessageParser: " << loaded.name << " from " << loaded.path << "\n";
+  return loaded;
+}
 
 void PluginRegistry::scanDirectory() {
   namespace fs = std::filesystem;
@@ -16,88 +78,90 @@ void PluginRegistry::scanDirectory() {
     return;
   }
 
-  for (const auto& entry : fs::directory_iterator(plugin_dir_)) {
-    if (!entry.is_regular_file()) {
+  for (const auto& entry : fs::recursive_directory_iterator(plugin_dir_)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".so") {
       continue;
     }
-    auto path = entry.path().string();
-    if (entry.path().extension() != ".so") {
-      continue;
+    if (auto ds = tryLoadDataSource(entry.path())) {
+      data_sources_.push_back(std::move(*ds));
+    } else if (auto mp = tryLoadMessageParser(entry.path())) {
+      message_parsers_.push_back(std::move(*mp));
+    } else {
+      std::cerr << "Failed to load plugin: " << entry.path() << "\n";
     }
-
-    // Try as DataSource
-    auto ds_result = PJ::DataSourceLibrary::load(path);
-    if (ds_result) {
-      LoadedDataSource loaded;
-      loaded.library = std::move(*ds_result);
-
-      auto handle = loaded.library.createHandle();
-      loaded.capabilities = handle.capabilities();
-
-      auto manifest_str = handle.manifest();
-      try {
-        auto manifest = nlohmann::json::parse(manifest_str);
-        loaded.name = manifest.value("name", entry.path().stem().string());
-        if (manifest.contains("file_extensions")) {
-          for (const auto& ext : manifest["file_extensions"]) {
-            loaded.file_extensions.push_back(ext.get<std::string>());
-          }
-        }
-      } catch (...) {
-        loaded.name = entry.path().stem().string();
-      }
-
-      std::cerr << "Loaded DataSource: " << loaded.name << " from " << path << "\n";
-      data_sources_.push_back(std::move(loaded));
-      continue;
-    }
-
-    // Try as MessageParser
-    auto mp_result = PJ::MessageParserLibrary::load(path);
-    if (mp_result) {
-      LoadedMessageParser loaded;
-      loaded.library = std::move(*mp_result);
-
-      auto handle = loaded.library.createHandle();
-      auto manifest_str = handle.manifest();
-      try {
-        auto manifest = nlohmann::json::parse(manifest_str);
-        loaded.name = manifest.value("name", entry.path().stem().string());
-        // "encoding" can be a string or an array of strings
-        if (manifest.contains("encoding")) {
-          auto& enc = manifest["encoding"];
-          if (enc.is_string()) {
-            loaded.encodings.push_back(enc.get<std::string>());
-          } else if (enc.is_array()) {
-            for (const auto& e : enc) {
-              if (e.is_string()) {
-                loaded.encodings.push_back(e.get<std::string>());
-              }
-            }
-          }
-        }
-      } catch (...) {
-        loaded.name = entry.path().stem().string();
-      }
-
-      std::cerr << "Loaded MessageParser: " << loaded.name << " from " << path << "\n";
-      message_parsers_.push_back(std::move(loaded));
-      continue;
-    }
-
-    // Neither DataSource nor MessageParser — log both errors for diagnostics.
-    std::cerr << "Failed to load plugin: " << path << "\n"
-              << "  as DataSource: " << ds_result.error() << "\n"
-              << "  as MessageParser: " << mp_result.error() << "\n";
   }
 }
 
 void PluginRegistry::reload() {
-  data_sources_.clear();
-  message_parsers_.clear();
-  scanDirectory();
-}
+  namespace fs = std::filesystem;
 
+  if (!fs::is_directory(plugin_dir_)) {
+    std::cerr << "Plugin directory not found: " << plugin_dir_ << "\n";
+    return;
+  }
+
+  // Collect all .so files currently on disk
+  std::vector<fs::path> on_disk;
+  for (const auto& entry : fs::recursive_directory_iterator(plugin_dir_)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".so") {
+      on_disk.push_back(entry.path());
+    }
+  }
+
+  // Remove entries whose .so no longer exists on disk
+  auto is_gone = [&](const std::string& p) {
+    return std::none_of(on_disk.begin(), on_disk.end(),
+                        [&](const fs::path& dp) { return dp.string() == p; });
+  };
+  std::erase_if(data_sources_, [&](const LoadedDataSource& ds) {
+    if (is_gone(ds.path)) {
+      std::cerr << "Unloaded DataSource (removed): " << ds.path << "\n";
+      return true;
+    }
+    return false;
+  });
+  std::erase_if(message_parsers_, [&](const LoadedMessageParser& mp) {
+    if (is_gone(mp.path)) {
+      std::cerr << "Unloaded MessageParser (removed): " << mp.path << "\n";
+      return true;
+    }
+    return false;
+  });
+
+  // Load new .so files; reload modified ones
+  for (const auto& so_path : on_disk) {
+    const std::string path_str = so_path.string();
+    const auto disk_mtime = fs::last_write_time(so_path);
+
+    auto ds_it = std::find_if(data_sources_.begin(), data_sources_.end(),
+                              [&](const LoadedDataSource& ds) { return ds.path == path_str; });
+    if (ds_it != data_sources_.end()) {
+      if (disk_mtime <= ds_it->loaded_mtime) {
+        continue;
+      }
+      std::cerr << "Reloading updated DataSource: " << path_str << "\n";
+      data_sources_.erase(ds_it);
+    } else {
+      auto mp_it = std::find_if(message_parsers_.begin(), message_parsers_.end(),
+                                [&](const LoadedMessageParser& mp) { return mp.path == path_str; });
+      if (mp_it != message_parsers_.end()) {
+        if (disk_mtime <= mp_it->loaded_mtime) {
+          continue;
+        }
+        std::cerr << "Reloading updated MessageParser: " << path_str << "\n";
+        message_parsers_.erase(mp_it);
+      }
+    }
+
+    if (auto ds = tryLoadDataSource(so_path)) {
+      data_sources_.push_back(std::move(*ds));
+    } else if (auto mp = tryLoadMessageParser(so_path)) {
+      message_parsers_.push_back(std::move(*mp));
+    } else {
+      std::cerr << "Failed to load plugin: " << path_str << "\n";
+    }
+  }
+}
 std::vector<LoadedDataSource*> PluginRegistry::fileImportSources() {
   std::vector<LoadedDataSource*> result;
   for (auto& ds : data_sources_) {

--- a/pj_proto_app/src/plugin_registry.hpp
+++ b/pj_proto_app/src/plugin_registry.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -11,15 +13,19 @@ namespace proto {
 
 struct LoadedDataSource {
   PJ::DataSourceLibrary library;
+  std::string path;
   std::string name;
   std::vector<std::string> file_extensions;
   uint64_t capabilities = 0;
+  std::filesystem::file_time_type loaded_mtime;
 };
 
 struct LoadedMessageParser {
   PJ::MessageParserLibrary library;
+  std::string path;
   std::string name;
   std::vector<std::string> encodings;
+  std::filesystem::file_time_type loaded_mtime;
 };
 
 class PluginRegistry {
@@ -38,6 +44,9 @@ class PluginRegistry {
   [[nodiscard]] LoadedMessageParser* findParserByEncoding(std::string_view encoding);
 
  private:
+  static std::optional<LoadedDataSource> tryLoadDataSource(const std::filesystem::path& so_path);
+  static std::optional<LoadedMessageParser> tryLoadMessageParser(const std::filesystem::path& so_path);
+
   std::string plugin_dir_;
   std::vector<LoadedDataSource> data_sources_;
   std::vector<LoadedMessageParser> message_parsers_;


### PR DESCRIPTION
## Summary

- Replace full clear+rescan with mtime-based diffing in `reload()`
- Plugins whose `.so` was removed are unloaded
- Plugins whose mtime hasn't changed are skipped (no dlclose/dlopen)
- New or modified `.so` files are loaded/reloaded

## Problem

Previously `reload()` was a full clear + rescan, unloading every plugin on each call regardless of what changed on disk.

## Solution

Implement an incremental strategy that tracks file paths and modification times, only reloading plugins when necessary.

## Test plan

- [ ] Run `./build.sh --debug && ./test.sh` — all tests pass
- [ ] Add a new plugin `.so` and call reload — plugin is loaded
- [ ] Remove a plugin `.so` and call reload — plugin is unloaded
- [ ] Touch a plugin `.so` and call reload — plugin is reloaded
- [ ] Call reload without changes — no plugins are reloaded