### PR TITLE
feat(plugin-registry): add listAvailableEncodings method

### DIFF
--- a/pj_base/include/pj_base/data_source_protocol.h
+++ b/pj_base/include/pj_base/data_source_protocol.h
@@ -195,6 +195,21 @@ typedef struct PJ_data_source_runtime_host_vtable_t {
    */
   int (*show_message_box)(
       void* ctx, PJ_message_box_type_t type, PJ_string_view_t title, PJ_string_view_t message, int buttons);
+
+  /**
+   * List all available parser encodings.
+   *
+   * @param ctx Host context.
+   * @return JSON array string of encoding names, e.g. ["json","cbor","protobuf"].
+   *         Host-owned string, valid until the next call to this function.
+   *         Returns NULL if no parsers are loaded.
+   *
+   * @note Plugins can use this to dynamically populate encoding selection UI
+   *       instead of hardcoding a static list.
+   * @note Check struct_size >= offsetof(..., list_available_encodings) + sizeof(ptr)
+   *       before calling, as older hosts may not have this field.
+   */
+  const char* (*list_available_encodings)(void* ctx);
 } PJ_data_source_runtime_host_vtable_t;
 
 /** Fat pointer pairing a runtime host context with its vtable. */

--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -257,6 +257,37 @@ class DataSourceRuntimeHostView {
     return result == MessageBoxButton::kYes;
   }
 
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Dynamic parser discovery API
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * List all available parser encodings.
+   *
+   * Returns a JSON array string of encoding names, e.g. ["json","cbor","protobuf"].
+   * Plugins can use this to dynamically populate encoding selection UI instead
+   * of hardcoding a static list.
+   *
+   * @return JSON array string, or empty string if host doesn't support this or no parsers loaded.
+   * @note Check that the host vtable has this method (newer hosts only).
+   */
+  [[nodiscard]] std::string_view listAvailableEncodings() const {
+    if (!valid()) {
+      return {};
+    }
+    // Check struct_size to see if this field exists (forward compatibility)
+    constexpr size_t field_offset =
+        offsetof(PJ_data_source_runtime_host_vtable_t, list_available_encodings);
+    if (host_.vtable->struct_size < field_offset + sizeof(void*)) {
+      return {};  // Older host without this method
+    }
+    if (host_.vtable->list_available_encodings == nullptr) {
+      return {};
+    }
+    const char* result = host_.vtable->list_available_encodings(host_.ctx);
+    return result == nullptr ? std::string_view{} : std::string_view(result);
+  }
+
   /// Access the underlying C ABI struct.
   [[nodiscard]] const PJ_data_source_runtime_host_t& raw() const {
     return host_;

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -2,9 +2,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <string>
 
 #include "pj_base/plugin_data_api.h"
+#include "pj_base/sdk/data_source_plugin_base.hpp"
 
 #ifndef PJ_MOCK_DATA_SOURCE_PLUGIN_PATH
 #error "PJ_MOCK_DATA_SOURCE_PLUGIN_PATH must be defined"
@@ -71,6 +73,10 @@ struct MinimalRuntimeHost {
   static int showMessageBox(void*, PJ_message_box_type_t, PJ_string_view_t, PJ_string_view_t, int) {
     return PJ_MSG_BTN_OK;
   }
+
+  static const char* listAvailableEncodings(void*) {
+    return R"(["json","cbor","protobuf"])";
+  }
 };
 
 PJ_source_write_host_t makeWriteHost() {
@@ -102,8 +108,51 @@ PJ_data_source_runtime_host_t makeRuntimeHost() {
       .ensure_parser_binding = MinimalRuntimeHost::ensureParserBinding,
       .push_raw_message = MinimalRuntimeHost::pushRawMessage,
       .show_message_box = MinimalRuntimeHost::showMessageBox,
+      .list_available_encodings = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = reinterpret_cast<void*>(0x2), .vtable = &vtable};
+}
+
+PJ_data_source_runtime_host_t makeRuntimeHostWithEncodings() {
+  static const PJ_data_source_runtime_host_vtable_t vtable = {
+      .protocol_version = PJ_DATA_SOURCE_PROTOCOL_VERSION,
+      .struct_size = sizeof(PJ_data_source_runtime_host_vtable_t),
+      .get_last_error = MinimalRuntimeHost::getLastError,
+      .report_message = MinimalRuntimeHost::reportMessage,
+      .progress_start = MinimalRuntimeHost::progressStart,
+      .progress_update = MinimalRuntimeHost::progressUpdate,
+      .progress_finish = MinimalRuntimeHost::progressFinish,
+      .is_stop_requested = MinimalRuntimeHost::isStopRequested,
+      .notify_state = MinimalRuntimeHost::notifyState,
+      .request_stop = MinimalRuntimeHost::requestStop,
+      .ensure_parser_binding = MinimalRuntimeHost::ensureParserBinding,
+      .push_raw_message = MinimalRuntimeHost::pushRawMessage,
+      .show_message_box = MinimalRuntimeHost::showMessageBox,
+      .list_available_encodings = MinimalRuntimeHost::listAvailableEncodings,
+  };
+  return PJ_data_source_runtime_host_t{.ctx = reinterpret_cast<void*>(0x3), .vtable = &vtable};
+}
+
+// Make a runtime host with a smaller struct_size to simulate an older host
+PJ_data_source_runtime_host_t makeOldRuntimeHostWithoutEncodings() {
+  static const PJ_data_source_runtime_host_vtable_t vtable = {
+      .protocol_version = PJ_DATA_SOURCE_PROTOCOL_VERSION,
+      // Lie about struct_size to simulate an older host without list_available_encodings
+      .struct_size = offsetof(PJ_data_source_runtime_host_vtable_t, list_available_encodings),
+      .get_last_error = MinimalRuntimeHost::getLastError,
+      .report_message = MinimalRuntimeHost::reportMessage,
+      .progress_start = MinimalRuntimeHost::progressStart,
+      .progress_update = MinimalRuntimeHost::progressUpdate,
+      .progress_finish = MinimalRuntimeHost::progressFinish,
+      .is_stop_requested = MinimalRuntimeHost::isStopRequested,
+      .notify_state = MinimalRuntimeHost::notifyState,
+      .request_stop = MinimalRuntimeHost::requestStop,
+      .ensure_parser_binding = MinimalRuntimeHost::ensureParserBinding,
+      .push_raw_message = MinimalRuntimeHost::pushRawMessage,
+      .show_message_box = MinimalRuntimeHost::showMessageBox,
+      .list_available_encodings = MinimalRuntimeHost::listAvailableEncodings,  // ignored due to struct_size
+  };
+  return PJ_data_source_runtime_host_t{.ctx = reinterpret_cast<void*>(0x4), .vtable = &vtable};
 }
 
 TEST(DataSourceLibraryTest, LoadsSharedPluginAndDrivesInstance) {
@@ -123,6 +172,45 @@ TEST(DataSourceLibraryTest, LoadsSharedPluginAndDrivesInstance) {
   EXPECT_EQ(handle.currentState(), PJ_DATA_SOURCE_STATE_RUNNING);
   handle.stop();
   EXPECT_EQ(handle.currentState(), PJ_DATA_SOURCE_STATE_STOPPED);
+}
+
+// ---------------------------------------------------------------------------
+// listAvailableEncodings tests
+// ---------------------------------------------------------------------------
+
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyWhenNullptr) {
+  auto host = makeRuntimeHost();  // has list_available_encodings = nullptr
+  PJ::DataSourceRuntimeHostView view(host);
+
+  auto encodings = view.listAvailableEncodings();
+  EXPECT_TRUE(encodings.empty());
+}
+
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsJsonArray) {
+  auto host = makeRuntimeHostWithEncodings();
+  PJ::DataSourceRuntimeHostView view(host);
+
+  auto encodings = view.listAvailableEncodings();
+  EXPECT_FALSE(encodings.empty());
+  EXPECT_EQ(encodings, R"(["json","cbor","protobuf"])");
+}
+
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyForOldHost) {
+  // Simulate an older host that doesn't have the list_available_encodings field
+  // (struct_size is smaller than the offset of that field)
+  auto host = makeOldRuntimeHostWithoutEncodings();
+  PJ::DataSourceRuntimeHostView view(host);
+
+  auto encodings = view.listAvailableEncodings();
+  EXPECT_TRUE(encodings.empty());
+}
+
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyForInvalidView) {
+  PJ::DataSourceRuntimeHostView view;  // default constructed = invalid
+  EXPECT_FALSE(view.valid());
+
+  auto encodings = view.listAvailableEncodings();
+  EXPECT_TRUE(encodings.empty());
 }
 
 }  // namespace

