### PR TITLE
feat(sdk): parser dialog injection with config persistence

### DIFF
--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -14,7 +14,6 @@
 #include <exception>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "pj_base/data_source_protocol.h"
 #include "pj_base/expected.hpp"
@@ -263,15 +262,16 @@ class DataSourceRuntimeHostView {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * List all available parser encodings as a JSON string.
+   * List all available parser encodings.
    *
    * Returns a JSON array string of encoding names, e.g. ["json","cbor","protobuf"].
-   * Prefer using listAvailableEncodings() which returns a parsed vector.
+   * Plugins can use this to dynamically populate encoding selection UI instead
+   * of hardcoding a static list.
    *
    * @return JSON array string, or empty string if host doesn't support this or no parsers loaded.
    * @note Check that the host vtable has this method (newer hosts only).
    */
-  [[nodiscard]] std::string_view listAvailableEncodingsJson() const {
+  [[nodiscard]] std::string_view listAvailableEncodings() const {
     if (!valid()) {
       return {};
     }
@@ -287,69 +287,6 @@ class DataSourceRuntimeHostView {
     const char* result = host_.vtable->list_available_encodings(host_.ctx);
     return result == nullptr ? std::string_view{} : std::string_view(result);
   }
-
-  /**
-   * List all available parser encodings.
-   *
-   * Returns a vector of encoding names, e.g. {"json", "cbor", "protobuf"}.
-   * Plugins can use this to dynamically populate encoding selection UI instead
-   * of hardcoding a static list.
-   *
-   * @return Vector of encoding names, or empty vector if host doesn't support this.
-   */
-  [[nodiscard]] std::vector<std::string> listAvailableEncodings() const {
-    auto json = listAvailableEncodingsJson();
-    return parseJsonStringArray(json);
-  }
-
- private:
-  /// Parse a simple JSON array of strings: ["a","b","c"] -> {"a","b","c"}
-  /// Handles escaped quotes within strings. Returns empty vector on malformed input.
-  static std::vector<std::string> parseJsonStringArray(std::string_view json) {
-    std::vector<std::string> result;
-    if (json.empty()) return result;
-
-    size_t i = 0;
-    // Skip whitespace and find opening bracket
-    while (i < json.size() && (json[i] == ' ' || json[i] == '\t' || json[i] == '\n')) ++i;
-    if (i >= json.size() || json[i] != '[') return result;
-    ++i;
-
-    while (i < json.size()) {
-      // Skip whitespace
-      while (i < json.size() && (json[i] == ' ' || json[i] == '\t' || json[i] == '\n' || json[i] == ',')) ++i;
-      if (i >= json.size() || json[i] == ']') break;
-
-      // Expect opening quote
-      if (json[i] != '"') return {};  // Malformed
-      ++i;
-
-      // Parse string content (handle escaped quotes)
-      std::string str;
-      while (i < json.size() && json[i] != '"') {
-        if (json[i] == '\\' && i + 1 < json.size()) {
-          ++i;  // Skip backslash
-          if (json[i] == '"' || json[i] == '\\') {
-            str += json[i];
-          } else {
-            str += '\\';
-            str += json[i];
-          }
-        } else {
-          str += json[i];
-        }
-        ++i;
-      }
-      if (i >= json.size()) return {};  // Unclosed string
-      ++i;  // Skip closing quote
-
-      result.push_back(std::move(str));
-    }
-
-    return result;
-  }
-
- public:
 
   /// Access the underlying C ABI struct.
   [[nodiscard]] const PJ_data_source_runtime_host_t& raw() const {

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -119,6 +119,11 @@ class WidgetDataView {
     return result;
   }
 
+  // --- QPlainTextEdit ---
+  [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
+    return getString(name, "plain_text");
+  }
+
   // --- QLabel ---
   [[nodiscard]] std::optional<std::string> label(std::string_view name) const {
     return getString(name, "label");
@@ -143,6 +148,20 @@ class WidgetDataView {
     return getString(name, "filter");
   }
   [[nodiscard]] std::optional<std::string> filePickerTitle(std::string_view name) const {
+    return getString(name, "title");
+  }
+
+  // --- Folder picker ---
+  [[nodiscard]] bool isFolderPicker(std::string_view name) const {
+    const nlohmann::json* w = widget(name);
+    if (!w) {
+      return false;
+    }
+    auto it = w->find("action");
+    return it != w->end() && it->is_string() && it->get<std::string>() == "folder_picker";
+  }
+
+  [[nodiscard]] std::optional<std::string> folderPickerTitle(std::string_view name) const {
     return getString(name, "title");
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -74,6 +74,13 @@ struct WidgetEventBuilder {
     return j.dump();
   }
 
+  /// Folder picker: folder selected
+  [[nodiscard]] static std::string folderSelected(std::string_view path) {
+    nlohmann::json j;
+    j["folder_selected"] = path;
+    return j.dump();
+  }
+
   /// QTabWidget: tab changed
   [[nodiscard]] static std::string tabChanged(int index) {
     nlohmann::json j;

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/dialog_engine.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/dialog_engine.hpp
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <pj_plugins/host/dialog_handle.hpp>
+#include <functional>
 #include <string>
 
 namespace PJ {
@@ -9,11 +10,26 @@ namespace PJ {
 /// Result of showing a dialog.
 enum class DialogResult { kAccepted, kRejected };
 
+/// Callback to resolve a parser's dialog vtable by encoding name.
+/// Returns nullptr if no dialog is available for that encoding.
+/// Used by DialogEngine to inject parser-specific options UI into data source dialogs.
+using QueryParserDialogFn = std::function<const PJ_dialog_vtable_t*(const std::string& encoding)>;
+
 /// Configuration for DialogEngine.
 struct DialogEngineConfig {
   int tick_interval_ms = 50;
   bool enable_diff = true;         // Only apply changed widgets on tick
   bool enable_file_picker = true;  // Show QFileDialog for file_picker actions
+
+  /// Optional callback to resolve parser dialog vtables.
+  /// When set and the loaded UI contains a widget named "pj_parser_slot",
+  /// the engine will inject the parser's dialog widget into that slot
+  /// whenever the encoding combo (comboBoxProtocol) changes.
+  QueryParserDialogFn parser_dialog_provider;
+
+  /// Initial parser config to restore when injecting the parser dialog.
+  /// If non-empty, the parser dialog's loadConfig() is called with this.
+  std::string initial_parser_config;
 };
 
 /// Orchestrates the full dialog lifecycle for a plugin:
@@ -37,12 +53,17 @@ class DialogEngine {
   /// Return the plugin's current saved config.
   [[nodiscard]] std::string savedConfig() const;
 
+  /// Return the parser dialog's saved config (empty if no parser dialog was shown).
+  /// Only valid after showDialog() returns kAccepted.
+  [[nodiscard]] std::string parserConfig() const;
+
   /// Stats from the last showDialog() call.
   struct Stats {
     int tick_count = 0;
     int event_count = 0;
     int diff_apply_count = 0;
     bool has_parser_slot = false;
+    bool parser_dialog_injected = false;  // True if a parser dialog was actually injected
   };
   [[nodiscard]] Stats lastStats() const {
     return stats_;
@@ -52,6 +73,7 @@ class DialogEngine {
   PJ::DialogHandle handle_;
   DialogEngineConfig config_;
   Stats stats_;
+  std::string parser_config_;  // Saved parser config (populated on accept)
 };
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -47,6 +47,10 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  virtual bool onFolderSelected(std::string_view /*widget_name*/, std::string_view /*path*/) {
+    return false;
+  }
+
   virtual bool onTabChanged(std::string_view /*widget_name*/, int /*index*/) {
     return false;
   }
@@ -71,6 +75,9 @@ class DialogPluginTyped : public DialogPluginBase {
     }
     if (auto v = event.fileSelected()) {
       return onFileSelected(widget_name, *v);
+    }
+    if (auto v = event.folderSelected()) {
+      return onFolderSelected(widget_name, *v);
     }
     if (event.clicked()) {
       return onClicked(widget_name);

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -90,6 +90,12 @@ class WidgetData {
     return *this;
   }
 
+  // --- QPlainTextEdit ---
+  WidgetData& setPlainText(std::string_view name, std::string_view text) {
+    entry(name)["plain_text"] = text;
+    return *this;
+  }
+
   // --- QLabel ---
   WidgetData& setLabel(std::string_view name, std::string_view text) {
     entry(name)["label"] = text;
@@ -108,6 +114,14 @@ class WidgetData {
     e["button_text"] = button_text;
     e["action"] = "file_picker";
     e["filter"] = filter;
+    e["title"] = title;
+    return *this;
+  }
+
+  WidgetData& setFolderPicker(std::string_view name, std::string_view button_text, std::string_view title) {
+    auto& e = entry(name);
+    e["button_text"] = button_text;
+    e["action"] = "folder_picker";
     e["title"] = title;
     return *this;
   }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -79,6 +79,11 @@ class WidgetEvent {
     return getString("file_selected");
   }
 
+  /// Folder picker: folder selected
+  std::optional<std::string> folderSelected() const {
+    return getString("folder_selected");
+  }
+
   /// QTabWidget: tab changed
   std::optional<int> tabIndex() const {
     return getInt("tab_index");

--- a/pj_plugins/dialog_protocol/src/dialog_engine.cpp
+++ b/pj_plugins/dialog_protocol/src/dialog_engine.cpp
@@ -1,7 +1,9 @@
 #include <QBuffer>
+#include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QFileDialog>
+#include <QGroupBox>
 #include <QSettings>
 #include <QTimer>
 #include <QUiLoader>
@@ -127,6 +129,185 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
   // Task 7: detect parser slot widget
   stats_.has_parser_slot = loaded->findChild<QWidget*>("pj_parser_slot") != nullptr;
 
+  // --- Parser slot injection state ---
+  QWidget* parser_slot = nullptr;
+  QWidget* parser_slot_container = nullptr;  // Parent GroupBox to show/hide
+  QVBoxLayout* parser_slot_layout = nullptr;
+  QWidget* parser_dialog_widget = nullptr;
+  std::unique_ptr<PJ::DialogHandle> parser_dialog_handle;
+  nlohmann::json parser_prev_data = nlohmann::json::object();
+
+  // Parameterized file/folder picker handlers (work for any dialog handle)
+  auto show_file_picker_for = [&](const std::string& widget_name, PJ::DialogHandle* handle, QWidget* target_widget,
+                                  nlohmann::json& target_prev_data) {
+    if (!config_.enable_file_picker || !handle) {
+      return;
+    }
+    PJ::WidgetDataView view(handle->widget_data());
+    if (!view.isFilePicker(widget_name)) {
+      return;
+    }
+    auto filter = view.filePickerFilter(widget_name).value_or("");
+    auto title = view.filePickerTitle(widget_name).value_or("Select File");
+    QString path =
+        QFileDialog::getOpenFileName(dialog, QString::fromStdString(title), QString(), QString::fromStdString(filter));
+    if (!path.isEmpty()) {
+      if (handle->sendEvent(widget_name, PJ::WidgetEventBuilder::fileSelected(path.toStdString()))) {
+        std::string raw = handle->widget_data();
+        nlohmann::json new_data = nlohmann::json::parse(raw, nullptr, false);
+        if (!new_data.is_discarded()) {
+          new_data.erase("__request_accept");
+          new_data.erase("__request_sub_dialog");
+          PJ::WidgetDataView v(raw);
+          applyWidgetData(target_widget, v);
+          target_prev_data = std::move(new_data);
+        }
+      }
+    }
+  };
+
+  auto show_folder_picker_for = [&](const std::string& widget_name, PJ::DialogHandle* handle, QWidget* target_widget,
+                                    nlohmann::json& target_prev_data) {
+    if (!config_.enable_file_picker || !handle) {
+      return;
+    }
+    PJ::WidgetDataView view(handle->widget_data());
+    if (!view.isFolderPicker(widget_name)) {
+      return;
+    }
+    auto title = view.folderPickerTitle(widget_name).value_or("Select Folder");
+    QString path = QFileDialog::getExistingDirectory(dialog, QString::fromStdString(title));
+    if (!path.isEmpty()) {
+      if (handle->sendEvent(widget_name, PJ::WidgetEventBuilder::folderSelected(path.toStdString()))) {
+        std::string raw = handle->widget_data();
+        nlohmann::json new_data = nlohmann::json::parse(raw, nullptr, false);
+        if (!new_data.is_discarded()) {
+          new_data.erase("__request_accept");
+          new_data.erase("__request_sub_dialog");
+          PJ::WidgetDataView v(raw);
+          applyWidgetData(target_widget, v);
+          target_prev_data = std::move(new_data);
+        }
+      }
+    }
+  };
+
+  // Lambda: inject parser dialog for the given encoding
+  auto inject_parser_dialog = [&](const QString& encoding) {
+    // 1. Clear previous parser dialog
+    if (parser_dialog_widget) {
+      parser_slot_layout->removeWidget(parser_dialog_widget);
+      delete parser_dialog_widget;
+      parser_dialog_widget = nullptr;
+    }
+    parser_dialog_handle.reset();
+    parser_prev_data = nlohmann::json::object();
+
+    // 2. Query parser dialog vtable via provider
+    if (!config_.parser_dialog_provider) {
+      if (parser_slot_container) {
+        parser_slot_container->setVisible(false);
+      }
+      return;
+    }
+
+    const PJ_dialog_vtable_t* vtable = config_.parser_dialog_provider(encoding.toStdString());
+    if (vtable == nullptr) {
+      // Parser has no dialog - hide the container
+      if (parser_slot_container) {
+        parser_slot_container->setVisible(false);
+      }
+      return;
+    }
+
+    // 3. Create parser dialog handle
+    parser_dialog_handle = std::make_unique<PJ::DialogHandle>(vtable);
+
+    // 3b. Load initial parser config if provided (restores previous state)
+    if (!config_.initial_parser_config.empty()) {
+      (void)parser_dialog_handle->load_config(config_.initial_parser_config);
+    }
+
+    // 4. Load parser dialog UI
+    std::string parser_ui = parser_dialog_handle->ui_content();
+    QByteArray parser_data(parser_ui.data(), static_cast<int>(parser_ui.size()));
+    QBuffer parser_buffer(&parser_data);
+    parser_buffer.open(QIODevice::ReadOnly);
+
+    QUiLoader parser_loader;
+    parser_dialog_widget = parser_loader.load(&parser_buffer, parser_slot);
+    if (!parser_dialog_widget) {
+      parser_dialog_handle.reset();
+      if (parser_slot_container) {
+        parser_slot_container->setVisible(false);
+      }
+      return;
+    }
+
+    // 5. Insert into slot and show container
+    parser_slot_layout->addWidget(parser_dialog_widget);
+    if (parser_slot_container) {
+      parser_slot_container->setVisible(true);
+    }
+    stats_.parser_dialog_injected = true;
+
+    // 6. Apply initial parser widget data
+    std::string parser_initial_raw = parser_dialog_handle->widget_data();
+    parser_prev_data = nlohmann::json::parse(parser_initial_raw, nullptr, false);
+    if (parser_prev_data.is_discarded()) {
+      parser_prev_data = nlohmann::json::object();
+    }
+    {
+      PJ::WidgetDataView view(parser_initial_raw);
+      applyWidgetData(parser_dialog_widget, view);
+    }
+
+    // 7. Wire parser dialog signals (events go to parser handle)
+    connectWidgetSignals(parser_dialog_widget, [&](const std::string& name, const std::string& event_json) {
+      stats_.event_count++;
+      if (parser_dialog_handle && parser_dialog_handle->sendEvent(name, event_json)) {
+        // Re-apply parser widget data
+        std::string raw = parser_dialog_handle->widget_data();
+        nlohmann::json new_data = nlohmann::json::parse(raw, nullptr, false);
+        if (!new_data.is_discarded()) {
+          new_data.erase("__request_accept");
+          new_data.erase("__request_sub_dialog");
+          if (config_.enable_diff) {
+            nlohmann::json diff = compute_diff(parser_prev_data, new_data);
+            if (!diff.empty()) {
+              PJ::WidgetDataView view(diff.dump());
+              applyWidgetData(parser_dialog_widget, view);
+            }
+          } else {
+            PJ::WidgetDataView view(raw);
+            applyWidgetData(parser_dialog_widget, view);
+          }
+          parser_prev_data = std::move(new_data);
+        }
+      }
+
+      // Handle file/folder pickers in parser dialog
+      show_file_picker_for(name, parser_dialog_handle.get(), parser_dialog_widget, parser_prev_data);
+      show_folder_picker_for(name, parser_dialog_handle.get(), parser_dialog_widget, parser_prev_data);
+    });
+  };
+
+  // Setup parser slot if detected and provider is available
+  if (stats_.has_parser_slot && config_.parser_dialog_provider) {
+    parser_slot = loaded->findChild<QWidget*>("pj_parser_slot");
+    if (parser_slot) {
+      parser_slot_container = parser_slot->parentWidget();  // Usually a QGroupBox
+      parser_slot_layout = new QVBoxLayout(parser_slot);
+      parser_slot_layout->setContentsMargins(0, 0, 0, 0);
+
+      // Connect encoding combo to trigger parser dialog injection
+      if (auto* combo = loaded->findChild<QComboBox*>("comboBoxProtocol")) {
+        QObject::connect(combo, &QComboBox::currentTextChanged, inject_parser_dialog);
+        // Note: initial injection happens AFTER widget_data is applied (see below)
+      }
+    }
+  }
+
   QWidget* binding_root = loaded;
 
   // 3. Apply initial widget data
@@ -138,6 +319,13 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
   {
     PJ::WidgetDataView view(initial_raw);
     applyWidgetData(binding_root, view);
+  }
+
+  // 3b. Trigger initial parser dialog injection now that combo is populated
+  if (parser_slot != nullptr) {
+    if (auto* combo = loaded->findChild<QComboBox*>("comboBoxProtocol")) {
+      inject_parser_dialog(combo->currentText());
+    }
   }
 
   // Helper: open a sub-dialog from UI XML (nested modal inside parent)
@@ -175,27 +363,6 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
     delete sub_dialog;
   };
 
-  // 4. Handle file picker actions
-  auto maybe_show_file_picker = [&](const std::string& widget_name) {
-    if (!config_.enable_file_picker) {
-      return;
-    }
-    PJ::WidgetDataView view(handle_.widget_data());
-    if (!view.isFilePicker(widget_name)) {
-      return;
-    }
-    auto filter = view.filePickerFilter(widget_name).value_or("");
-    auto title = view.filePickerTitle(widget_name).value_or("Select File");
-    QString path =
-        QFileDialog::getOpenFileName(dialog, QString::fromStdString(title), QString(), QString::fromStdString(filter));
-    if (!path.isEmpty()) {
-      if (handle_.sendEvent(widget_name, PJ::WidgetEventBuilder::fileSelected(path.toStdString()))) {
-        auto ar = apply_and_diff(binding_root, handle_, prev_data, config_.enable_diff, stats_.diff_apply_count);
-        maybe_open_sub_dialog(ar);
-      }
-    }
-  };
-
   // 5. Wire signals
   connectWidgetSignals(binding_root, [&](const std::string& name, const std::string& event_json) {
     stats_.event_count++;
@@ -207,7 +374,8 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
       }
       maybe_open_sub_dialog(ar);
     }
-    maybe_show_file_picker(name);
+    show_file_picker_for(name, &handle_, binding_root, prev_data);
+    show_folder_picker_for(name, &handle_, binding_root, prev_data);
   });
 
   // 6. Start tick timer
@@ -230,9 +398,16 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
   DialogResult dr;
   if (result == QDialog::Accepted) {
     handle_.accept(handle_.save_config());
+    // Save parser config if a parser dialog was shown
+    if (parser_dialog_handle) {
+      parser_config_ = parser_dialog_handle->save_config();
+    } else {
+      parser_config_.clear();
+    }
     dr = DialogResult::kAccepted;
   } else {
     handle_.reject();
+    parser_config_.clear();
     dr = DialogResult::kRejected;
   }
   // Save dialog geometry for next time
@@ -251,6 +426,10 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
 
 std::string DialogEngine::savedConfig() const {
   return handle_.save_config();
+}
+
+std::string DialogEngine::parserConfig() const {
+  return parser_config_;
 }
 
 std::string DialogEngine::runHeadless(int max_ticks) {

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -7,6 +7,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
+#include <QPlainTextEdit>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QSignalBlocker>
@@ -45,6 +46,17 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
     }
     if (auto v = view.readOnly(name)) {
       le->setReadOnly(*v);
+    }
+    return;
+  }
+
+  // --- QPlainTextEdit ---
+  if (auto* pte = qobject_cast<QPlainTextEdit*>(w)) {
+    if (auto v = view.plainText(name)) {
+      pte->setPlainText(QString::fromStdString(*v));
+    }
+    if (auto v = view.readOnly(name)) {
+      pte->setReadOnly(*v);
     }
     return;
   }

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -186,24 +186,13 @@ TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyWhenNullptr) {
   EXPECT_TRUE(encodings.empty());
 }
 
-TEST(RuntimeHostViewTest, ListAvailableEncodingsJsonReturnsJsonArray) {
-  auto host = makeRuntimeHostWithEncodings();
-  PJ::DataSourceRuntimeHostView view(host);
-
-  auto json = view.listAvailableEncodingsJson();
-  EXPECT_FALSE(json.empty());
-  EXPECT_EQ(json, R"(["json","cbor","protobuf"])");
-}
-
-TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsParsedVector) {
+TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsJsonArray) {
   auto host = makeRuntimeHostWithEncodings();
   PJ::DataSourceRuntimeHostView view(host);
 
   auto encodings = view.listAvailableEncodings();
-  ASSERT_EQ(encodings.size(), 3u);
-  EXPECT_EQ(encodings[0], "json");
-  EXPECT_EQ(encodings[1], "cbor");
-  EXPECT_EQ(encodings[2], "protobuf");
+  EXPECT_FALSE(encodings.empty());
+  EXPECT_EQ(encodings, R"(["json","cbor","protobuf"])");
 }
 
 TEST(RuntimeHostViewTest, ListAvailableEncodingsReturnsEmptyForOldHost) {

--- a/pj_proto_app/src/data_source_session.cpp
+++ b/pj_proto_app/src/data_source_session.cpp
@@ -103,7 +103,7 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
     return false;
   }
 
-  // Bind schema if provided
+  // Bind schema if provided by request
   if (request->schema.size > 0) {
     PJ::Span<const uint8_t> schema_span(request->schema.data, request->schema.size);
     if (!parser->bindSchema(type_name, schema_span)) {
@@ -114,10 +114,21 @@ bool rhEnsureParserBinding(void* ctx, const PJ_parser_binding_request_t* request
     }
   }
 
-  // Load parser config if provided
+  // Load parser config: prefer request config, fall back to dialog config
+  std::string_view parser_config;
   if (request->parser_config_json.size > 0) {
-    std::string_view config(request->parser_config_json.data, request->parser_config_json.size);
-    (void)parser->loadConfig(config);
+    parser_config = std::string_view(request->parser_config_json.data, request->parser_config_json.size);
+  } else if (!state->parser_config_json.empty()) {
+    parser_config = state->parser_config_json;
+  }
+
+  if (!parser_config.empty()) {
+    auto status = parser->loadConfig(parser_config);
+    if (!status) {
+      state->last_error = "failed to load parser config: " + parser->lastError();
+      std::cerr << "[bridge] " << state->last_error << "\n";
+      return false;
+    }
   }
 
   uint32_t binding_id = state->next_binding_id++;
@@ -132,9 +143,14 @@ bool rhPushRawMessage(void* ctx, PJ_parser_binding_handle_t handle, int64_t time
   auto* state = static_cast<RuntimeHostState*>(ctx);
   auto it = state->parser_bindings.find(handle.id);
   if (it == state->parser_bindings.end()) {
+    state->last_error = "invalid parser binding handle";
     return false;
   }
-  return it->second.parser->parse(timestamp_ns, PJ::Span<const uint8_t>(payload.data, payload.size));
+  if (!it->second.parser->parse(timestamp_ns, PJ::Span<const uint8_t>(payload.data, payload.size))) {
+    state->last_error = it->second.parser->lastError();
+    return false;
+  }
+  return true;
 }
 
 int rhShowMessageBox(

--- a/pj_proto_app/src/data_source_session.hpp
+++ b/pj_proto_app/src/data_source_session.hpp
@@ -60,6 +60,9 @@ struct RuntimeHostState {
 
   // Cached JSON array for list_available_encodings (lifetime: until next call)
   std::string available_encodings_cache;
+
+  // Parser dialog config (used for binding schemas)
+  std::string parser_config_json;
 };
 
 class DataSourceSession : public QObject {
@@ -114,6 +117,11 @@ class DataSourceSession : public QObject {
   /// Bind the message box callback from the Qt layer. Must be called before start.
   void setMessageBoxCallback(ShowMessageBoxCallback callback) {
     runtime_state_.show_message_box_callback = std::move(callback);
+  }
+
+  /// Set the parser dialog config (for schema binding in delegated ingest).
+  void setParserConfig(std::string config) {
+    runtime_state_.parser_config_json = std::move(config);
   }
 
  signals:

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -19,13 +19,29 @@
 #include "pj_marketplace/extension_manager.hpp"
 #include "pj_marketplace/marketplace_window.hpp"
 
-
 #include "pj_datastore/reader.hpp"
 #include "pj_plugins/host_qt/dialog_engine.hpp"
+#include "plugin_registry.hpp"
 
 namespace proto {
 
 namespace {
+
+/// Creates a callback to resolve parser dialog vtables by encoding.
+/// Used by DialogEngine to inject parser options UI into transport dialogs.
+PJ::QueryParserDialogFn makeParserDialogProvider(PluginRegistry* registry) {
+  return [registry](const std::string& encoding) -> const PJ_dialog_vtable_t* {
+    auto* parser = registry->findParserByEncoding(encoding);
+    if (parser == nullptr) {
+      return nullptr;
+    }
+    auto vtable_result = parser->library.resolveDialogVtable();
+    if (!vtable_result) {
+      return nullptr;  // Parser doesn't export a dialog
+    }
+    return *vtable_result;
+  };
+}
 
 /// Creates a callback that shows a QMessageBox.
 /// Assumes caller is on GUI thread (protoapp calls plugin methods from GUI thread).
@@ -298,7 +314,9 @@ void MainWindow::onLoadFile() {
       auto* dialog_ctx = session->handle().dialogContext();
       if (dialog_ctx != nullptr) {
         auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
-        PJ::DialogEngine dialog_engine(std::move(dialog_handle));
+        PJ::DialogEngineConfig engine_config;
+        engine_config.parser_dialog_provider = makeParserDialogProvider(&registry_);
+        PJ::DialogEngine dialog_engine(std::move(dialog_handle), engine_config);
         if (dialog_engine.showDialog(this) == PJ::DialogResult::kRejected) {
           return;
         }
@@ -343,7 +361,9 @@ void MainWindow::onStartStream() {
 
   QSettings settings;
   auto settings_key = QString("PluginConfig/%1").arg(QString::fromStdString(source->name));
+  auto parser_settings_key = QString("ParserConfig/%1").arg(QString::fromStdString(source->name));
   std::string saved_config = settings.value(settings_key, "").toString().toStdString();
+  std::string saved_parser_config = settings.value(parser_settings_key, "").toString().toStdString();
 
   // Create session first so the dialog runs on the SAME handle that will stream.
   // This matches the original plugin architecture: one object, one socket.
@@ -360,19 +380,29 @@ void MainWindow::onStartStream() {
 
   // Dialog flow — use the session's own handle, not a temp handle
   std::string config = saved_config;
+  std::string parser_config = saved_parser_config;
   if ((source->capabilities & PJ_DATA_SOURCE_CAPABILITY_HAS_DIALOG) != 0) {
     auto vt_result = source->library.resolveDialogVtable();
     if (vt_result) {
       auto* dialog_ctx = session->handle().dialogContext();
       if (dialog_ctx != nullptr) {
         auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
-        PJ::DialogEngine dialog_engine(std::move(dialog_handle));
+        PJ::DialogEngineConfig engine_config;
+        engine_config.parser_dialog_provider = makeParserDialogProvider(&registry_);
+        engine_config.initial_parser_config = saved_parser_config;
+        PJ::DialogEngine dialog_engine(std::move(dialog_handle), engine_config);
         if (dialog_engine.showDialog(this) == PJ::DialogResult::kRejected) {
           return;
         }
         config = dialog_engine.savedConfig();
+        parser_config = dialog_engine.parserConfig();
       }
     }
+  }
+
+  // Pass parser config to session for delegated ingest schema binding
+  if (!parser_config.empty()) {
+    session->setParserConfig(parser_config);
   }
 
   if (!session->startStream(config)) {
@@ -380,8 +410,9 @@ void MainWindow::onStartStream() {
   }
   sessions_.push_back(std::move(session));
 
-  // Persist the config
+  // Persist configs
   settings.setValue(settings_key, QString::fromStdString(config));
+  settings.setValue(parser_settings_key, QString::fromStdString(parser_config));
 
   streaming_active_ = true;
   if (!refresh_timer_.isActive()) {


### PR DESCRIPTION
## Summary

Adds support for injecting parser-specific option dialogs into data source dialogs (MQTT, ZMQ) via a `pj_parser_slot` widget. When the encoding combo changes, the DialogEngine queries the parser_dialog_provider callback and dynamically loads the parser's UI into the slot.

## Changes

**SDK extensions:**
- `WidgetData`: `setPlainText()`, `setFolderPicker()`
- `WidgetDataView`: `plainText()`, `isFolderPicker()`, `folderPickerTitle()`
- `WidgetEvent`: `folderSelected()`
- `DialogPluginTyped`: `onFolderSelected()` virtual dispatch
- `widget_binding`: QPlainTextEdit support

**DialogEngine:**
- `QueryParserDialogFn` callback to resolve parser dialog vtables
- `initial_parser_config` for restoring parser dialog state
- `parserConfig()` accessor for retrieving parser config after accept
- Folder picker support via `QFileDialog::getExistingDirectory`

**Proto app:**
- Parser config persistence in QSettings (`ParserConfig/{source}`)
- `setParserConfig()` on DataSourceSession for delegated ingest
- Error propagation from parser in `rhPushRawMessage`

## Test Plan

- [x] MQTT + JSON with embedded timestamp field
- [x] MQTT + Protobuf with .proto file selection
- [x] ZMQ + Protobuf
- [x] Parser config persists across dialog re-opens