### PR TITLE
feat(sdk): add showMessageBox to DataSource runtime host API

### DIFF
--- a/pj_base/include/pj_base/data_source_protocol.h
+++ b/pj_base/include/pj_base/data_source_protocol.h
@@ -66,6 +66,29 @@ typedef enum {
   PJ_DATA_SOURCE_MESSAGE_ERROR = 2,
 } PJ_data_source_message_level_t;
 
+/** Type of message box to display. Determines the icon shown. */
+typedef enum {
+  PJ_MESSAGE_BOX_INFO = 0,     /**< Information icon (i). */
+  PJ_MESSAGE_BOX_WARNING = 1,  /**< Warning icon (!). */
+  PJ_MESSAGE_BOX_ERROR = 2,    /**< Error/critical icon (X). */
+  PJ_MESSAGE_BOX_QUESTION = 3, /**< Question icon (?). */
+} PJ_message_box_type_t;
+
+/**
+ * Standard buttons for message boxes.
+ * Combine with bitwise OR: PJ_MSG_BTN_OK | PJ_MSG_BTN_CANCEL
+ */
+typedef enum {
+  PJ_MSG_BTN_OK = 0x01,
+  PJ_MSG_BTN_CANCEL = 0x02,
+  PJ_MSG_BTN_YES = 0x04,
+  PJ_MSG_BTN_NO = 0x08,
+  PJ_MSG_BTN_CONTINUE = 0x10,
+  PJ_MSG_BTN_ABORT = 0x20,
+  PJ_MSG_BTN_RETRY = 0x40,
+  PJ_MSG_BTN_IGNORE = 0x80,
+} PJ_message_box_buttons_t;
+
 /**
  * Capability flags returned by the plugin's capabilities() function.
  * Combine with bitwise OR. The host uses these to decide which features to
@@ -150,6 +173,28 @@ typedef struct PJ_data_source_runtime_host_vtable_t {
    */
   bool (*push_raw_message)(
       void* ctx, PJ_parser_binding_handle_t handle, int64_t host_timestamp_ns, PJ_bytes_view_t payload);
+
+  /**
+   * Display a modal message box to the user and wait for their response.
+   *
+   * This function BLOCKS until the user closes the dialog. The host is
+   * responsible for showing the dialog on the UI thread in a thread-safe manner.
+   *
+   * @param ctx      Host context.
+   * @param type     Dialog type (determines icon): info, warning, error, question.
+   * @param title    Window title for the dialog.
+   * @param message  Message text to display (may contain newlines).
+   * @param buttons  Bitmask of PJ_message_box_buttons_t values.
+   *
+   * @return The button that was clicked (a single PJ_message_box_buttons_t value),
+   *         or -1 if the host does not support modal dialogs (e.g., headless mode).
+   *
+   * @note If buttons == 0, the host should use PJ_MSG_BTN_OK as default.
+   * @note In headless mode, the host may return the "positive" button by default
+   *       (OK, Yes, Continue) or -1.
+   */
+  int (*show_message_box)(
+      void* ctx, PJ_message_box_type_t type, PJ_string_view_t title, PJ_string_view_t message, int buttons);
 } PJ_data_source_runtime_host_vtable_t;
 
 /** Fat pointer pairing a runtime host context with its vtable. */

--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -40,6 +40,34 @@ enum class DataSourceMessageLevel : uint32_t {
   kError = PJ_DATA_SOURCE_MESSAGE_ERROR,
 };
 
