### PR TITLE
fix(plugins): guard RTLD_DEEPBIND for macOS compatibility

### DIFF
--- a/pj_plugins/src/detail/library_loader.hpp
+++ b/pj_plugins/src/detail/library_loader.hpp
@@ -21,7 +21,15 @@ inline Expected<void*> loadLibraryHandle(std::string_view path) {
   }
   return reinterpret_cast<void*>(module);
 #else
-  void* handle = dlopen(std::string(path).c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
+  // RTLD_DEEPBIND prevents symbol conflicts (e.g. Conan OpenSSL vs system libcrypto)
+  // but is a glibc extension — not available on macOS or musl.
+  // TODO: consider a Platform abstraction class (like pj_marketplace/PlatformUtils)
+  //       to centralize OS-specific behavior.
+  int flags = RTLD_NOW | RTLD_LOCAL;
+#if defined(__linux__) && defined(RTLD_DEEPBIND)
+  flags |= RTLD_DEEPBIND;
+#endif
+  void* handle = dlopen(std::string(path).c_str(), flags);
   if (handle == nullptr) {
     return unexpected(std::string(dlerror()));
   }


### PR DESCRIPTION
## Summary
- `RTLD_DEEPBIND` is a glibc-only extension, not available on macOS (or musl)
- PR #29 added it unconditionally, breaking all macOS CI builds in pj-official-plugins
- Guard it behind `__linux__ && RTLD_DEEPBIND` so it's only used where supported

## Context
RTLD_DEEPBIND was added to prevent OpenSSL symbol conflicts when loading plugins
that link against Conan's OpenSSL while the host uses system libcrypto. This is a
real problem on Linux but the flag doesn't exist on macOS/BSD.

A TODO notes that a Platform abstraction class (similar to `pj_marketplace/PlatformUtils`)
would be a better long-term approach to centralize OS-specific behavior.

## Test plan
- [x] Linux build still uses RTLD_DEEPBIND (verified locally)
- [ ] macOS CI should now pass (was failing with `use of undeclared identifier 'RTLD_DEEPBIND'`)