### PR TITLE
feat(dialog_sdk): add keyboard shortcut support for QPushButton

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -134,6 +134,10 @@ class WidgetDataView {
     return getString(name, "button_text");
   }
 
+  [[nodiscard]] std::optional<std::string> shortcut(std::string_view name) const {
+    return getString(name, "shortcut");
+  }
+
   // --- File picker ---
   [[nodiscard]] bool isFilePicker(std::string_view name) const {
     const nlohmann::json* w = widget(name);

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/widget_binding.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/widget_binding.hpp
@@ -19,4 +19,9 @@ void applyWidgetData(QWidget* root, const PJ::WidgetDataView& view);
 /// an event JSON string built by WidgetEventBuilder.
 void connectWidgetSignals(QWidget* root, WidgetEventCallback callback);
 
+/// Create QShortcut objects for QPushButtons that declare a "shortcut" key
+/// in the widget data. Each shortcut triggers click() on the target button.
+/// Call once after the dialog is fully constructed and signals are connected.
+void installButtonShortcuts(QWidget* root, const PJ::WidgetDataView& view);
+
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -108,6 +108,13 @@ class WidgetData {
     return *this;
   }
 
+  /// Assign a keyboard shortcut to a QPushButton (e.g. "Ctrl+A", "Ctrl+Shift+A").
+  /// The host creates a QShortcut that triggers click() on the button.
+  WidgetData& setShortcut(std::string_view name, std::string_view key_sequence) {
+    entry(name)["shortcut"] = key_sequence;
+    return *this;
+  }
+
   WidgetData& setFilePicker(
       std::string_view name, std::string_view button_text, std::string_view filter, std::string_view title) {
     auto& e = entry(name);

--- a/pj_plugins/dialog_protocol/src/dialog_engine.cpp
+++ b/pj_plugins/dialog_protocol/src/dialog_engine.cpp
@@ -378,6 +378,12 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
     show_folder_picker_for(name, &handle_, binding_root, prev_data);
   });
 
+  // 5b. Install button keyboard shortcuts declared in widget data
+  {
+    PJ::WidgetDataView shortcut_view(handle_.widget_data());
+    installButtonShortcuts(dialog, shortcut_view);
+  }
+
   // 6. Start tick timer
   QTimer tick_timer;
   tick_timer.setInterval(config_.tick_interval_ms);

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -10,6 +10,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QShortcut>
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QSplitter>
@@ -325,6 +326,25 @@ void connectWidgetSignals(QWidget* root, WidgetEventCallback callback) {
       });
       continue;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// installButtonShortcuts — create QShortcuts for buttons declaring a shortcut
+// ---------------------------------------------------------------------------
+
+void installButtonShortcuts(QWidget* root, const PJ::WidgetDataView& view) {
+  for (const auto& name : view.widgetNames()) {
+    auto sc = view.shortcut(name);
+    if (!sc) {
+      continue;
+    }
+    auto* btn = root->findChild<QPushButton*>(QString::fromStdString(name));
+    if (!btn) {
+      continue;
+    }
+    auto* shortcut = new QShortcut(QKeySequence(QString::fromStdString(*sc)), root);
+    QObject::connect(shortcut, &QShortcut::activated, btn, &QPushButton::click);
   }
 }
 


### PR DESCRIPTION
## Summary

Add `WidgetData::setShortcut()` so plugins can declaratively bind keyboard shortcuts to buttons. The host materializes them as `QShortcut` objects that trigger `click()` synchronously through the normal event pipeline.

**New API surface:**
- `WidgetData::setShortcut(name, key_sequence)` — declare a shortcut for a button
- `WidgetDataView::shortcut(name)` — read shortcut from widget data
- `installButtonShortcuts(root, view)` — host-side helper to create QShortcut objects

## Use Case

This enables plugins to provide keyboard shortcuts for common actions without Qt dependencies. For example, a file loader dialog could bind Ctrl+A to "Select All" and Ctrl+Shift+A to "Deselect All".

## Test Plan

- [x] Verify shortcuts trigger button click events
- [x] Verify shortcuts work in injected parser dialogs
- [x] Verify no conflicts with existing Qt shortcuts