### PR TITLE
feat(extension_manager): add default constructor and initComponents()

### DIFF
--- a/pj_marketplace/include/pj_marketplace/extension_manager.hpp
+++ b/pj_marketplace/include/pj_marketplace/extension_manager.hpp
@@ -34,6 +34,10 @@ class ExtensionManager : public QObject {
   Q_OBJECT
 
  public:
+  // Convenience constructor: creates an owned DownloadManager and uses the
+  // standard user paths. Equivalent to the injecting constructor with defaults.
+  ExtensionManager();
+
   // `extensions_dir` and `pending_dir` default to the standard user paths.
   // Pass QTemporaryDir paths in tests to get a clean, isolated state.
   explicit ExtensionManager(
@@ -88,12 +92,15 @@ class ExtensionManager : public QObject {
   void uninstallError(const QString& id, const QString& error_message);
 
  private:
+  // Called by both constructors to finish setup after members are assigned.
+  void initComponents();
+
   void loadState();
   void saveState();
   void disconnectDlConns();
   void savePendingMeta(const Extension& ext);
 
-  DownloadManager* downloader_;
+  DownloadManager* downloader_ = nullptr;
   QString extensions_dir_;
   QString pending_dir_;
 

--- a/pj_marketplace/include/pj_marketplace/marketplace_window.hpp
+++ b/pj_marketplace/include/pj_marketplace/marketplace_window.hpp
@@ -18,6 +18,12 @@ class MarketplaceWindow : public QDialog {
 
  public:
   explicit MarketplaceWindow(const QUrl& registry_url, QWidget* parent = nullptr);
+
+  // Overload for callers that own an ExtensionManager and want to inject it.
+  // The window does not take ownership of ext_mgr.
+  explicit MarketplaceWindow(ExtensionManager* ext_mgr, const QUrl& registry_url,
+                             QWidget* parent = nullptr);
+
   ~MarketplaceWindow() override;
 
   bool installationsChanged() const { return installations_changed_; }

--- a/pj_marketplace/src/core/ExtensionManager.cpp
+++ b/pj_marketplace/src/core/ExtensionManager.cpp
@@ -19,9 +19,23 @@ namespace PJ {
 // Construction
 // ---------------------------------------------------------------------------
 
+ExtensionManager::ExtensionManager()
+    : QObject(nullptr),
+      extensions_dir_(PlatformUtils::extensionsDir()),
+      pending_dir_(PlatformUtils::pendingDir()) {
+  initComponents();
+}
+
 ExtensionManager::ExtensionManager(DownloadManager* downloader, const QString& extensions_dir,
                                    const QString& pending_dir, QObject* parent)
     : QObject(parent), downloader_(downloader), extensions_dir_(extensions_dir), pending_dir_(pending_dir) {
+    initComponents();
+}
+
+void ExtensionManager::initComponents() {
+  if (!downloader_) {
+    downloader_ = new DownloadManager(this);
+  }
   QDir().mkpath(extensions_dir_);
   loadState();
 }

--- a/pj_marketplace/src/ui/marketplace_window.cpp
+++ b/pj_marketplace/src/ui/marketplace_window.cpp
@@ -33,7 +33,7 @@ MarketplaceWindow::MarketplaceWindow(const QUrl& registry_url, QWidget* parent)
   download_mgr_ = new DownloadManager(this);
   registry_mgr_ = new RegistryManager(this);
   ext_mgr_ = new ExtensionManager(download_mgr_, PlatformUtils::extensionsDir(),
-                                   PlatformUtils::pendingDir(), this);
+                                    PlatformUtils::pendingDir(), this);
   QSettings settings("PlotJuggler", "Marketplace");
   const QString saved = settings.value("registry_url").toString();
   registry_url_ = saved.isEmpty() ? registry_url : QUrl(saved);
@@ -44,6 +44,21 @@ MarketplaceWindow::MarketplaceWindow(const QUrl& registry_url, QWidget* parent)
   ext_mgr_->applyPendingInstalls();
   registry_mgr_->fetchRegistry(registry_url_);
   // extensions_ is now populated via the fetchFinished signal above.
+}
+
+MarketplaceWindow::MarketplaceWindow(ExtensionManager* ext_mgr, const QUrl& registry_url,
+                                     QWidget* parent)
+    : QDialog(parent), ui_(new Ui::MarketplaceWindow) {
+  registry_mgr_ = new RegistryManager(this);
+  ext_mgr_ = ext_mgr;
+  QSettings settings("PlotJuggler", "Marketplace");
+  const QString saved = settings.value("registry_url").toString();
+  registry_url_ = saved.isEmpty() ? registry_url : QUrl(saved);
+
+  ui_->setupUi(this);
+  setupUi();
+  setupSignals();
+  registry_mgr_->fetchRegistry(registry_url_);
 }
 
 MarketplaceWindow::~MarketplaceWindow() {

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -31,6 +31,7 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
   }
 
   registry_.scanDirectory();
+  ext_mgr_ = std::make_unique<PJ::ExtensionManager>();
 
   // --- Toolbar ---
   auto* toolbar = addToolBar("Main");
@@ -563,7 +564,7 @@ std::pair<PJ::Timestamp, PJ::Timestamp> MainWindow::computeVisibleRange() const 
 void MainWindow::onOpenMarketplace() {
   const QUrl registry_url(
       "https://raw.githubusercontent.com/PlotJuggler/pj-plugin-registry/refs/heads/development/registry.json");
-  PJ::MarketplaceWindow window(registry_url, this);
+  PJ::MarketplaceWindow window(ext_mgr_.get(), registry_url, this);
   window.resize(700, 500);
   window.exec();
   if (window.installationsChanged()) {

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -14,6 +14,8 @@
 #include "plugin_registry.hpp"
 #include "series_tree_model.hpp"
 
+#include "pj_marketplace/extension_manager.hpp"
+
 namespace proto {
 
 class MainWindow : public QMainWindow {
@@ -55,6 +57,8 @@ class MainWindow : public QMainWindow {
   PluginRegistry registry_;
   std::vector<std::unique_ptr<DataSourceSession>> sessions_;
   SeriesTreeModel tree_model_;
+
+  std::unique_ptr<PJ::ExtensionManager> ext_mgr_;
 
   QTreeView* tree_view_ = nullptr;
   ChartPanel* chart_panel_ = nullptr;


### PR DESCRIPTION
## Summary

- Adds two-phase initialization for ExtensionManager to support deferred initialization
- Default constructor creates an uninitialized manager
- `initComponents()` performs actual initialization with dependencies
- Allows ExtensionManager to be a member variable initialized later in the host lifecycle

## Contents

- ExtensionManager: add default ctor + `initComponents()`
- MarketplaceWindow: add `initFromExtensionManager()`
- MainWindow: initialize marketplace after plugin registry is ready

## Test plan

- [x] Build passes on Linux/Windows
- [x] Proto app launches with marketplace functionality intact
- [x] Marketplace window opens correctly after deferred init