### PR TITLE
fix(protoapp): always call loadConfig for streaming sources

### DIFF
--- a/pj_plugins/src/detail/library_loader.hpp
+++ b/pj_plugins/src/detail/library_loader.hpp
@@ -21,7 +21,7 @@ inline Expected<void*> loadLibraryHandle(std::string_view path) {
   }
   return reinterpret_cast<void*>(module);
 #else
-  void* handle = dlopen(std::string(path).c_str(), RTLD_NOW | RTLD_LOCAL);
+  void* handle = dlopen(std::string(path).c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
   if (handle == nullptr) {
     return unexpected(std::string(dlerror()));
   }

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -354,10 +354,9 @@ void MainWindow::onStartStream() {
   // Bind runtime host early so the dialog can call listAvailableEncodings()
   session->bindRuntimeHostForDialog();
 
-  // Restore saved config so the dialog remembers previous choices
-  if (!saved_config.empty()) {
-    (void)session->handle().loadConfig(saved_config);
-  }
+  // Always call loadConfig() so the plugin can initialize (e.g., populate encodings list)
+  // even if there's no saved config yet
+  (void)session->handle().loadConfig(saved_config);
 
   // Dialog flow — use the session's own handle, not a temp handle
   std::string config = saved_config;


### PR DESCRIPTION
## Summary

This PR contains two important fixes for streaming data sources:

### 1. Always call `loadConfig()` for streaming sources

Previously, `loadConfig()` was only called if there was a saved config. On first run (no saved config), plugins wouldn't receive `loadConfig()` before the dialog was shown, preventing them from initializing properly.

This affected plugins that use `loadConfig()` to populate dynamic UI elements (e.g., encoding lists from `runtimeHost().listAvailableEncodings()`).

### 2. Add `RTLD_DEEPBIND` to prevent OpenSSL symbol conflicts

Plugins using paho-mqtt-cpp (MQTT) were crashing with SIGSEGV in `libcrypto.so.3` when clicking the Connect button. The root cause was OpenSSL symbol conflicts between Conan's OpenSSL (linked by paho-mqtt) and the system's libcrypto.

Adding `RTLD_DEEPBIND` to `dlopen()` makes each plugin resolve its own symbols first, preventing these conflicts.

## Changes

- Always call `loadConfig()` for streaming sources, even with empty config
- Add `RTLD_DEEPBIND` flag to `dlopen()` in `library_loader.hpp`

## Related

- Plugins PR #28 (MQTT): depends on this fix
- Plugins PR #29 (ZMQ): depends on this fix