### PR TITLE
feat(sdk): add parseEncodingsJson helper for plugins

### DIFF
--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -270,6 +270,7 @@ class DataSourceRuntimeHostView {
    *
    * @return JSON array string, or empty string if host doesn't support this or no parsers loaded.
    * @note Check that the host vtable has this method (newer hosts only).
+   * @see pj_plugins/sdk/encoding_utils.hpp for parseEncodingsJson() helper.
    */
   [[nodiscard]] std::string_view listAvailableEncodings() const {
     if (!valid()) {

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/encoding_utils.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/encoding_utils.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file encoding_utils.hpp
+ * @brief Utility functions for parsing encoding lists from the runtime host.
+ *
+ * This header provides helpers to convert the JSON string returned by
+ * runtimeHost().listAvailableEncodings() into a std::vector<std::string>.
+ */
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace PJ::sdk {
+
+/**
+ * Parse a JSON array of encoding names into a vector.
+ *
+ * @param json_str JSON array string, e.g. ["json","cbor","protobuf"]
+ * @return Vector of encoding names, or empty vector on parse error.
+ *
+ * Usage:
+ * @code
+ *   auto json = runtimeHost().listAvailableEncodings();
+ *   auto encodings = PJ::sdk::parseEncodingsJson(json);
+ *   dialog_.setAvailableEncodings(encodings);
+ * @endcode
+ */
+inline std::vector<std::string> parseEncodingsJson(std::string_view json_str) {
+  if (json_str.empty()) {
+    return {};
+  }
+
+  auto j = nlohmann::json::parse(json_str, nullptr, false);
+  if (j.is_discarded() || !j.is_array()) {
+    return {};
+  }
+
+  std::vector<std::string> result;
+  result.reserve(j.size());
+  for (const auto& item : j) {
+    if (item.is_string()) {
+      result.push_back(item.get<std::string>());
+    }
+  }
+  return result;
+}
+
+}  // namespace PJ::sdk


### PR DESCRIPTION
## Summary

- Add `encoding_utils.hpp` in `pj_plugins/sdk/` with `parseEncodingsJson()` helper
- Converts JSON array from `runtimeHost().listAvailableEncodings()` to `std::vector<std::string>`
- Keeps JSON parsing dependencies out of `pj_base`

## Why

Plugins (MQTT, ZMQ) need to populate encoding combos dynamically. The SDK returns JSON, plugins need a vector. This helper avoids duplicating parsing logic in each plugin.

## Test plan

- [x] Compiles with MQTT and ZMQ plugins locally
- [ ] CI passes after plugins PR uses this helper