### PR TITLE
feat(protoapp): add mouse wheel zoom to chart

### DIFF
--- a/pj_proto_app/src/chart_panel.cpp
+++ b/pj_proto_app/src/chart_panel.cpp
@@ -110,10 +110,12 @@ void ChartPanel::updateData(PJ::Timestamp t_min, PJ::Timestamp t_max) {
     s.line->replace(points);
   }
 
-  // Auto-scale axes
-  double x_min_s = static_cast<double>(t_min - first_timestamp_) / 1e9;
-  double x_max_s = static_cast<double>(t_max - first_timestamp_) / 1e9;
-  x_axis_->setRange(x_min_s, x_max_s);
+  // Auto-scale x-axis only when the user has not zoomed manually
+  if (!user_zoom_) {
+    double x_min_s = static_cast<double>(t_min - first_timestamp_) / 1e9;
+    double x_max_s = static_cast<double>(t_max - first_timestamp_) / 1e9;
+    x_axis_->setRange(x_min_s, x_max_s);
+  }
 
   if (y_min < y_max) {
     double margin = (y_max - y_min) * 0.05;
@@ -148,6 +150,23 @@ void ChartPanel::dropEvent(QDropEvent* event) {
 
   // Trigger an immediate chart update after adding a series.
   emit seriesDropped();
+}
+
+void ChartPanel::wheelEvent(QWheelEvent* event) {
+  double factor = (event->angleDelta().y() > 0) ? 0.8 : 1.25;
+  QPointF scene_pos = mapToScene(event->position().toPoint());
+  double mouse_x_s = chart()->mapToValue(scene_pos).x();
+  double x_min = x_axis_->min();
+  double x_max = x_axis_->max();
+  x_axis_->setRange(mouse_x_s - (mouse_x_s - x_min) * factor, mouse_x_s + (x_max - mouse_x_s) * factor);
+  user_zoom_ = true;
+  event->accept();
+}
+
+void ChartPanel::mouseDoubleClickEvent(QMouseEvent* event) {
+  user_zoom_ = false;
+  emit seriesDropped();  // triggers MainWindow to redraw with the full data range
+  QChartView::mouseDoubleClickEvent(event);
 }
 
 void ChartPanel::contextMenuEvent(QContextMenuEvent* event) {

--- a/pj_proto_app/src/chart_panel.hpp
+++ b/pj_proto_app/src/chart_panel.hpp
@@ -3,6 +3,8 @@
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QMenu>
+#include <QMouseEvent>
+#include <QWheelEvent>
 #include <QtCharts/QChartView>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
@@ -40,6 +42,8 @@ class ChartPanel : public QChartView {
   void dragMoveEvent(QDragMoveEvent* event) override;
   void dropEvent(QDropEvent* event) override;
   void contextMenuEvent(QContextMenuEvent* event) override;
+  void wheelEvent(QWheelEvent* event) override;
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
 
  private:
   const PJ::DataEngine& engine_;
@@ -47,6 +51,7 @@ class ChartPanel : public QChartView {
   QValueAxis* y_axis_;
   std::vector<PlottedSeries> series_;
   PJ::Timestamp first_timestamp_ = 0;
+  bool user_zoom_ = false;
 };
 
 }  // namespace proto


### PR DESCRIPTION
## Summary
- Add mouse wheel zoom to ChartPanel centered on cursor position
- Auto-scale x-axis is suspended while the user zooms; double-click resets
- Zoom factor: scroll up = zoom in (0.8x range), scroll down = zoom out (1.25x range)

## Test plan
- [x] Open a file with time series data, drag-drop to chart
- [x] Scroll wheel up/down to zoom in/out — verify zoom centers on cursor
- [x] Verify double-click resets zoom and restores auto-scale
- [x] Verify y-axis auto-scale continues working during zoom