### PR TITLE
fix(ui): prevent horizontal stretching of status messages

### DIFF
--- a/pj_marketplace/src/ui/marketplace_window.ui
+++ b/pj_marketplace/src/ui/marketplace_window.ui
@@ -91,13 +91,14 @@ QScrollArea > QWidget > QWidget { background: palette(mid); }</string>
      <item>
       <widget class="QLabel" name="status_label_">
        <property name="text"><string/></property>
+       <property name="wordWrap"><bool>true</bool></property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="status_stretch">
-       <property name="orientation"><enum>Qt::Horizontal</enum></property>
-       <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
-      </spacer>
      </item>
      <item>
       <widget class="QProgressBar" name="progress_bar_">


### PR DESCRIPTION
## Summary

- Enable word wrap and vertical expansion for status labels in Marketplace
- Maintain consistent UI width when displaying long status/error messages

## Problem

Long status messages would expand the UI horizontally, causing inconsistent widths and breaking visual alignment.

## Solution

- Enable `wordWrap` property on status labels to wrap text into multiple lines
- Update `sizePolicy` to Expanding/Minimum for vertical growth while respecting width
- Remove redundant horizontal spacers

## Test plan

- [x] Open Marketplace and trigger a long error message
- [x] Verify message wraps vertically instead of stretching horizontally
- [x] Verify marketplace width remains consistent