### PR TITLE
fix(marketplace): detect pending install/uninstall state on window open

### DIFF
--- a/pj_marketplace/include/pj_marketplace/extension_manager.hpp
+++ b/pj_marketplace/include/pj_marketplace/extension_manager.hpp
@@ -80,6 +80,14 @@ class ExtensionManager : public QObject {
 
   bool isInstalled(const QString& id) const;
 
+  // Returns true if the extension is staged in the pending directory and will
+  // become active after the next restart (Windows update path).
+  bool hasPendingInstall(const QString& id) const;
+
+  // Returns true if the extension directory contains a pending-uninstall marker
+  // and will be deleted at the next startup (Windows uninstall path).
+  bool hasPendingUninstall(const QString& id) const;
+
   // Compares the registry version against the installed one using QVersionNumber,
   // which handles multi-segment semver correctly ("1.10.0" > "1.9.0").
   // Returns false if the extension is not installed.

--- a/pj_marketplace/src/core/ExtensionManager.cpp
+++ b/pj_marketplace/src/core/ExtensionManager.cpp
@@ -316,6 +316,30 @@ bool ExtensionManager::isInstalled(const QString& id) const {
   return installed_.contains(id);
 }
 
+bool ExtensionManager::hasPendingInstall(const QString& id) const {
+  const QDir pending(pending_dir_);
+  if (!pending.exists()) {
+    return false;
+  }
+  for (const QFileInfo& entry : pending.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot)) {
+    QFile manifest_file(entry.absoluteFilePath() + "/" + kManifestFileName);
+    if (!manifest_file.open(QIODevice::ReadOnly)) {
+      continue;
+    }
+    const QString manifest_id = QJsonDocument::fromJson(manifest_file.readAll()).object()["id"].toString();
+    if (manifest_id == id) {
+      emit const_cast<ExtensionManager*>(this)->installPendingRestart(id);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ExtensionManager::hasPendingUninstall(const QString& id) const {
+    const QString path = extensions_dir_ + "/" + id;                                                                                                                  
+    return QFile::exists(path + "/" + kPendingUninstallMarker);  
+}
+
 bool ExtensionManager::hasUpdate(const Extension& ext) const {
   if (!installed_.contains(ext.id)) {
     return false;

--- a/pj_marketplace/src/ui/marketplace_window.cpp
+++ b/pj_marketplace/src/ui/marketplace_window.cpp
@@ -227,7 +227,8 @@ void MarketplaceWindow::populateCards() {
     auto* btn_box = new QHBoxLayout();
     btn_box->setSpacing(6);
 
-    if (pending_restart_ids_.contains(ext.id)) {
+    if (pending_restart_ids_.contains(ext.id) || ext_mgr_->hasPendingInstall(ext.id) ||
+        ext_mgr_->hasPendingUninstall(ext.id)) {
       auto* badge = new QPushButton("Needs Restart", card);
       badge->setFixedWidth(90);
       badge->setEnabled(false);


### PR DESCRIPTION
## Summary

- Add `hasPendingInstall` / `hasPendingUninstall` to `ExtensionManager` to query staged operations on disk
- Show "Needs Restart" badge in marketplace cards when a deferred Windows install or uninstall is detected

Previously, reopening the marketplace after a Windows deferred operation showed an incorrect "Install" button instead of the "Needs Restart" badge.

## Test plan

- [x] Install extension on Windows, close marketplace
- [x] Reopen marketplace → should show "Needs Restart" (not "Install")
- [x] Uninstall extension on Windows, close marketplace  
- [x] Reopen marketplace → should show "Needs Restart" (not "Uninstall")