+/// Type of message box to display (determines icon).
+enum class MessageBoxType : uint32_t {
+  kInfo = PJ_MESSAGE_BOX_INFO,
+  kWarning = PJ_MESSAGE_BOX_WARNING,
+  kError = PJ_MESSAGE_BOX_ERROR,
+  kQuestion = PJ_MESSAGE_BOX_QUESTION,
+};
+
+/// Standard buttons for message boxes (combinable with |).
+enum class MessageBoxButton : int {
+  kOk = PJ_MSG_BTN_OK,
+  kCancel = PJ_MSG_BTN_CANCEL,
+  kYes = PJ_MSG_BTN_YES,
+  kNo = PJ_MSG_BTN_NO,
+  kContinue = PJ_MSG_BTN_CONTINUE,
+  kAbort = PJ_MSG_BTN_ABORT,
+  kRetry = PJ_MSG_BTN_RETRY,
+  kIgnore = PJ_MSG_BTN_IGNORE,
+};
+
+/// Allow combining MessageBoxButton values with |.
+inline int operator|(MessageBoxButton a, MessageBoxButton b) {
+  return static_cast<int>(a) | static_cast<int>(b);
+}
+inline int operator|(int a, MessageBoxButton b) {
+  return a | static_cast<int>(b);
+}
+
 /// @name Capability flag constants
 /// @{
 constexpr uint64_t kCapabilityFiniteImport = PJ_DATA_SOURCE_CAPABILITY_FINITE_IMPORT;
@@ -172,6 +200,61 @@ class DataSourceRuntimeHostView {
       return unexpected(std::string(lastError()));
     }
     return okStatus();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Modal message box API
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Display a modal message box and wait for user response.
+   * @param type    Dialog type (determines icon).
+   * @param title   Window title.
+   * @param message Message text (may contain newlines).
+   * @param buttons Bitmask of MessageBoxButton values.
+   * @return The button clicked, or MessageBoxButton::kOk if host doesn't support dialogs.
+   */
+  [[nodiscard]] MessageBoxButton showMessageBox(
+      MessageBoxType type, std::string_view title, std::string_view message, int buttons = 0) const {
+    if (!valid() || host_.vtable->show_message_box == nullptr) {
+      // Host doesn't support message boxes — return positive default
+      if (buttons & static_cast<int>(MessageBoxButton::kContinue)) return MessageBoxButton::kContinue;
+      if (buttons & static_cast<int>(MessageBoxButton::kYes)) return MessageBoxButton::kYes;
+      return MessageBoxButton::kOk;
+    }
+    int result = host_.vtable->show_message_box(
+        host_.ctx, static_cast<PJ_message_box_type_t>(type), sdk::toAbiString(title), sdk::toAbiString(message),
+        buttons == 0 ? PJ_MSG_BTN_OK : buttons);
+    return static_cast<MessageBoxButton>(result);
+  }
+
+  /// Show an information message box with OK button.
+  void showInfo(std::string_view title, std::string_view message) const {
+    (void)showMessageBox(MessageBoxType::kInfo, title, message, static_cast<int>(MessageBoxButton::kOk));
+  }
+
+  /// Show a warning message box with OK button.
+  void showWarning(std::string_view title, std::string_view message) const {
+    (void)showMessageBox(MessageBoxType::kWarning, title, message, static_cast<int>(MessageBoxButton::kOk));
+  }
+
+  /// Show an error message box with OK button.
+  void showError(std::string_view title, std::string_view message) const {
+    (void)showMessageBox(MessageBoxType::kError, title, message, static_cast<int>(MessageBoxButton::kOk));
+  }
+
+  /// Show a question dialog with Continue/Abort buttons. Returns true if user chose Continue.
+  [[nodiscard]] bool askContinue(std::string_view title, std::string_view message) const {
+    auto result =
+        showMessageBox(MessageBoxType::kQuestion, title, message, MessageBoxButton::kContinue | MessageBoxButton::kAbort);
+    return result == MessageBoxButton::kContinue;
+  }
+
+  /// Show a question dialog with Yes/No buttons. Returns true if user chose Yes.
+  [[nodiscard]] bool askYesNo(std::string_view title, std::string_view message) const {
+    auto result =
+        showMessageBox(MessageBoxType::kQuestion, title, message, MessageBoxButton::kYes | MessageBoxButton::kNo);
+    return result == MessageBoxButton::kYes;
   }
 
   /// Access the underlying C ABI struct.

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -67,6 +67,10 @@ struct MinimalRuntimeHost {
   static bool pushRawMessage(void*, PJ_parser_binding_handle_t, int64_t, PJ_bytes_view_t) {
     return true;
   }
+
+  static int showMessageBox(void*, PJ_message_box_type_t, PJ_string_view_t, PJ_string_view_t, int) {
+    return PJ_MSG_BTN_OK;
+  }
 };
 
 PJ_source_write_host_t makeWriteHost() {
@@ -97,6 +101,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost() {
       .request_stop = MinimalRuntimeHost::requestStop,
       .ensure_parser_binding = MinimalRuntimeHost::ensureParserBinding,
       .push_raw_message = MinimalRuntimeHost::pushRawMessage,
+      .show_message_box = MinimalRuntimeHost::showMessageBox,
   };
   return PJ_data_source_runtime_host_t{.ctx = reinterpret_cast<void*>(0x2), .vtable = &vtable};
 }

