### PR TITLE
feat: code editor widget and ToolboxSession with non-modal support

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -184,6 +184,14 @@ class WidgetDataView {
     return getString(name, "plain_text");
   }
 
+  // --- Code editor ---
+  [[nodiscard]] std::optional<std::string> codeContent(std::string_view name) const {
+    return getString(name, "code_content");
+  }
+  [[nodiscard]] std::optional<std::string> codeLanguage(std::string_view name) const {
+    return getString(name, "code_language");
+  }
+
   // --- QLabel ---
   [[nodiscard]] std::optional<std::string> label(std::string_view name) const {
     return getString(name, "label");

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -94,6 +94,13 @@ struct WidgetEventBuilder {
     j["item_double_clicked_index"] = index;
     return j.dump();
   }
+
+  /// Code editor: code changed
+  [[nodiscard]] static std::string codeChanged(std::string_view code) {
+    nlohmann::json j;
+    j["code_changed"] = code;
+    return j.dump();
+  }
 };
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -59,11 +59,18 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  virtual bool onCodeChanged(std::string_view /*widget_name*/, std::string_view /*code*/) {
+    return false;
+  }
+
  private:
   /// Parses event_json and dispatches to the appropriate typed virtual above.
   bool onWidgetEvent(std::string_view widget_name, std::string_view event_json) final {
     WidgetEvent event(event_json);
 
+    if (auto v = event.codeChanged()) {
+      return onCodeChanged(widget_name, *v);
+    }
     if (auto v = event.text()) {
       return onTextChanged(widget_name, *v);
     }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -137,6 +137,21 @@ class WidgetData {
     return *this;
   }
 
+  // --- Code editor (QPlainTextEdit with syntax highlighting) ---
+
+  /// Set the code content of a QPlainTextEdit used as a code editor.
+  /// Unlike setPlainText (read-only), this enables editing and wires onCodeChanged events.
+  WidgetData& setCodeContent(std::string_view name, std::string_view code) {
+    entry(name)["code_content"] = code;
+    return *this;
+  }
+
+  /// Set the language for syntax highlighting (e.g. "lua", "python").
+  WidgetData& setCodeLanguage(std::string_view name, std::string_view lang) {
+    entry(name)["code_language"] = lang;
+    return *this;
+  }
+
   // --- QLabel ---
   WidgetData& setLabel(std::string_view name, std::string_view text) {
     entry(name)["label"] = text;

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -94,6 +94,11 @@ class WidgetEvent {
     return getInt("item_double_clicked_index");
   }
 
+  /// Code editor: code changed
+  std::optional<std::string> codeChanged() const {
+    return getString("code_changed");
+  }
+
   /// Check if a key exists in the event data
   bool has(std::string_view key) const {
     return data_.contains(std::string(key));

--- a/pj_plugins/dialog_protocol/src/lua_syntax_highlighter.hpp
+++ b/pj_plugins/dialog_protocol/src/lua_syntax_highlighter.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+
+namespace PJ {
+
+/// Minimal Lua syntax highlighter for QPlainTextEdit code editors.
+class LuaSyntaxHighlighter : public QSyntaxHighlighter {
+ public:
+  explicit LuaSyntaxHighlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {
+    // Keywords
+    QTextCharFormat keyword_fmt;
+    keyword_fmt.setForeground(QColor("#0000ff"));
+    keyword_fmt.setFontWeight(QFont::Bold);
+    const char* keywords[] = {"and",    "break", "do",       "else",   "elseif", "end",  "false",
+                              "for",    "function", "goto", "if",     "in",     "local", "nil",
+                              "not",    "or",    "repeat",   "return", "then",   "true", "until", "while"};
+    for (const char* kw : keywords) {
+      rules_.append({QRegularExpression("\\b" + QString(kw) + "\\b"), keyword_fmt});
+    }
+
+    // Numbers
+    QTextCharFormat number_fmt;
+    number_fmt.setForeground(QColor("#098658"));
+    rules_.append({QRegularExpression("\\b[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?\\b"), number_fmt});
+
+    // Strings (double and single quoted)
+    QTextCharFormat string_fmt;
+    string_fmt.setForeground(QColor("#a31515"));
+    rules_.append({QRegularExpression("\"[^\"]*\""), string_fmt});
+    rules_.append({QRegularExpression("'[^']*'"), string_fmt});
+
+    // Single-line comments
+    comment_fmt_.setForeground(QColor("#008000"));
+    comment_fmt_.setFontItalic(true);
+    rules_.append({QRegularExpression("--[^\n]*"), comment_fmt_});
+
+    // Built-in functions
+    QTextCharFormat builtin_fmt;
+    builtin_fmt.setForeground(QColor("#795e26"));
+    const char* builtins[] = {"print", "type", "tostring", "tonumber", "pairs", "ipairs",
+                              "math",  "table", "string", "assert", "error", "pcall"};
+    for (const char* bi : builtins) {
+      rules_.append({QRegularExpression("\\b" + QString(bi) + "\\b"), builtin_fmt});
+    }
+  }
+
+ protected:
+  void highlightBlock(const QString& text) override {
+    for (const auto& rule : rules_) {
+      auto it = rule.pattern.globalMatch(text);
+      while (it.hasNext()) {
+        auto match = it.next();
+        setFormat(static_cast<int>(match.capturedStart()), static_cast<int>(match.capturedLength()), rule.format);
+      }
+    }
+
+    // Multi-line comments: --[[ ... ]]
+    setCurrentBlockState(0);
+    qsizetype start_index = 0;
+    if (previousBlockState() != 1) {
+      start_index = text.indexOf("--[[");
+    }
+    while (start_index >= 0) {
+      qsizetype end_index = text.indexOf("]]", start_index + 4);
+      qsizetype length;
+      if (end_index == -1) {
+        setCurrentBlockState(1);
+        length = text.length() - start_index;
+      } else {
+        length = end_index - start_index + 2;
+      }
+      setFormat(static_cast<int>(start_index), static_cast<int>(length), comment_fmt_);
+      start_index = text.indexOf("--[[", start_index + length);
+    }
+  }
+
+ private:
+  struct Rule {
+    QRegularExpression pattern;
+    QTextCharFormat format;
+  };
+  QList<Rule> rules_;
+  QTextCharFormat comment_fmt_;
+};
+
+}  // namespace PJ

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -20,6 +20,7 @@
 #include <pj_plugins/host/widget_event_builder.hpp>
 #include <pj_plugins/host_qt/chart_preview_widget.hpp>
 #include <pj_plugins/host_qt/widget_binding.hpp>
+#include "lua_syntax_highlighter.hpp"
 #include <set>
 
 namespace PJ {
@@ -55,8 +56,23 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
 
   // --- QPlainTextEdit ---
   if (auto* pte = qobject_cast<QPlainTextEdit*>(w)) {
-    if (auto v = view.plainText(name)) {
-      pte->setPlainText(QString::fromStdString(*v));
+    if (auto code = view.codeContent(name)) {
+      // Code editor mode: only update if content actually differs (preserve cursor).
+      QString new_text = QString::fromStdString(*code);
+      if (pte->toPlainText() != new_text) {
+        pte->setPlainText(new_text);
+      }
+      // Install syntax highlighter on first use.
+      if (auto lang = view.codeLanguage(name)) {
+        if (!pte->property("_pj_code_lang").isValid()) {
+          pte->setProperty("_pj_code_lang", QString::fromStdString(*lang));
+          if (*lang == "lua") {
+            new PJ::LuaSyntaxHighlighter(pte->document());
+          }
+        }
+      }
+    } else if (auto pt = view.plainText(name)) {
+      pte->setPlainText(QString::fromStdString(*pt));
     }
     if (auto v = view.readOnly(name)) {
       pte->setReadOnly(*v);
@@ -300,6 +316,15 @@ void connectWidgetSignals(QWidget* root, WidgetEventCallback callback) {
       QObject::connect(le, &QLineEdit::textChanged, le, [callback, name](const QString& text) {
         callback(name, WidgetEventBuilder::textChanged(text.toStdString()));
       });
+      continue;
+    }
+    if (auto* pte = qobject_cast<QPlainTextEdit*>(w)) {
+      // Only wire code editors (marked by _pj_code_lang property), not read-only plain text.
+      if (pte->property("_pj_code_lang").isValid()) {
+        QObject::connect(pte, &QPlainTextEdit::textChanged, pte, [callback, name, pte]() {
+          callback(name, WidgetEventBuilder::codeChanged(pte->toPlainText().toStdString()));
+        });
+      }
       continue;
     }
     if (auto* cb = qobject_cast<QComboBox*>(w)) {

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -1,0 +1,127 @@
+#include "toolbox_session.hpp"
+
+#include <iostream>
+
+#include "pj_plugins/host_qt/dialog_engine.hpp"
+
+namespace proto {
+
+// ---------------------------------------------------------------------------
+// Runtime host vtable — captureless C callbacks via context pointer
+// ---------------------------------------------------------------------------
+
+static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
+    .protocol_version = PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION,
+    .struct_size = sizeof(PJ_toolbox_runtime_host_vtable_t),
+
+    .get_last_error =
+        [](void* ctx) -> const char* {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          return s->last_error.empty() ? nullptr : s->last_error.c_str();
+        },
+
+    .report_message =
+        [](void* ctx, PJ_toolbox_message_level_t level, PJ_string_view_t msg) {
+          (void)ctx;
+          const char* lvl = level == PJ_TOOLBOX_MESSAGE_ERROR     ? "ERROR"
+                            : level == PJ_TOOLBOX_MESSAGE_WARNING ? "WARNING"
+                                                                  : "INFO";
+          std::cerr << "[Toolbox " << lvl << "] " << std::string(msg.data, msg.size) << "\n";
+        },
+
+    .notify_data_changed =
+        [](void* ctx) {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          if (s->session) emit s->session->dataChanged();
+        },
+};
+
+// ---------------------------------------------------------------------------
+// ToolboxSession
+// ---------------------------------------------------------------------------
+
+ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                               std::string name, QObject* parent)
+    : QObject(parent),
+      engine_(engine),
+      library_(library),
+      name_(std::move(name)),
+      handle_(library_.createHandle()) {}
+
+bool ToolboxSession::init(const std::string& config_json) {
+  if (!handle_.valid()) return false;
+
+  toolbox_host_ = std::make_unique<PJ::DatastoreToolboxHost>(engine_);
+  runtime_state_.session = this;
+
+  if (!handle_.bindToolboxHost(toolbox_host_->raw())) {
+    std::cerr << "Toolbox '" << name_ << "': bindToolboxHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  auto runtime_host = makeRuntimeHost(this);
+  if (!handle_.bindRuntimeHost(runtime_host)) {
+    std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!config_json.empty() && config_json != "{}") {
+    (void)handle_.loadConfig(config_json);
+  }
+
+  return true;
+}
+
+bool ToolboxSession::hasDialog() const {
+  return handle_.valid() &&
+         (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_HAS_DIALOG) != 0;
+}
+
+bool ToolboxSession::runDialog(QWidget* parent) {
+  if (!hasDialog()) return false;
+  if (dialog_running_) return false;  // prevent re-entrant opens on non-modal dialogs
+
+  auto vt_result = library_.resolveDialogVtable();
+  if (!vt_result) return false;
+
+  auto* dialog_ctx = handle_.dialogContext();
+  if (dialog_ctx == nullptr) return false;
+
+  auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
+
+  PJ::DialogEngineConfig config;
+  config.non_modal = isNonModal();
+
+  PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
+
+  dialog_running_ = true;
+  auto result = dialog_engine.showDialog(parent);
+  dialog_running_ = false;
+
+  if (result == PJ::DialogResult::kRejected) return false;
+
+  (void)handle_.loadConfig(dialog_engine.savedConfig());
+  flushPending();
+  return true;
+}
+
+std::string ToolboxSession::saveConfig() const {
+  return handle_.valid() ? handle_.saveConfig() : "{}";
+}
+
+void ToolboxSession::flushPending() {
+  if (toolbox_host_) toolbox_host_->flushPending();
+}
+
+bool ToolboxSession::isNonModal() const {
+  return handle_.valid() && (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG) != 0;
+}
+
+PJ_toolbox_runtime_host_t ToolboxSession::makeRuntimeHost(ToolboxSession* self) {
+  return PJ_toolbox_runtime_host_t{
+      .ctx = &self->runtime_state_,
+      .vtable = &kRuntimeVtable,
+  };
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+#include <string>
+
+#include "pj_base/toolbox_protocol.h"
+#include "pj_datastore/engine.hpp"
+#include "pj_datastore/plugin_data_host.hpp"
+#include "pj_plugins/host/toolbox_handle.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
+#include "plugin_registry.hpp"
+
+namespace proto {
+
+class ToolboxSession : public QObject {
+  Q_OBJECT
+
+ public:
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+                 QObject* parent = nullptr);
+
+  /// Bind hosts and load persisted config. Returns false on error.
+  bool init(const std::string& config_json = "{}");
+
+  /// Open the plugin's dialog (modal or non-modal per capability). Returns true if accepted.
+  bool runDialog(QWidget* parent);
+
+  /// Flush any pending writes to the DataEngine.
+  void flushPending();
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] bool hasDialog() const;
+  [[nodiscard]] std::string saveConfig() const;
+
+ signals:
+  void dataChanged();
+
+ public:
+  // Public so the file-scope static vtable lambdas can cast to it.
+  struct RuntimeState {
+    std::string last_error;
+    ToolboxSession* session = nullptr;
+  };
+
+ private:
+  static PJ_toolbox_runtime_host_t makeRuntimeHost(ToolboxSession* self);
+
+  bool isNonModal() const;
+
+  PJ::DataEngine& engine_;
+  PJ::ToolboxLibrary& library_;
+  std::string name_;
+  PJ::ToolboxHandle handle_;
+  std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;
+
+  // Runtime host state — must outlive handle_
+  RuntimeState runtime_state_;
+  bool dialog_running_ = false;
+};
+
+}  // namespace proto


### PR DESCRIPTION
## Summary

- **Code editor widget**: extends the Dialog SDK so plugins can embed an editable code area in their dialogs. A `QPlainTextEdit` can now be configured as a code editor via `setCodeContent()` / `setCodeLanguage()`, with Lua syntax highlighting included out-of-the-box. Events fire via `onCodeChanged()` virtual on `DialogPluginTyped`.
- **ToolboxSession**: encapsulates the lifecycle of a toolbox plugin instance inside `pj_proto_app` — binding hosts, loading config, and running the dialog. Respects the `kToolboxCapabilityNonModalDialog` flag so toolboxes that declared non-modal get a non-blocking dialog automatically.

## Test plan
- [ ] Build `pj_proto_app` — no compile errors
- [ ] Load the Quaternion toolbox plugin: dialog opens non-modally (main window stays interactive)
- [ ] Drag-and-drop from the series tree into the Quaternion dialog works while dialog is open
- [ ] A toolbox dialog without `kToolboxCapabilityNonModalDialog` still opens modally (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)