### PR TITLE
feat(dialog_sdk): add chart preview widget support

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.8.3'
+          modules: 'qtcharts'
           cache: 'true'
 
       - name: Install system packages

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -31,6 +31,7 @@ enum class ToolboxMessageLevel : uint32_t {
 /// @name Capability flag constants
 /// @{
 constexpr uint64_t kToolboxCapabilityHasDialog = PJ_TOOLBOX_CAPABILITY_HAS_DIALOG;
+constexpr uint64_t kToolboxCapabilityNonModalDialog = PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG;
 /// @}
 
 /**

--- a/pj_base/include/pj_base/toolbox_protocol.h
+++ b/pj_base/include/pj_base/toolbox_protocol.h
@@ -51,7 +51,8 @@ typedef enum {
  * Combine with bitwise OR.
  */
 enum {
-  PJ_TOOLBOX_CAPABILITY_HAS_DIALOG = 1ull << 0, /**< Plugin provides a persistent UI panel. */
+  PJ_TOOLBOX_CAPABILITY_HAS_DIALOG = 1ull << 0,       /**< Plugin provides a persistent UI panel. */
+  PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG = 1ull << 1, /**< Dialog should be shown non-modally so the host window remains interactive (e.g. for drag-and-drop). */
 };
 
 /**

--- a/pj_plugins/dialog_protocol/CMakeLists.txt
+++ b/pj_plugins/dialog_protocol/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 # --- Qt Dialog Engine (optional — requires Qt6) ---
 
 if(PJ_BUILD_DIALOG_ENGINE_QT)
-  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools Charts)
   qt_standard_project_setup()
 
   # Workaround: Qt 6.5 links AGL framework which was removed in macOS 15+ SDK.
@@ -158,10 +158,12 @@ if(PJ_BUILD_DIALOG_ENGINE_QT)
   add_library(pj_dialog_engine_qt STATIC
     src/widget_binding.cpp
     src/dialog_engine.cpp
+    src/chart_preview_widget.cpp
+    include/pj_plugins/host_qt/chart_preview_widget.hpp
   )
   target_compile_options(pj_dialog_engine_qt PRIVATE ${PJ_WARNING_FLAGS})
   target_link_libraries(pj_dialog_engine_qt
-    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools
+    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools Qt6::Charts
   )
   target_include_directories(pj_dialog_engine_qt PUBLIC include)
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -138,6 +138,47 @@ class WidgetDataView {
     return result;
   }
 
+  // --- Chart (QFrame used as chart container) ---
+
+  struct ChartSeriesView {
+    std::string label;
+    std::vector<std::pair<double, double>> points;  // {x, y}
+  };
+
+  [[nodiscard]] std::optional<std::vector<ChartSeriesView>> chartSeries(std::string_view name) const {
+    const nlohmann::json* w = widget(name);
+    if (!w) {
+      return std::nullopt;
+    }
+    auto it = w->find("chart_series");
+    if (it == w->end() || !it->is_array()) {
+      return std::nullopt;
+    }
+    std::vector<ChartSeriesView> result;
+    result.reserve(it->size());
+    for (const auto& s : *it) {
+      if (!s.is_object()) {
+        continue;
+      }
+      ChartSeriesView sv;
+      auto label_it = s.find("label");
+      if (label_it != s.end() && label_it->is_string()) {
+        sv.label = label_it->get<std::string>();
+      }
+      auto pts_it = s.find("points");
+      if (pts_it != s.end() && pts_it->is_array()) {
+        sv.points.reserve(pts_it->size());
+        for (const auto& pt : *pts_it) {
+          if (pt.is_array() && pt.size() == 2 && pt[0].is_number() && pt[1].is_number()) {
+            sv.points.emplace_back(pt[0].get<double>(), pt[1].get<double>());
+          }
+        }
+      }
+      result.push_back(std::move(sv));
+    }
+    return result;
+  }
+
   // --- QPlainTextEdit ---
   [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
     return getString(name, "plain_text");

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QtCharts/QChartView>
+#include <string>
+#include <utility>
+#include <vector>
+
+QT_BEGIN_NAMESPACE
+class QValueAxis;
+QT_END_NAMESPACE
+
+namespace PJ {
+
+/// Lightweight chart widget that renders named XY line series inside a QFrame.
+/// Created and managed by the widget binding layer — plugin authors never touch this directly.
+class ChartPreviewWidget : public QChartView {
+  Q_OBJECT
+
+ public:
+  explicit ChartPreviewWidget(QWidget* parent = nullptr);
+
+  struct Series {
+    std::string label;
+    std::vector<std::pair<double, double>> points;
+  };
+
+  void setSeries(const std::vector<Series>& series);
+  void clearSeries();
+
+ private:
+  QValueAxis* x_axis_ = nullptr;
+  QValueAxis* y_axis_ = nullptr;
+};
+
+}  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/dialog_engine.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/dialog_engine.hpp
@@ -30,6 +30,11 @@ struct DialogEngineConfig {
   /// Initial parser config to restore when injecting the parser dialog.
   /// If non-empty, the parser dialog's loadConfig() is called with this.
   std::string initial_parser_config;
+
+  /// If true, the dialog is shown non-modally (Qt::NonModal) so the parent
+  /// window remains interactive. Required for drag-and-drop from the host UI
+  /// into the dialog. Defaults to false (modal).
+  bool non_modal = false;
 };
 
 /// Orchestrates the full dialog lifecycle for a plugin:

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -7,6 +7,18 @@
 
 namespace PJ {
 
+/// A single point in a chart series (used by setChartSeries).
+struct ChartPoint {
+  double x;
+  double y;
+};
+
+/// A named series of XY points for chart display (used by setChartSeries).
+struct ChartSeries {
+  std::string label;
+  std::vector<ChartPoint> points;
+};
+
 /// Builder for the JSON string returned by get_widget_data().
 /// Each method targets an existing widget in the .ui file by its objectName.
 class WidgetData {
@@ -135,6 +147,30 @@ class WidgetData {
     e["button_text"] = button_text;
     e["action"] = "folder_picker";
     e["title"] = title;
+    return *this;
+  }
+
+  // --- Chart (QFrame used as chart container) ---
+
+  /// Set chart series data on a QFrame widget. The host will create or update
+  /// a chart view inside the frame, displaying one QLineSeries per entry.
+  WidgetData& setChartSeries(std::string_view name, const std::vector<ChartSeries>& series) {
+    auto& e = entry(name);
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& s : series) {
+      nlohmann::json pts = nlohmann::json::array();
+      for (const auto& p : s.points) {
+        pts.push_back({p.x, p.y});
+      }
+      arr.push_back({{"label", s.label}, {"points", std::move(pts)}});
+    }
+    e["chart_series"] = std::move(arr);
+    return *this;
+  }
+
+  /// Remove all series from the chart inside the named QFrame.
+  WidgetData& clearChart(std::string_view name) {
+    entry(name)["chart_series"] = nlohmann::json::array();
     return *this;
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -107,6 +107,30 @@ class WidgetData {
     return *this;
   }
 
+  // --- Chart (QFrame used as chart container) ---
+
+  /// Set chart series data on a QFrame widget. The host will create or update
+  /// a chart view inside the frame, displaying one QLineSeries per entry.
+  WidgetData& setChartSeries(std::string_view name, const std::vector<ChartSeries>& series) {
+    auto& e = entry(name);
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& s : series) {
+      nlohmann::json pts = nlohmann::json::array();
+      for (const auto& p : s.points) {
+        pts.push_back({p.x, p.y});
+      }
+      arr.push_back({{"label", s.label}, {"points", std::move(pts)}});
+    }
+    e["chart_series"] = std::move(arr);
+    return *this;
+  }
+
+  /// Remove all series from the chart inside the named QFrame.
+  WidgetData& clearChart(std::string_view name) {
+    entry(name)["chart_series"] = nlohmann::json::array();
+    return *this;
+  }
+
   // --- QPlainTextEdit ---
   WidgetData& setPlainText(std::string_view name, std::string_view text) {
     entry(name)["plain_text"] = text;
@@ -147,30 +171,6 @@ class WidgetData {
     e["button_text"] = button_text;
     e["action"] = "folder_picker";
     e["title"] = title;
-    return *this;
-  }
-
-  // --- Chart (QFrame used as chart container) ---
-
-  /// Set chart series data on a QFrame widget. The host will create or update
-  /// a chart view inside the frame, displaying one QLineSeries per entry.
-  WidgetData& setChartSeries(std::string_view name, const std::vector<ChartSeries>& series) {
-    auto& e = entry(name);
-    nlohmann::json arr = nlohmann::json::array();
-    for (const auto& s : series) {
-      nlohmann::json pts = nlohmann::json::array();
-      for (const auto& p : s.points) {
-        pts.push_back({p.x, p.y});
-      }
-      arr.push_back({{"label", s.label}, {"points", std::move(pts)}});
-    }
-    e["chart_series"] = std::move(arr);
-    return *this;
-  }
-
-  /// Remove all series from the chart inside the named QFrame.
-  WidgetData& clearChart(std::string_view name) {
-    entry(name)["chart_series"] = nlohmann::json::array();
     return *this;
   }
 

--- a/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
+++ b/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
@@ -1,0 +1,68 @@
+#include <pj_plugins/host_qt/chart_preview_widget.hpp>
+
+#include <QPointF>
+#include <QtCharts/QChart>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
+#include <limits>
+
+namespace PJ {
+
+ChartPreviewWidget::ChartPreviewWidget(QWidget* parent) : QChartView(new QChart(), parent) {
+  setRenderHint(QPainter::Antialiasing);
+
+  x_axis_ = new QValueAxis();
+  y_axis_ = new QValueAxis();
+  chart()->addAxis(x_axis_, Qt::AlignBottom);
+  chart()->addAxis(y_axis_, Qt::AlignLeft);
+
+  chart()->legend()->setVisible(true);
+  chart()->legend()->setAlignment(Qt::AlignBottom);
+  chart()->setMargins(QMargins(4, 4, 4, 4));
+}
+
+void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
+  chart()->removeAllSeries();
+
+  double x_min = std::numeric_limits<double>::max();
+  double x_max = std::numeric_limits<double>::lowest();
+  double y_min = std::numeric_limits<double>::max();
+  double y_max = std::numeric_limits<double>::lowest();
+
+  for (const auto& s : series) {
+    auto* line = new QLineSeries();
+    line->setName(QString::fromStdString(s.label));
+
+    QList<QPointF> points;
+    points.reserve(static_cast<int>(s.points.size()));
+    for (const auto& [x, y] : s.points) {
+      points.append(QPointF(x, y));
+      if (x < x_min) x_min = x;
+      if (x > x_max) x_max = x;
+      if (y < y_min) y_min = y;
+      if (y > y_max) y_max = y;
+    }
+    line->replace(points);
+
+    chart()->addSeries(line);
+    line->attachAxis(x_axis_);
+    line->attachAxis(y_axis_);
+  }
+
+  if (x_min < x_max) {
+    x_axis_->setRange(x_min, x_max);
+  }
+  if (y_min < y_max) {
+    double margin = (y_max - y_min) * 0.05;
+    if (margin == 0.0) {
+      margin = 1.0;
+    }
+    y_axis_->setRange(y_min - margin, y_max + margin);
+  }
+}
+
+void ChartPreviewWidget::clearSeries() {
+  chart()->removeAllSeries();
+}
+
+}  // namespace PJ

--- a/pj_plugins/dialog_protocol/src/dialog_engine.cpp
+++ b/pj_plugins/dialog_protocol/src/dialog_engine.cpp
@@ -2,6 +2,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QEventLoop>
 #include <QFileDialog>
 #include <QGroupBox>
 #include <QSettings>
@@ -396,8 +397,19 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
   });
   tick_timer.start();
 
-  // 7. Run dialog
-  int result = dialog->exec();
+  // 7. Run dialog (modal or non-modal)
+  int result;
+  if (config_.non_modal) {
+    dialog->setWindowModality(Qt::NonModal);
+    dialog->show();
+    dialog->activateWindow();
+    QEventLoop loop;
+    QObject::connect(dialog, &QDialog::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+    result = dialog->result();
+  } else {
+    result = dialog->exec();
+  }
   tick_timer.stop();
 
   // 8. Notify plugin and clean up

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -16,7 +16,9 @@
 #include <QSplitter>
 #include <QTabWidget>
 #include <QTableWidget>
+#include <QVBoxLayout>
 #include <pj_plugins/host/widget_event_builder.hpp>
+#include <pj_plugins/host_qt/chart_preview_widget.hpp>
 #include <pj_plugins/host_qt/widget_binding.hpp>
 #include <set>
 
@@ -230,10 +232,35 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
     return;
   }
 
-  // Containers (QFrame, QGroupBox, QWidget) — only generic properties applied above.
+  // --- QFrame with chart_series → ChartPreviewWidget ---
+  if (auto* frame = qobject_cast<QFrame*>(w)) {
+    if (auto series_data = view.chartSeries(name)) {
+      // Find or create the ChartPreviewWidget inside this frame.
+      auto* chart = frame->findChild<PJ::ChartPreviewWidget*>();
+      if (!chart) {
+        auto* layout = frame->layout();
+        if (!layout) {
+          layout = new QVBoxLayout(frame);
+          layout->setContentsMargins(0, 0, 0, 0);
+        }
+        chart = new PJ::ChartPreviewWidget(frame);
+        layout->addWidget(chart);
+      }
+      // Convert WidgetDataView series to ChartPreviewWidget series.
+      std::vector<PJ::ChartPreviewWidget::Series> chart_series;
+      chart_series.reserve(series_data->size());
+      for (const auto& s : *series_data) {
+        chart_series.push_back({s.label, s.points});
+      }
+      chart->setSeries(chart_series);
+    }
+    return;
+  }
+
+  // Containers (QGroupBox, QWidget) — only generic properties applied above.
   // Warn about widget types that have data in the view but aren't handled.
   // Skip known container types that only use generic enabled/visible properties.
-  if (!qobject_cast<QFrame*>(w) && !qobject_cast<QGroupBox*>(w) && !qobject_cast<QSplitter*>(w)) {
+  if (!qobject_cast<QGroupBox*>(w) && !qobject_cast<QSplitter*>(w)) {
     qWarning(
         "WidgetBinding: unsupported widget type '%s' for '%s'; "
         "see dialog-plugin-guide.md for supported types",


### PR DESCRIPTION
## Summary

- Add `ChartPoint`/`ChartSeries` structs to `WidgetData` with `setChartSeries()` and `clearChart()` builder methods
- Add `chartSeries()` parser to `WidgetDataView` for host-side reading
- Add `ChartPreviewWidget` (`QChartView` subclass) wired into `widget_binding`: any `QFrame` widget receiving `chart_series` data gets a chart view created inside it automatically
- Add `Qt6::Charts` dependency to `pj_dialog_engine_qt`

Plugins can now push XY line series data to any `QFrame` widget by name, enabling embedded chart previews inside plugin dialogs.

## Test plan

- [x] Build `pj_dialog_engine_qt` and verify no warnings
- [x] Place a `QFrame` named `previewChart` in a `.ui` file and call `wd.setChartSeries("previewChart", series)` — verify chart renders inside the frame
- [x] Call `wd.clearChart("previewChart")` — verify chart clears
- [x] Verify `WidgetDataView::chartSeries()` correctly parses the JSON produced by `setChartSeries()`