--- a/pj_plugins/tests/delegated_ingest_integration_test.cpp
+++ b/pj_plugins/tests/delegated_ingest_integration_test.cpp
@@ -177,6 +177,10 @@ struct BridgeRuntimeHost {
     }
     return self->parser_handle->parse(host_timestamp_ns, PJ::Span<const uint8_t>(payload.data, payload.size));
   }
+
+  static int showMessageBox(void*, PJ_message_box_type_t, PJ_string_view_t, PJ_string_view_t, int) {
+    return PJ_MSG_BTN_OK;
+  }
 };
 
 PJ_data_source_runtime_host_t makeBridgeRuntimeHost(BridgeRuntimeHost* bridge) {
@@ -193,6 +197,7 @@ PJ_data_source_runtime_host_t makeBridgeRuntimeHost(BridgeRuntimeHost* bridge) {
       .request_stop = BridgeRuntimeHost::requestStop,
       .ensure_parser_binding = BridgeRuntimeHost::ensureParserBinding,
       .push_raw_message = BridgeRuntimeHost::pushRawMessage,
+      .show_message_box = BridgeRuntimeHost::showMessageBox,
   };
   return PJ_data_source_runtime_host_t{.ctx = bridge, .vtable = &vtable};
 }

--- a/pj_plugins/tests/file_source_integration_test.cpp
+++ b/pj_plugins/tests/file_source_integration_test.cpp
@@ -121,6 +121,10 @@ bool rhPushRawMessage(void*, PJ_parser_binding_handle_t, int64_t, PJ_bytes_view_
   return true;
 }
 
+int rhShowMessageBox(void*, PJ_message_box_type_t, PJ_string_view_t, PJ_string_view_t, int) {
+  return PJ_MSG_BTN_OK;
+}
+
 // ---------------------------------------------------------------------------
 // Host factory helpers
 // ---------------------------------------------------------------------------
@@ -153,6 +157,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost(RuntimeHostState* state) {
       .request_stop = rhRequestStop,
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
+      .show_message_box = rhShowMessageBox,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
 }

--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -131,6 +131,19 @@ bool rhPushRawMessage(void* ctx, PJ_parser_binding_handle_t handle, int64_t time
   return it->second.parser->parse(timestamp_ns, PJ::Span<const uint8_t>(payload.data, payload.size));
 }
 
+int rhShowMessageBox(
+    void* ctx, PJ_message_box_type_t type, PJ_string_view_t title, PJ_string_view_t message, int buttons) {
+  auto* state = static_cast<RuntimeHostState*>(ctx);
+  if (!state->show_message_box_callback) {
+    // No callback bound - return positive default (headless mode)
+    if (buttons & PJ_MSG_BTN_CONTINUE) return PJ_MSG_BTN_CONTINUE;
+    if (buttons & PJ_MSG_BTN_YES) return PJ_MSG_BTN_YES;
+    return PJ_MSG_BTN_OK;
+  }
+  return state->show_message_box_callback(
+      type, std::string_view(title.data, title.size), std::string_view(message.data, message.size), buttons);
+}
+
 }  // namespace
 
 PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostState* state) {
@@ -147,6 +160,7 @@ PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostStat
       .request_stop = rhRequestStop,
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
+      .show_message_box = rhShowMessageBox,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
 }

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -2,9 +2,11 @@
 
 #include <QObject>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -31,6 +33,11 @@ struct DedupMessage {
   int count = 0;
 };
 
