### PR TITLE
refactor(plugin-registry): remove additional_encodings, use encoding array

### DIFF
--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -69,10 +69,6 @@ bool PluginRegistry::loadAndRegisterMessageParser(const std::filesystem::path& s
     if (manifest.contains("encoding")) {
       push_encodings(manifest["encoding"]);
     }
-    // Additional encoding aliases (e.g., "ros1"/"ros2" for ROS parser)
-    if (manifest.contains("additional_encodings")) {
-      push_encodings(manifest["additional_encodings"]);
-    }
   } catch (...) {
     loaded.name = so_path.stem().string();
   }


### PR DESCRIPTION
## Summary

The manifest format now uses `"encoding"` as an array directly, making the separate `"additional_encodings"` field unnecessary.

**Changes:**
- Remove `additional_encodings` parsing from `plugin_registry.cpp`
- Unify encoding lookup to use the `encoding` array field only

## Test plan

- [x] Verify plugins with `encoding` array are correctly registered
- [x] Verify plugins with single `encoding` string still work (backwards compat)
- [x] CI passes on all platforms