### PR TITLE
fix(protoapp): propagate binding errors to plugins via lastError API

### DIFF
--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -10,8 +10,9 @@ namespace proto {
 
 namespace {
 
-const char* rhGetLastError(void*) {
-  return nullptr;
+const char* rhGetLastError(void* ctx) {
+  auto* s = static_cast<RuntimeHostState*>(ctx);
+  return s->last_error.empty() ? nullptr : s->last_error.c_str();
 }
 
 void rhReportMessage(void* ctx, PJ_data_source_message_level_t level, PJ_string_view_t msg) {
@@ -68,14 +69,16 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
 
   auto* parser_entry = state->registry->findParserByEncoding(encoding);
   if (parser_entry == nullptr) {
-    std::cerr << "[bridge] no parser found for encoding '" << encoding << "'\n";
+    state->last_error = "no parser found for encoding '" + std::string(encoding) + "'";
+    std::cerr << "[bridge] " << state->last_error << "\n";
     return false;
   }
 
   // Create parser instance
   auto parser = std::make_unique<PJ::MessageParserHandle>(parser_entry->library.createHandle());
   if (!parser->valid()) {
-    std::cerr << "[bridge] failed to create parser instance for '" << encoding << "'\n";
+    state->last_error = "failed to create parser instance for '" + std::string(encoding) + "'";
+    std::cerr << "[bridge] " << state->last_error << "\n";
     return false;
   }
 
@@ -83,7 +86,8 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
   auto topic_result =
       state->engine->createTopic(state->dataset_id, PJ::TopicDescriptor{.name = std::string(topic_name)});
   if (!topic_result) {
-    std::cerr << "[bridge] failed to create topic '" << topic_name << "': " << topic_result.error() << "\n";
+    state->last_error = "failed to create topic '" + std::string(topic_name) + "': " + topic_result.error();
+    std::cerr << "[bridge] " << state->last_error << "\n";
     return false;
   }
 
@@ -94,7 +98,8 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
 
   // Bind write host to parser
   if (!parser->bindWriteHost(write_host->raw())) {
-    std::cerr << "[bridge] failed to bind write host to parser\n";
+    state->last_error = "failed to bind write host to parser";
+    std::cerr << "[bridge] " << state->last_error << "\n";
     return false;
   }
 
@@ -102,6 +107,7 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
   if (request->schema.size > 0) {
     PJ::Span<const uint8_t> schema_span(request->schema.data, request->schema.size);
     if (!parser->bindSchema(type_name, schema_span)) {
+      state->last_error = "failed to parse " + std::string(type_name) + ": " + parser->lastError();
       std::cerr << "[bridge] parser schema binding failed for type '" << type_name << "': " << parser->lastError()
                 << "\n";
       return false;

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -46,6 +46,7 @@ struct RuntimeHostState {
   int progress_finishes = 0;
   std::atomic<bool> stop_requested{false};
   std::unordered_map<std::string, DedupMessage> messages;
+  std::string last_error;
 
   // Delegated ingest bridge state
   PJ::DataEngine* engine = nullptr;


### PR DESCRIPTION
## Summary

When `ensureParserBinding()` fails, plugins need to know **why** it failed to show meaningful error messages. The SDK provides the `lastError()` API for this purpose, but the protoapp implementation always returned `nullptr`.

### Before this fix

Plugins received empty error strings:
```
No channels could be bound to parsers:
  - /camera/image (encoding: ros1):
```

Users couldn't distinguish between:
- "Parser not installed" (they can install it)
- "Schema corrupted" (the file has a problem)
- "Internal parser error" (a bug)

### After this fix

Plugins show actionable messages:
```
No channels could be bound to parsers:
  - /camera/image (encoding: ros1): no parser found for encoding 'ros1'
  - /bad/data (encoding: cdr): failed to parse broken_msgs/Garbage: Missing ROSType
```

## Technical details

The SDK uses a C ABI for plugin ↔ host communication. When `ensure_parser_binding()` returns `false`, the SDK wrapper calls `get_last_error()` to populate the `Expected<Handle>` error message. This contract was already designed correctly — the bug was that `rhGetLastError()` always returned `nullptr`.

### Changes

| File | Change |
|------|--------|
| `data_source_session.hpp` | Add `std::string last_error` to `RuntimeHostState` |
| `data_source_session.cpp` | Store error message at each of 5 failure points |
| `data_source_session.cpp` | Return `state->last_error` from `rhGetLastError()` |

### Failure points now covered

1. No parser found for encoding
2. Failed to create parser instance
3. Failed to create topic in datastore
4. Failed to bind write host to parser
5. Failed to parse schema (includes parser's lastError)

## Impact

Enables MCAP, Foxglove Bridge, and PJ Bridge plugins to report binding failures with context. No SDK changes required.

## Test plan

- [x] Load MCAP with unsupported encoding → verify error message shows encoding name
- [x] Load MCAP with malformed schema → verify error message shows parse failure details