+/// Signature for the message box callback bound by the Qt layer.
+/// Returns the button that was clicked (a PJ_message_box_buttons_t value).
+using ShowMessageBoxCallback =
+    std::function<int(PJ_message_box_type_t type, std::string_view title, std::string_view message, int buttons)>;
+
 struct RuntimeHostState {
   std::mutex callback_mutex;  // protects messages and state_transitions from plugin threads
   std::vector<PJ_data_source_state_t> state_transitions;
@@ -46,6 +53,9 @@ struct RuntimeHostState {
   PluginRegistry* registry = nullptr;
   uint32_t next_binding_id = 1;
   std::unordered_map<uint32_t, ParserBinding> parser_bindings;
+
+  // Qt-layer callback for showing message boxes (bound at runtime by host app)
+  ShowMessageBoxCallback show_message_box_callback;
 };
 
 class DataSourceSession : public QObject {
@@ -91,6 +101,11 @@ class DataSourceSession : public QObject {
   }
   [[nodiscard]] const std::string& lastError() const {
     return last_error_;
+  }
+
+  /// Bind the message box callback from the Qt layer. Must be called before start.
+  void setMessageBoxCallback(ShowMessageBoxCallback callback) {
+    runtime_state_.show_message_box_callback = std::move(callback);
   }
 
  signals:

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -25,6 +25,78 @@
 
 namespace proto {
 
+namespace {
+
+/// Creates a callback that shows a QMessageBox.
+/// Assumes caller is on GUI thread (protoapp calls plugin methods from GUI thread).
+ShowMessageBoxCallback makeMessageBoxCallback(QWidget* parent) {
+  return [parent](PJ_message_box_type_t type, std::string_view title, std::string_view message, int buttons) -> int {
+    QString q_title = QString::fromUtf8(title.data(), static_cast<qsizetype>(title.size()));
+    QString q_message = QString::fromUtf8(message.data(), static_cast<qsizetype>(message.size()));
+
+    // Use manual QMessageBox to support custom button text (e.g., "Continue")
+    QMessageBox msg_box(parent);
+    msg_box.setWindowTitle(q_title);
+    msg_box.setText(q_message);
+
+    // Set icon based on type
+    switch (type) {
+      case PJ_MESSAGE_BOX_WARNING:
+        msg_box.setIcon(QMessageBox::Warning);
+        break;
+      case PJ_MESSAGE_BOX_ERROR:
+        msg_box.setIcon(QMessageBox::Critical);
+        break;
+      case PJ_MESSAGE_BOX_QUESTION:
+        msg_box.setIcon(QMessageBox::Question);
+        break;
+      case PJ_MESSAGE_BOX_INFO:
+      default:
+        msg_box.setIcon(QMessageBox::Information);
+        break;
+    }
+
+    // Map to track custom buttons -> PJ constants
+    std::vector<std::pair<QPushButton*, int>> button_map;
+
+    auto add_button = [&](int pj_btn, const QString& text, QMessageBox::ButtonRole role) {
+      if (buttons & pj_btn) {
+        auto* btn = msg_box.addButton(text, role);
+        button_map.emplace_back(btn, pj_btn);
+      }
+    };
+
+    if (buttons == 0) {
+      auto* btn = msg_box.addButton(QMessageBox::Ok);
+      button_map.emplace_back(btn, PJ_MSG_BTN_OK);
+    } else {
+      // Add buttons with proper labels
+      add_button(PJ_MSG_BTN_OK, QStringLiteral("OK"), QMessageBox::AcceptRole);
+      add_button(PJ_MSG_BTN_CANCEL, QStringLiteral("Cancel"), QMessageBox::RejectRole);
+      add_button(PJ_MSG_BTN_YES, QStringLiteral("Yes"), QMessageBox::YesRole);
+      add_button(PJ_MSG_BTN_NO, QStringLiteral("No"), QMessageBox::NoRole);
+      add_button(PJ_MSG_BTN_ABORT, QStringLiteral("Abort"), QMessageBox::RejectRole);
+      add_button(PJ_MSG_BTN_RETRY, QStringLiteral("Retry"), QMessageBox::AcceptRole);
+      add_button(PJ_MSG_BTN_IGNORE, QStringLiteral("Ignore"), QMessageBox::AcceptRole);
+      add_button(PJ_MSG_BTN_CONTINUE, QStringLiteral("Continue"), QMessageBox::AcceptRole);
+    }
+
+    msg_box.exec();
+
+    // Find which button was clicked
+    QAbstractButton* clicked = msg_box.clickedButton();
+    for (const auto& [btn, pj_val] : button_map) {
+      if (btn == clicked) {
+        return pj_val;
+      }
+    }
+
+    return PJ_MSG_BTN_OK;  // fallback
+  };
+}
+
+}  // namespace
+
 MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
     : QMainWindow(parent), registry_(plugin_dir), tree_model_(engine_) {
   auto td_result = engine_.createTimeDomain("default");
@@ -121,6 +193,7 @@ void MainWindow::loadFile(const QString& file_path) {
 
   auto session =
       std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, display_name, &registry_, this);
+  session->setMessageBoxCallback(makeMessageBoxCallback(this));
   if (!session->startFileImport(config)) {
     qWarning("Import failed for '%s': %s", display_name.c_str(), session->lastError().c_str());
   }
@@ -229,6 +302,7 @@ void MainWindow::onLoadFile() {
 
   auto session =
       std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, display_name, &registry_, this);
+  session->setMessageBoxCallback(makeMessageBoxCallback(this));
   session->startFileImport(config);
   sessions_.push_back(std::move(session));
 
@@ -271,6 +345,7 @@ void MainWindow::onStartStream() {
   // This matches the original plugin architecture: one object, one socket.
   auto session =
       std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, source->name, &registry_, this);
+  session->setMessageBoxCallback(makeMessageBoxCallback(this));
 
   // Restore saved config so the dialog remembers previous choices
   if (!config.empty()) {
@@ -323,6 +398,7 @@ void MainWindow::startDummyStream() {
 
   auto session =
       std::make_unique<DataSourceSession>(engine_, dummy->library, default_td_id_, dummy->name, &registry_, this);
+  session->setMessageBoxCallback(makeMessageBoxCallback(this));
   session->startStream("{}");
   sessions_.push_back(std::move(session));
 
@@ -532,6 +608,7 @@ void MainWindow::restartSession(DataSourceSession* session) {
 
   // Create and start a new session with the same config
   auto new_session = std::make_unique<DataSourceSession>(engine_, library, default_td_id_, name, &registry_, this);
+  new_session->setMessageBoxCallback(makeMessageBoxCallback(this));
   new_session->startStream(config);
   sessions_.push_back(std::move(new_session));
 


### PR DESCRIPTION
## Summary

Extends the DataSource SDK with modal message box support, allowing plugins to display info/warning/error/question dialogs during data loading or streaming.

### Changes

**C ABI (`data_source_protocol.h`):**
- `PJ_message_box_type_t` enum: Info, Warning, Error, Question
- `PJ_message_box_buttons_t` flags: Ok, Cancel, Yes, No, Continue, Abort, Retry, Ignore
- `show_message_box` function in runtime host vtable

**C++ SDK (`data_source_plugin_base.hpp`):**
- `MessageBoxType` and `MessageBoxButton` enums
- `DataSourceRuntimeHostView::showMessageBox()` with typed return
- Convenience: `showInfo`, `showWarning`, `showError`
- Decision helpers: `askContinue`, `askYesNo`

**Protoapp:**
- `ShowMessageBoxCallback` in RuntimeHostState
- `makeMessageBoxCallback()` factory using QMessageBox
- Callback bound to sessions before start

## Test plan

- [x] 46/46 tests pass
- [x] Build compiles with -Wall -Wextra -Werror
- [x] Manual test with plugin showing warnings