### PR TITLE
fix(build): install Conan deps from subdirectory conanfiles

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,16 @@ build_config() {
   conan install "$SCRIPT_DIR" --output-folder="$build_dir" --build=missing \
     -s build_type="$build_type" -s compiler.cppstd=20 \
     "${conan_extra[@]+"${conan_extra[@]}"}"
+
+  # Install dependencies from subdirectory conanfiles (e.g. pj_ported_plugins)
+  for sub_conan in "$SCRIPT_DIR"/pj_ported_plugins/conanfile.txt; do
+    if [[ -f "$sub_conan" ]]; then
+      echo "--- Installing deps from $(dirname "$sub_conan") ---"
+      conan install "$(dirname "$sub_conan")" --output-folder="$build_dir" --build=missing \
+        -s build_type="$build_type" -s compiler.cppstd=20 \
+        "${conan_extra[@]+"${conan_extra[@]}"}"
+    fi
+  done
   cmake -S "$SCRIPT_DIR" -B "$build_dir" \
     -DCMAKE_TOOLCHAIN_FILE="$build_dir/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE="$build_type" \


### PR DESCRIPTION
## Summary

- `build.sh` only ran `conan install` on the root `conanfile.txt`, missing dependencies declared in `pj_ported_plugins/conanfile.txt` (e.g. `ixwebsocket`)
- This caused CMake configure failures when building plugins like `foxglove_bridge` or `pj_bridge`
- The fix scans for subdirectory conanfiles and installs their dependencies into the same build output folder before running CMake

## Test plan

- [x] Run `./build.sh` from a clean build directory and verify all plugins compile (including `foxglove_source_plugin` and `pj_bridge_source_plugin`)
- [x] Run `./build.sh --debug` and verify ASAN build also picks up subdirectory deps