### PR TITLE
feat(proto-app): add toolbox plugin loading to PluginRegistry

### DIFF
--- a/pj_proto_app/CMakeLists.txt
+++ b/pj_proto_app/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(pj_proto_app PRIVATE
   pj_datastore
   pj_data_source_host
   pj_message_parser_host
+  pj_toolbox_host
   pj_dialog_engine_qt
   pj_marketplace
   pj_marketplace_ui

--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -81,6 +81,29 @@ bool PluginRegistry::loadAndRegisterMessageParser(const std::filesystem::path& s
   return true;
 }
 
+bool PluginRegistry::loadAndRegisterToolbox(const std::filesystem::path& so_path) {
+  auto result = PJ::ToolboxLibrary::load(so_path.string());
+  if (!result) {
+    return false;
+  }
+  LoadedToolbox loaded;
+  loaded.library = std::move(*result);
+  loaded.path = so_path.string();
+  loaded.loaded_mtime = std::filesystem::last_write_time(so_path);
+
+  auto handle = loaded.library.createHandle();
+  loaded.capabilities = handle.capabilities();
+  try {
+    auto manifest = nlohmann::json::parse(handle.manifest());
+    loaded.name = manifest.value("name", so_path.stem().string());
+  } catch (...) {
+    loaded.name = so_path.stem().string();
+  }
+  std::cerr << "Loaded Toolbox: " << loaded.name << " from " << loaded.path << "\n";
+  toolbox_plugins_.push_back(std::move(loaded));
+  return true;
+}
+
 void PluginRegistry::scanDirectory() {
   namespace fs = std::filesystem;
 
@@ -95,7 +118,8 @@ void PluginRegistry::scanDirectory() {
       continue;
     }
     if (!loadAndRegisterDataSource(entry.path()) &&
-        !loadAndRegisterMessageParser(entry.path())) {
+        !loadAndRegisterMessageParser(entry.path()) &&
+        !loadAndRegisterToolbox(entry.path())) {
       std::cerr << "Failed to load plugin: " << entry.path() << "\n";
     }
   }
@@ -137,6 +161,13 @@ void PluginRegistry::reload() {
     }
     return false;
   });
+  std::erase_if(toolbox_plugins_, [&](const LoadedToolbox& tb) {
+    if (is_gone(tb.path)) {
+      std::cerr << "Unloaded Toolbox (removed): " << tb.path << "\n";
+      return true;
+    }
+    return false;
+  });
 
   // Load new .so files; reload modified ones
   for (const auto& so_path : on_disk) {
@@ -160,11 +191,22 @@ void PluginRegistry::reload() {
         }
         std::cerr << "Reloading updated MessageParser: " << path_str << "\n";
         message_parsers_.erase(mp_it);
+      } else {
+        auto tb_it = std::find_if(toolbox_plugins_.begin(), toolbox_plugins_.end(),
+                                  [&](const LoadedToolbox& tb) { return tb.path == path_str; });
+        if (tb_it != toolbox_plugins_.end()) {
+          if (disk_mtime <= tb_it->loaded_mtime) {
+            continue;
+          }
+          std::cerr << "Reloading updated Toolbox: " << path_str << "\n";
+          toolbox_plugins_.erase(tb_it);
+        }
       }
     }
 
     if (!loadAndRegisterDataSource(so_path) &&
-        !loadAndRegisterMessageParser(so_path)) {
+        !loadAndRegisterMessageParser(so_path) &&
+        !loadAndRegisterToolbox(so_path)) {
       std::cerr << "Failed to load plugin: " << path_str << "\n";
     }
   }

--- a/pj_proto_app/src/plugin_registry.hpp
+++ b/pj_proto_app/src/plugin_registry.hpp
@@ -8,6 +8,7 @@
 
 #include "pj_plugins/host/data_source_library.hpp"
 #include "pj_plugins/host/message_parser_library.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
 
 namespace proto {
 
@@ -25,6 +26,14 @@ struct LoadedMessageParser {
   std::string path;
   std::string name;
   std::vector<std::string> encodings;
+  std::filesystem::file_time_type loaded_mtime;
+};
+
+struct LoadedToolbox {
+  PJ::ToolboxLibrary library;
+  std::string path;
+  std::string name;
+  uint64_t capabilities = 0;
   std::filesystem::file_time_type loaded_mtime;
 };
 
@@ -50,6 +59,9 @@ class PluginRegistry {
   /// Returns e.g. ["json","cbor","protobuf"]. Returns "[]" if no parsers loaded.
   [[nodiscard]] std::string listAvailableEncodings() const;
 
+  /// Get all loaded toolbox plugins.
+  [[nodiscard]] const std::vector<LoadedToolbox>& allToolboxes() const { return toolbox_plugins_; }
+
  private:
   /// Try to load a DataSource plugin and register it. Returns true on success.
   bool loadAndRegisterDataSource(const std::filesystem::path& so_path);
@@ -57,9 +69,13 @@ class PluginRegistry {
   /// Try to load a MessageParser plugin and register it. Returns true on success.
   bool loadAndRegisterMessageParser(const std::filesystem::path& so_path);
 
+  /// Try to load a Toolbox plugin and register it. Returns true on success.
+  bool loadAndRegisterToolbox(const std::filesystem::path& so_path);
+
   std::string plugin_dir_;
   std::vector<LoadedDataSource> data_sources_;
   std::vector<LoadedMessageParser> message_parsers_;
+  std::vector<LoadedToolbox> toolbox_plugins_;
 };
 
 }  // namespace proto


### PR DESCRIPTION
## Summary

- Extend `PluginRegistry` to discover, load, and hot-reload toolbox plugins alongside data sources and message parsers
- Add `LoadedToolbox` struct tracking library handle, path, name, capabilities and modification time
- Integrate toolbox loading into `scanDirectory()` and `reload()` flows (load, unload on removal, reload on mtime change)
- Add `allToolboxes()` accessor for downstream consumers
- Link `pj_toolbox_host` into `pj_proto_app`

## Test plan

- [ ] Build `pj_proto_app` and verify no linker errors
- [ ] Place a toolbox `.so` in the plugin directory and verify it appears in `allToolboxes()`
- [ ] Modify the `.so` on disk and call `reload()` — verify it reloads
- [ ] Remove the `.so` and call `reload()` — verify it is unregistered