### PR TITLE
fix(proto_app): call applyPendingInstalls() on startup

### DIFF
--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -121,9 +121,9 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
   }
 
   ext_mgr_ = std::make_unique<PJ::ExtensionManager>();
+  ext_mgr_->applyPendingInstalls();
   ext_mgr_->applyPendingUninstalls();
   registry_.scanDirectory();
-  ext_mgr_ = std::make_unique<PJ::ExtensionManager>();
 
   // --- Toolbar ---
   auto* toolbar = addToolBar("Main");


### PR DESCRIPTION
## Summary

`applyPendingInstalls()` was never being invoked during `ExtensionManager` initialization, so pending plugin installs were silently ignored.

Also remove a duplicate `ExtensionManager` construction that was shadowing the original instance.

## Problem

When users installed plugins through the marketplace, the installation was marked as "pending" but never actually applied on subsequent app launches.

## Fix

Call `applyPendingInstalls()` during initialization to process any pending installs before the extension manager is used.

## Test Plan

- [x] Install a plugin via marketplace
- [x] Close and reopen the application
- [x] Verify the plugin is available and functional