### PR TITLE
feat(dialog_sdk): add setDisabledRows support for QTableWidget

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -119,6 +119,25 @@ class WidgetDataView {
     return result;
   }
 
+  [[nodiscard]] std::optional<std::vector<int>> disabledRows(std::string_view name) const {
+    const nlohmann::json* w = widget(name);
+    if (!w) {
+      return std::nullopt;
+    }
+    auto it = w->find("disabled_rows");
+    if (it == w->end() || !it->is_array()) {
+      return std::nullopt;
+    }
+    std::vector<int> result;
+    result.reserve(it->size());
+    for (const auto& item : *it) {
+      if (item.is_number_integer()) {
+        result.push_back(item.get<int>());
+      }
+    }
+    return result;
+  }
+
   // --- QPlainTextEdit ---
   [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
     return getString(name, "plain_text");

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -90,6 +90,11 @@ class WidgetData {
     return *this;
   }
 
+  WidgetData& setDisabledRows(std::string_view name, const std::vector<int>& rows) {
+    entry(name)["disabled_rows"] = rows;
+    return *this;
+  }
+
   // --- QPlainTextEdit ---
   WidgetData& setPlainText(std::string_view name, std::string_view text) {
     entry(name)["plain_text"] = text;

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -162,6 +162,25 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
         }
       }
     }
+    if (auto v = view.disabledRows(name)) {
+      std::set<int> disabled(v->begin(), v->end());
+      for (int r = 0; r < tw->rowCount(); ++r) {
+        bool is_disabled = disabled.count(r) > 0;
+        for (int c = 0; c < tw->columnCount(); ++c) {
+          if (auto* item = tw->item(r, c)) {
+            auto flags = item->flags();
+            if (is_disabled) {
+              flags &= ~Qt::ItemIsEnabled;
+              flags &= ~Qt::ItemIsSelectable;
+            } else {
+              flags |= Qt::ItemIsEnabled;
+              flags |= Qt::ItemIsSelectable;
+            }
+            item->setFlags(flags);
+          }
+        }
+      }
+    }
     if (auto v = view.selectedRows(name)) {
       tw->clearSelection();
       for (int r : *v) {


### PR DESCRIPTION
## Summary

Adds support for disabling individual rows in QTableWidget via the dialog protocol.

- `WidgetData::setDisabledRows(name, rows)` - Plugin-side builder method to mark rows as disabled
- `WidgetDataView::disabledRows(name)` - Host-side accessor to read disabled rows
- `widget_binding.cpp` - Applies Qt `ItemIsEnabled` and `ItemIsSelectable` flags per row

This enables plugins to grey out rows that should not be selectable, such as MCAP channels with `message_count=0`.

## Test plan

- [x] Build passes on all platforms
- [x] Unit tests pass
- [x] Manual test with MCAP plugin (companion PR in pj-official-plugins)

## Related

- Companion PR in pj-official-plugins: feat(mcap): grey out channels with message_count=0