### PR TITLE
feat(sdk): early runtime host binding for dialog + listAvailableEncodings vector helper

### DIFF
--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -14,6 +14,7 @@
 #include <exception>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "pj_base/data_source_protocol.h"
 #include "pj_base/expected.hpp"
@@ -262,16 +263,15 @@ class DataSourceRuntimeHostView {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * List all available parser encodings.
+   * List all available parser encodings as a JSON string.
    *
    * Returns a JSON array string of encoding names, e.g. ["json","cbor","protobuf"].
-   * Plugins can use this to dynamically populate encoding selection UI instead
-   * of hardcoding a static list.
+   * Prefer using listAvailableEncodings() which returns a parsed vector.
    *
    * @return JSON array string, or empty string if host doesn't support this or no parsers loaded.
    * @note Check that the host vtable has this method (newer hosts only).
    */
-  [[nodiscard]] std::string_view listAvailableEncodings() const {
+  [[nodiscard]] std::string_view listAvailableEncodingsJson() const {
     if (!valid()) {
       return {};
     }
@@ -287,6 +287,69 @@ class DataSourceRuntimeHostView {
     const char* result = host_.vtable->list_available_encodings(host_.ctx);
     return result == nullptr ? std::string_view{} : std::string_view(result);
   }
+
+  /**
+   * List all available parser encodings.
+   *
+   * Returns a vector of encoding names, e.g. {"json", "cbor", "protobuf"}.
+   * Plugins can use this to dynamically populate encoding selection UI instead
+   * of hardcoding a static list.
+   *
+   * @return Vector of encoding names, or empty vector if host doesn't support this.
+   */
+  [[nodiscard]] std::vector<std::string> listAvailableEncodings() const {
+    auto json = listAvailableEncodingsJson();
+    return parseJsonStringArray(json);
+  }
+
+ private:
+  /// Parse a simple JSON array of strings: ["a","b","c"] -> {"a","b","c"}
+  /// Handles escaped quotes within strings. Returns empty vector on malformed input.
+  static std::vector<std::string> parseJsonStringArray(std::string_view json) {
+    std::vector<std::string> result;
+    if (json.empty()) return result;
+
+    size_t i = 0;
+    // Skip whitespace and find opening bracket
+    while (i < json.size() && (json[i] == ' ' || json[i] == '\t' || json[i] == '\n')) ++i;
+    if (i >= json.size() || json[i] != '[') return result;
+    ++i;
+
+    while (i < json.size()) {
+      // Skip whitespace
+      while (i < json.size() && (json[i] == ' ' || json[i] == '\t' || json[i] == '\n' || json[i] == ',')) ++i;
+      if (i >= json.size() || json[i] == ']') break;
+
+      // Expect opening quote
+      if (json[i] != '"') return {};  // Malformed
+      ++i;
+
+      // Parse string content (handle escaped quotes)
+      std::string str;
+      while (i < json.size() && json[i] != '"') {
+        if (json[i] == '\\' && i + 1 < json.size()) {
+          ++i;  // Skip backslash
+          if (json[i] == '"' || json[i] == '\\') {
+            str += json[i];
+          } else {
+            str += '\\';
+            str += json[i];
+          }
+        } else {
+          str += json[i];
+        }
+        ++i;
+      }
+      if (i >= json.size()) return {};  // Unclosed string
+      ++i;  // Skip closing quote
+
+      result.push_back(std::move(str));
+    }
+
+    return result;
+  }
+
+ public:
 
   /// Access the underlying C ABI struct.
   [[nodiscard]] const PJ_data_source_runtime_host_t& raw() const {

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -186,13 +186,24 @@ TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyWhenNullptr) {
   EXPECT_TRUE(encodings.empty());
 }
 
-TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsJsonArray) {
+TEST(RuntimeHostViewTest, ListAvailableEncodingsJsonReturnsJsonArray) {
+  auto host = makeRuntimeHostWithEncodings();
+  PJ::DataSourceRuntimeHostView view(host);
+
+  auto json = view.listAvailableEncodingsJson();
+  EXPECT_FALSE(json.empty());
+  EXPECT_EQ(json, R"(["json","cbor","protobuf"])");
+}
+
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsParsedVector) {
   auto host = makeRuntimeHostWithEncodings();
   PJ::DataSourceRuntimeHostView view(host);
 
   auto encodings = view.listAvailableEncodings();
-  EXPECT_FALSE(encodings.empty());
-  EXPECT_EQ(encodings, R"(["json","cbor","protobuf"])");
+  ASSERT_EQ(encodings.size(), 3u);
+  EXPECT_EQ(encodings[0], "json");
+  EXPECT_EQ(encodings[1], "cbor");
+  EXPECT_EQ(encodings[2], "protobuf");
 }
 
 TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyForOldHost) {

--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -192,6 +192,16 @@ DataSourceSession::DataSourceSession(
       registry_(registry),
       handle_(library.createHandle()) {}
 
+void DataSourceSession::bindRuntimeHostForDialog() {
+  // Bind a minimal runtime host so the dialog can call listAvailableEncodings().
+  // Only registry is needed for that callback; engine/dataset_id are set later in setupAndStart().
+  runtime_state_.registry = registry_;
+  runtime_state_.engine = nullptr;
+  runtime_state_.dataset_id = 0;
+
+  (void)handle_.bindRuntimeHost(makeRuntimeHost(&runtime_state_));
+}
+
 bool DataSourceSession::setupAndStart(const std::string& config_json) {
   auto ds_result = engine_.createDataset(PJ::DatasetDescriptor{.source_name = source_name_, .time_domain_id = td_id_});
   if (!ds_result) {

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -70,6 +70,10 @@ class DataSourceSession : public QObject {
       PJ::DataEngine& engine, PJ::DataSourceLibrary& library, PJ::TimeDomainId td_id, std::string source_name,
       PluginRegistry* registry, QObject* parent = nullptr);
 
+  /// Bind a minimal runtime host so the dialog can call listAvailableEncodings().
+  /// Must be called before showing the dialog. setupAndStart() will complete the binding.
+  void bindRuntimeHostForDialog();
+
   bool startFileImport(const std::string& config_json);
   bool startStream(const std::string& config_json);
   void stopStream();

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -263,13 +263,12 @@ void MainWindow::onLoadFile() {
     source = sources[idx];
   }
 
-  std::string config;
-
   // Restore last-used config for this plugin (preserves user choices across sessions)
   auto settings_key = QString("PluginConfig/%1").arg(QString::fromStdString(source->name));
   std::string saved_config = settings.value(settings_key, "").toString().toStdString();
 
   // Merge the new filepath into the saved config (or create a fresh one)
+  std::string config;
   {
     auto base = saved_config.empty() ? nlohmann::json::object() : nlohmann::json::parse(saved_config, nullptr, false);
     if (base.is_discarded()) {
@@ -279,14 +278,24 @@ void MainWindow::onLoadFile() {
     config = base.dump();
   }
 
-  // Dialog flow
+  auto display_name = QFileInfo(file_path).fileName().toStdString();
+
+  // Create session early so the dialog can call listAvailableEncodings()
+  auto session =
+      std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, display_name, &registry_, this);
+  session->setMessageBoxCallback(makeMessageBoxCallback(this));
+
+  // Bind runtime host early so the dialog can call listAvailableEncodings()
+  session->bindRuntimeHostForDialog();
+
+  // Load merged config (filepath + last-used settings) so the dialog is pre-populated
+  (void)session->handle().loadConfig(config);
+
+  // Dialog flow — use the session's own handle
   if ((source->capabilities & PJ_DATA_SOURCE_CAPABILITY_HAS_DIALOG) != 0) {
     auto vt_result = source->library.resolveDialogVtable();
     if (vt_result) {
-      auto temp_handle = source->library.createHandle();
-      // Load merged config (filepath + last-used settings) so the dialog is pre-populated
-      (void)temp_handle.loadConfig(config);
-      auto* dialog_ctx = temp_handle.dialogContext();
+      auto* dialog_ctx = session->handle().dialogContext();
       if (dialog_ctx != nullptr) {
         auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
         PJ::DialogEngine dialog_engine(std::move(dialog_handle));
@@ -298,11 +307,6 @@ void MainWindow::onLoadFile() {
     }
   }
 
-  auto display_name = QFileInfo(file_path).fileName().toStdString();
-
-  auto session =
-      std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, display_name, &registry_, this);
-  session->setMessageBoxCallback(makeMessageBoxCallback(this));
   session->startFileImport(config);
   sessions_.push_back(std::move(session));
 
@@ -339,7 +343,7 @@ void MainWindow::onStartStream() {
 
   QSettings settings;
   auto settings_key = QString("PluginConfig/%1").arg(QString::fromStdString(source->name));
-  std::string config = settings.value(settings_key, "").toString().toStdString();
+  std::string saved_config = settings.value(settings_key, "").toString().toStdString();
 
   // Create session first so the dialog runs on the SAME handle that will stream.
   // This matches the original plugin architecture: one object, one socket.
@@ -347,12 +351,16 @@ void MainWindow::onStartStream() {
       std::make_unique<DataSourceSession>(engine_, source->library, default_td_id_, source->name, &registry_, this);
   session->setMessageBoxCallback(makeMessageBoxCallback(this));
 
+  // Bind runtime host early so the dialog can call listAvailableEncodings()
+  session->bindRuntimeHostForDialog();
+
   // Restore saved config so the dialog remembers previous choices
-  if (!config.empty()) {
-    (void)session->handle().loadConfig(config);
+  if (!saved_config.empty()) {
+    (void)session->handle().loadConfig(saved_config);
   }
 
   // Dialog flow — use the session's own handle, not a temp handle
+  std::string config = saved_config;
   if ((source->capabilities & PJ_DATA_SOURCE_CAPABILITY_HAS_DIALOG) != 0) {
     auto vt_result = source->library.resolveDialogVtable();
     if (vt_result) {


### PR DESCRIPTION
## Summary

Enable plugins to query available encodings **before** the dialog is shown by introducing a two-phase runtime host binding pattern.

## Problem

The original `listAvailableEncodings()` added in PR #27 was callable only after `bindRuntimeHost()`, which happens AFTER the dialog closes. Plugins like MQTT/ZMQ need this information to populate their encoding combo boxes during `widget_data()`.

## Solution: Two-Phase Binding

**Phase 1 (before dialog):** Bind minimal runtime host with registry access only
```cpp
session->bindRuntimeHostForDialog();  // Only registry, no engine/dataset
```

**Phase 2 (after dialog):** Complete binding with engine and dataset
```cpp
session->setupAndStart(config);  // Full binding as before
```

## Changes

### DataSourceSession
- Add `bindRuntimeHostForDialog()` method for early binding
- Only binds registry pointer; engine/dataset are set later

### main_window.cpp
- Call `bindRuntimeHostForDialog()` before showing the dialog
- Remove config JSON injection approach (cleaner API)

### SDK (`data_source_plugin_base.hpp`)
- `listAvailableEncodings()` now returns `std::vector<std::string>` directly
- `listAvailableEncodingsJson()` returns raw JSON for special cases
- Zero-dependency JSON array parser built into pj_base

### Tests
- Updated `data_source_library_test.cpp` with new test cases

## Usage from Plugins

```cpp
// mqtt_source.cpp
PJ::Status loadConfig(std::string_view config_json) override {
  dialog_.loadConfig(config_json);
  // Runtime host is now available here (Phase 1 binding done)
  dialog_.setAvailableEncodings(runtimeHost().listAvailableEncodings());
  return PJ::okStatus();
}
```

## Related PRs

- PR #27 (merged) — Added `listAvailableEncodings()` to vtable
- pj-official-plugins PR #28 — MQTT uses dynamic encodings
- pj-official-plugins PR #29 — ZMQ uses dynamic encodings