### PR TITLE
fix(plugin-registry): read additional_encodings from parser manifests

### DIFF
--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -52,9 +52,8 @@ std::optional<LoadedMessageParser> PluginRegistry::tryLoadMessageParser(const st
   try {
     auto manifest = nlohmann::json::parse(handle.manifest());
     loaded.name = manifest.value("name", so_path.stem().string());
-    // "encoding" can be a string or an array of strings
-    if (manifest.contains("encoding")) {
-      const auto& enc = manifest["encoding"];
+    // Helper to push encoding(s) from a JSON value (string or array of strings)
+    auto push_encodings = [&](const nlohmann::json& enc) {
       if (enc.is_string()) {
         loaded.encodings.push_back(enc.get<std::string>());
       } else if (enc.is_array()) {
@@ -64,6 +63,14 @@ std::optional<LoadedMessageParser> PluginRegistry::tryLoadMessageParser(const st
           }
         }
       }
+    };
+    // Primary encoding field
+    if (manifest.contains("encoding")) {
+      push_encodings(manifest["encoding"]);
+    }
+    // Additional encoding aliases (e.g., "ros1"/"ros2" for ROS parser)
+    if (manifest.contains("additional_encodings")) {
+      push_encodings(manifest["additional_encodings"]);
     }
   } catch (...) {
     loaded.name = so_path.stem().string();


### PR DESCRIPTION
## Summary

The host only read the primary `encoding` field from plugin manifests. Parsers that declare encoding aliases under `additional_encodings` were not registered for those encodings, causing import failures for files using those encodings.

**Problem:** MCAP files with `messageEncoding: "ros1"` (instead of the canonical `"ros1msg"`) fail to import because no parser is registered for that encoding.

**Solution:** Read both `encoding` and `additional_encodings` from the manifest and register the parser for all declared encodings.

## Technical Details

Parser manifests can declare:
- `encoding`: primary encoding (e.g., `"ros2msg"`)
- `additional_encodings`: aliases (e.g., `["ros1msg", "cdr", "ros1", "ros2"]`)

Both fields now get added to the parser's registered encodings list in `PluginRegistry::tryLoadMessageParser()`.

## Related

- **pj-official-plugins PR #16**: Adds `"ros1"` and `"ros2"` to `additional_encodings` in `parser_ros/manifest.json`
- Without this core change, PR #16 has no effect

## Files Changed

- `pj_proto_app/src/plugin_registry.cpp` — read `additional_encodings` field