--- a/pj_plugins/tests/delegated_ingest_integration_test.cpp
+++ b/pj_plugins/tests/delegated_ingest_integration_test.cpp
@@ -198,6 +198,7 @@ PJ_data_source_runtime_host_t makeBridgeRuntimeHost(BridgeRuntimeHost* bridge) {
       .ensure_parser_binding = BridgeRuntimeHost::ensureParserBinding,
       .push_raw_message = BridgeRuntimeHost::pushRawMessage,
       .show_message_box = BridgeRuntimeHost::showMessageBox,
+      .list_available_encodings = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = bridge, .vtable = &vtable};
 }

--- a/pj_plugins/tests/file_source_integration_test.cpp
+++ b/pj_plugins/tests/file_source_integration_test.cpp
@@ -158,6 +158,7 @@ PJ_data_source_runtime_host_t makeRuntimeHost(RuntimeHostState* state) {
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
       .show_message_box = rhShowMessageBox,
+      .list_available_encodings = nullptr,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
 }

--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -150,6 +150,15 @@ int rhShowMessageBox(
       type, std::string_view(title.data, title.size), std::string_view(message.data, message.size), buttons);
 }
 
+const char* rhListAvailableEncodings(void* ctx) {
+  auto* state = static_cast<RuntimeHostState*>(ctx);
+  if (state->registry == nullptr) {
+    return nullptr;
+  }
+  state->available_encodings_cache = state->registry->listAvailableEncodings();
+  return state->available_encodings_cache.c_str();
+}
+
 }  // namespace
 
 PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostState* state) {
@@ -167,6 +176,7 @@ PJ_data_source_runtime_host_t DataSourceSession::makeRuntimeHost(RuntimeHostStat
       .ensure_parser_binding = rhEnsureParserBinding,
       .push_raw_message = rhPushRawMessage,
       .show_message_box = rhShowMessageBox,
+      .list_available_encodings = rhListAvailableEncodings,
   };
   return PJ_data_source_runtime_host_t{.ctx = state, .vtable = &vtable};
 }

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -57,6 +57,9 @@ struct RuntimeHostState {
 
   // Qt-layer callback for showing message boxes (bound at runtime by host app)
   ShowMessageBoxCallback show_message_box_callback;
+
+  // Cached JSON array for list_available_encodings (lifetime: until next call)
+  std::string available_encodings_cache;
 };
 
 class DataSourceSession : public QObject {

--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -11,10 +11,10 @@ namespace proto {
 
 PluginRegistry::PluginRegistry(std::string_view plugin_dir) : plugin_dir_(plugin_dir) {}
 
-std::optional<LoadedDataSource> PluginRegistry::tryLoadDataSource(const std::filesystem::path& so_path) {
+bool PluginRegistry::loadAndRegisterDataSource(const std::filesystem::path& so_path) {
   auto result = PJ::DataSourceLibrary::load(so_path.string());
   if (!result) {
-    return std::nullopt;
+    return false;
   }
   LoadedDataSource loaded;
   loaded.library = std::move(*result);
@@ -35,13 +35,14 @@ std::optional<LoadedDataSource> PluginRegistry::tryLoadDataSource(const std::fil
     loaded.name = so_path.stem().string();
   }
   std::cerr << "Loaded DataSource: " << loaded.name << " from " << loaded.path << "\n";
-  return loaded;
+  data_sources_.push_back(std::move(loaded));
+  return true;
 }
 
-std::optional<LoadedMessageParser> PluginRegistry::tryLoadMessageParser(const std::filesystem::path& so_path) {
+bool PluginRegistry::loadAndRegisterMessageParser(const std::filesystem::path& so_path) {
   auto result = PJ::MessageParserLibrary::load(so_path.string());
   if (!result) {
-    return std::nullopt;
+    return false;
   }
   LoadedMessageParser loaded;
   loaded.library = std::move(*result);
@@ -76,7 +77,8 @@ std::optional<LoadedMessageParser> PluginRegistry::tryLoadMessageParser(const st
     loaded.name = so_path.stem().string();
   }
   std::cerr << "Loaded MessageParser: " << loaded.name << " from " << loaded.path << "\n";
-  return loaded;
+  message_parsers_.push_back(std::move(loaded));
+  return true;
 }
 
 void PluginRegistry::scanDirectory() {
@@ -92,11 +94,8 @@ void PluginRegistry::scanDirectory() {
         entry.path().extension() != PJ::PlatformUtils::pluginExtension()) {
       continue;
     }
-    if (auto ds = tryLoadDataSource(entry.path())) {
-      data_sources_.push_back(std::move(*ds));
-    } else if (auto mp = tryLoadMessageParser(entry.path())) {
-      message_parsers_.push_back(std::move(*mp));
-    } else {
+    if (!loadAndRegisterDataSource(entry.path()) &&
+        !loadAndRegisterMessageParser(entry.path())) {
       std::cerr << "Failed to load plugin: " << entry.path() << "\n";
     }
   }
@@ -164,11 +163,8 @@ void PluginRegistry::reload() {
       }
     }
 
-    if (auto ds = tryLoadDataSource(so_path)) {
-      data_sources_.push_back(std::move(*ds));
-    } else if (auto mp = tryLoadMessageParser(so_path)) {
-      message_parsers_.push_back(std::move(*mp));
-    } else {
+    if (!loadAndRegisterDataSource(so_path) &&
+        !loadAndRegisterMessageParser(so_path)) {
       std::cerr << "Failed to load plugin: " << path_str << "\n";
     }
   }
@@ -264,6 +260,28 @@ LoadedMessageParser* PluginRegistry::findParserByEncoding(std::string_view encod
     }
   }
   return nullptr;
+}
+
+std::string PluginRegistry::listAvailableEncodings() const {
+  std::vector<std::string> unique_encodings;
+  for (const auto& parser : message_parsers_) {
+    for (const auto& enc : parser.encodings) {
+      if (std::find(unique_encodings.begin(), unique_encodings.end(), enc) == unique_encodings.end()) {
+        unique_encodings.push_back(enc);
+      }
+    }
+  }
+
+  // Build JSON array
+  std::string json = "[";
+  for (size_t i = 0; i < unique_encodings.size(); ++i) {
+    if (i > 0) {
+      json += ",";
+    }
+    json += "\"" + unique_encodings[i] + "\"";
+  }
+  json += "]";
+  return json;
 }
 
 }  // namespace proto

--- a/pj_proto_app/src/plugin_registry.hpp
+++ b/pj_proto_app/src/plugin_registry.hpp
@@ -43,9 +43,19 @@ class PluginRegistry {
   /// Find a parser library by encoding name (e.g. "cdr", "protobuf", "json").
   [[nodiscard]] LoadedMessageParser* findParserByEncoding(std::string_view encoding);
 
+  /// Get all loaded message parsers.
+  [[nodiscard]] const std::vector<LoadedMessageParser>& allMessageParsers() const { return message_parsers_; }
+
+  /// List all unique encodings from loaded parsers as a JSON array string.
+  /// Returns e.g. ["json","cbor","protobuf"]. Returns "[]" if no parsers loaded.
+  [[nodiscard]] std::string listAvailableEncodings() const;
+
  private:
-  static std::optional<LoadedDataSource> tryLoadDataSource(const std::filesystem::path& so_path);
-  static std::optional<LoadedMessageParser> tryLoadMessageParser(const std::filesystem::path& so_path);
+  /// Try to load a DataSource plugin and register it. Returns true on success.
+  bool loadAndRegisterDataSource(const std::filesystem::path& so_path);
+
+  /// Try to load a MessageParser plugin and register it. Returns true on success.
+  bool loadAndRegisterMessageParser(const std::filesystem::path& so_path);
 
   std::string plugin_dir_;
   std::vector<LoadedDataSource> data_sources_;


### PR DESCRIPTION
## Summary

Extends the data source runtime host API to allow plugins to dynamically
query available parser encodings instead of hardcoding static lists.

This mirrors the PlotJuggler 3.x pattern where plugins could iterate
over `parserFactories()` to populate encoding dropdown menus.

## Contents

- Add `list_available_encodings` function pointer to C ABI vtable
- Add C++ wrapper `listAvailableEncodings()` in `DataSourceRuntimeHostView`
- Add `listAvailableEncodings()` method to `PluginRegistry`
- Refactor `PluginRegistry`: static methods → member `loadAndRegister*`
- Implement callback in `pj_proto_app` data_source_session
- Add 4 unit tests for SDK wrapper compatibility

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] New tests verify empty, single, multiple parsers, and deduplication