### PR TITLE
feat: add ToolboxSession with non-modal dialog support

### DIFF
--- a/pj_plugins/CMakeLists.txt
+++ b/pj_plugins/CMakeLists.txt
@@ -102,6 +102,7 @@ target_compile_options(pj_toolbox_host PRIVATE ${PJ_WARNING_FLAGS})
 target_link_libraries(pj_toolbox_host
   PUBLIC
     pj_base
+    pj_dialog_protocol
   PRIVATE
     ${CMAKE_DL_LIBS}
 )

--- a/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <pj_base/toolbox_protocol.h>
+#include <pj_plugins/dialog_protocol.h>
 
 #include <pj_plugins/host/toolbox_handle.hpp>
 #include <string>
@@ -59,6 +60,9 @@ class ToolboxLibrary {
   [[nodiscard]] ToolboxHandle createHandle() const {
     return ToolboxHandle(vtable_);
   }
+
+  /// Resolve the dialog vtable from this .so. Returns error if not exported.
+  [[nodiscard]] Expected<const PJ_dialog_vtable_t*> resolveDialogVtable() const;
 
   /// Filesystem path the library was loaded from.
   [[nodiscard]] std::string path() const {

--- a/pj_plugins/src/data_source_library.cpp
+++ b/pj_plugins/src/data_source_library.cpp
@@ -5,27 +5,6 @@
 #include "detail/library_loader.hpp"
 
 namespace PJ {
-namespace {
-
-Expected<PJ_get_data_source_vtable_fn> loadEntryPoint(void* handle) {
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle), "PJ_get_data_source_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_data_source_vtable not found"));
-  }
-  return reinterpret_cast<PJ_get_data_source_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle, "PJ_get_data_source_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  return reinterpret_cast<PJ_get_data_source_vtable_fn>(symbol);
-#endif
-}
-
-}  // namespace
 
 DataSourceLibrary::DataSourceLibrary(void* handle, const PJ_data_source_vtable_t* vtable, std::string path)
     : handle_(handle), vtable_(vtable), path_(std::move(path)) {}
@@ -58,13 +37,14 @@ Expected<DataSourceLibrary> DataSourceLibrary::load(std::string_view path) {
     return unexpected(handle.error());
   }
 
-  auto entry = loadEntryPoint(*handle);
-  if (!entry) {
+  auto sym = detail::resolveSymbol(*handle, "PJ_get_data_source_vtable");
+  if (!sym) {
     detail::closeLibraryHandle(*handle);
-    return unexpected(entry.error());
+    return unexpected(sym.error());
   }
+  auto entry = reinterpret_cast<PJ_get_data_source_vtable_fn>(*sym);
 
-  const PJ_data_source_vtable_t* vtable = (*entry)();
+  const PJ_data_source_vtable_t* vtable = entry();
   if (vtable == nullptr) {
     detail::closeLibraryHandle(*handle);
     return unexpected(std::string("PJ_get_data_source_vtable returned null"));
@@ -82,26 +62,11 @@ Expected<DataSourceLibrary> DataSourceLibrary::load(std::string_view path) {
 }
 
 Expected<const PJ_dialog_vtable_t*> DataSourceLibrary::resolveDialogVtable() const {
-  if (handle_ == nullptr) {
-    return unexpected(std::string("library not loaded"));
+  auto sym = detail::resolveSymbol(handle_, "PJ_get_dialog_vtable");
+  if (!sym) {
+    return unexpected(sym.error());
   }
-
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle_), "PJ_get_dialog_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_dialog_vtable not found"));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle_, "PJ_get_dialog_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#endif
-
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(*sym);
   const PJ_dialog_vtable_t* vt = fn();
   if (vt == nullptr) {
     return unexpected(std::string("PJ_get_dialog_vtable returned null"));

--- a/pj_plugins/src/detail/library_loader.hpp
+++ b/pj_plugins/src/detail/library_loader.hpp
@@ -37,6 +37,28 @@ inline Expected<void*> loadLibraryHandle(std::string_view path) {
 #endif
 }
 
+/// Resolve a named symbol from a loaded library handle.
+inline Expected<void*> resolveSymbol(void* handle, const char* symbol_name) {
+  if (handle == nullptr) {
+    return unexpected(std::string("library not loaded"));
+  }
+#if defined(_WIN32)
+  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle), symbol_name);
+  if (symbol == nullptr) {
+    return unexpected(std::string(symbol_name) + " not found");
+  }
+  return reinterpret_cast<void*>(symbol);
+#else
+  dlerror();
+  void* symbol = dlsym(handle, symbol_name);
+  const char* err = dlerror();
+  if (err != nullptr) {
+    return unexpected(std::string(err));
+  }
+  return symbol;
+#endif
+}
+
 inline void closeLibraryHandle(void* handle) {
   if (handle == nullptr) {
     return;

--- a/pj_plugins/src/message_parser_library.cpp
+++ b/pj_plugins/src/message_parser_library.cpp
@@ -5,27 +5,6 @@
 #include "detail/library_loader.hpp"
 
 namespace PJ {
-namespace {
-
-Expected<PJ_get_message_parser_vtable_fn> loadEntryPoint(void* handle) {
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle), "PJ_get_message_parser_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_message_parser_vtable not found"));
-  }
-  return reinterpret_cast<PJ_get_message_parser_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle, "PJ_get_message_parser_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  return reinterpret_cast<PJ_get_message_parser_vtable_fn>(symbol);
-#endif
-}
-
-}  // namespace
 
 MessageParserLibrary::MessageParserLibrary(void* handle, const PJ_message_parser_vtable_t* vtable, std::string path)
     : handle_(handle), vtable_(vtable), path_(std::move(path)) {}
@@ -58,13 +37,14 @@ Expected<MessageParserLibrary> MessageParserLibrary::load(std::string_view path)
     return unexpected(handle.error());
   }
 
-  auto entry = loadEntryPoint(*handle);
-  if (!entry) {
+  auto sym = detail::resolveSymbol(*handle, "PJ_get_message_parser_vtable");
+  if (!sym) {
     detail::closeLibraryHandle(*handle);
-    return unexpected(entry.error());
+    return unexpected(sym.error());
   }
+  auto entry = reinterpret_cast<PJ_get_message_parser_vtable_fn>(*sym);
 
-  const PJ_message_parser_vtable_t* vtable = (*entry)();
+  const PJ_message_parser_vtable_t* vtable = entry();
   if (vtable == nullptr) {
     detail::closeLibraryHandle(*handle);
     return unexpected(std::string("PJ_get_message_parser_vtable returned null"));
@@ -82,26 +62,11 @@ Expected<MessageParserLibrary> MessageParserLibrary::load(std::string_view path)
 }
 
 Expected<const PJ_dialog_vtable_t*> MessageParserLibrary::resolveDialogVtable() const {
-  if (handle_ == nullptr) {
-    return unexpected(std::string("library not loaded"));
+  auto sym = detail::resolveSymbol(handle_, "PJ_get_dialog_vtable");
+  if (!sym) {
+    return unexpected(sym.error());
   }
-
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle_), "PJ_get_dialog_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_dialog_vtable not found"));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle_, "PJ_get_dialog_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#endif
-
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(*sym);
   const PJ_dialog_vtable_t* vt = fn();
   if (vt == nullptr) {
     return unexpected(std::string("PJ_get_dialog_vtable returned null"));

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -2,36 +2,9 @@
 
 #include <utility>
 
-#if defined(_WIN32)
-#include <windows.h>
-#else
-#include <dlfcn.h>
-#endif
-
 #include "detail/library_loader.hpp"
 
 namespace PJ {
-namespace {
-
-Expected<PJ_get_toolbox_vtable_fn> loadEntryPoint(void* handle) {
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle), "PJ_get_toolbox_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_toolbox_vtable not found"));
-  }
-  return reinterpret_cast<PJ_get_toolbox_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle, "PJ_get_toolbox_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  return reinterpret_cast<PJ_get_toolbox_vtable_fn>(symbol);
-#endif
-}
-
-}  // namespace
 
 ToolboxLibrary::ToolboxLibrary(void* handle, const PJ_toolbox_vtable_t* vtable, std::string path)
     : handle_(handle), vtable_(vtable), path_(std::move(path)) {}
@@ -64,13 +37,14 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
     return unexpected(handle.error());
   }
 
-  auto entry = loadEntryPoint(*handle);
-  if (!entry) {
+  auto sym = detail::resolveSymbol(*handle, "PJ_get_toolbox_vtable");
+  if (!sym) {
     detail::closeLibraryHandle(*handle);
-    return unexpected(entry.error());
+    return unexpected(sym.error());
   }
+  auto entry = reinterpret_cast<PJ_get_toolbox_vtable_fn>(*sym);
 
-  const PJ_toolbox_vtable_t* vtable = (*entry)();
+  const PJ_toolbox_vtable_t* vtable = entry();
   if (vtable == nullptr) {
     detail::closeLibraryHandle(*handle);
     return unexpected(std::string("PJ_get_toolbox_vtable returned null"));
@@ -88,24 +62,11 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
 }
 
 Expected<const PJ_dialog_vtable_t*> ToolboxLibrary::resolveDialogVtable() const {
-  if (handle_ == nullptr) {
-    return unexpected(std::string("library not loaded"));
+  auto sym = detail::resolveSymbol(handle_, "PJ_get_dialog_vtable");
+  if (!sym) {
+    return unexpected(sym.error());
   }
-#if defined(_WIN32)
-  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle_), "PJ_get_dialog_vtable");
-  if (symbol == nullptr) {
-    return unexpected(std::string("PJ_get_dialog_vtable not found"));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#else
-  dlerror();
-  void* symbol = dlsym(handle_, "PJ_get_dialog_vtable");
-  const char* err = dlerror();
-  if (err != nullptr) {
-    return unexpected(std::string(err));
-  }
-  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
-#endif
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(*sym);
   const PJ_dialog_vtable_t* vt = fn();
   if (vt == nullptr) {
     return unexpected(std::string("PJ_get_dialog_vtable returned null"));

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -2,6 +2,12 @@
 
 #include <utility>
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 #include "detail/library_loader.hpp"
 
 namespace PJ {
@@ -79,6 +85,38 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
   }
 
   return ToolboxLibrary(*handle, vtable, std::string(path));
+}
+
+Expected<const PJ_dialog_vtable_t*> ToolboxLibrary::resolveDialogVtable() const {
+  if (handle_ == nullptr) {
+    return unexpected(std::string("library not loaded"));
+  }
+#if defined(_WIN32)
+  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle_), "PJ_get_dialog_vtable");
+  if (symbol == nullptr) {
+    return unexpected(std::string("PJ_get_dialog_vtable not found"));
+  }
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
+#else
+  dlerror();
+  void* symbol = dlsym(handle_, "PJ_get_dialog_vtable");
+  const char* err = dlerror();
+  if (err != nullptr) {
+    return unexpected(std::string(err));
+  }
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
+#endif
+  const PJ_dialog_vtable_t* vt = fn();
+  if (vt == nullptr) {
+    return unexpected(std::string("PJ_get_dialog_vtable returned null"));
+  }
+  if (vt->protocol_version != PJ_DIALOG_PROTOCOL_VERSION) {
+    return unexpected(std::string("Dialog protocol version mismatch"));
+  }
+  if (vt->struct_size < sizeof(PJ_dialog_vtable_t)) {
+    return unexpected(std::string("Dialog vtable is smaller than expected"));
+  }
+  return vt;
 }
 
 void ToolboxLibrary::reset() {

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -1,0 +1,127 @@
+#include "toolbox_session.hpp"
+
+#include <iostream>
+
+#include "pj_plugins/host_qt/dialog_engine.hpp"
+
+namespace proto {
+
+// ---------------------------------------------------------------------------
+// Runtime host vtable — captureless C callbacks via context pointer
+// ---------------------------------------------------------------------------
+
+static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
+    .protocol_version = PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION,
+    .struct_size = sizeof(PJ_toolbox_runtime_host_vtable_t),
+
+    .get_last_error =
+        [](void* ctx) -> const char* {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          return s->last_error.empty() ? nullptr : s->last_error.c_str();
+        },
+
+    .report_message =
+        [](void* ctx, PJ_toolbox_message_level_t level, PJ_string_view_t msg) {
+          (void)ctx;
+          const char* lvl = level == PJ_TOOLBOX_MESSAGE_ERROR     ? "ERROR"
+                            : level == PJ_TOOLBOX_MESSAGE_WARNING ? "WARNING"
+                                                                  : "INFO";
+          std::cerr << "[Toolbox " << lvl << "] " << std::string(msg.data, msg.size) << "\n";
+        },
+
+    .notify_data_changed =
+        [](void* ctx) {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          if (s->session) emit s->session->dataChanged();
+        },
+};
+
+// ---------------------------------------------------------------------------
+// ToolboxSession
+// ---------------------------------------------------------------------------
+
+ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                               std::string name, QObject* parent)
+    : QObject(parent),
+      engine_(engine),
+      library_(library),
+      name_(std::move(name)),
+      handle_(library_.createHandle()) {}
+
+bool ToolboxSession::init(const std::string& config_json) {
+  if (!handle_.valid()) return false;
+
+  toolbox_host_ = std::make_unique<PJ::DatastoreToolboxHost>(engine_);
+  runtime_state_.session = this;
+
+  if (!handle_.bindToolboxHost(toolbox_host_->raw())) {
+    std::cerr << "Toolbox '" << name_ << "': bindToolboxHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  auto runtime_host = makeRuntimeHost(this);
+  if (!handle_.bindRuntimeHost(runtime_host)) {
+    std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!config_json.empty() && config_json != "{}") {
+    (void)handle_.loadConfig(config_json);
+  }
+
+  return true;
+}
+
+bool ToolboxSession::hasDialog() const {
+  return handle_.valid() &&
+         (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_HAS_DIALOG) != 0;
+}
+
+bool ToolboxSession::runDialog(QWidget* parent) {
+  if (!hasDialog()) return false;
+  if (dialog_running_) return false;  // prevent re-entrant opens on non-modal dialogs
+
+  auto vt_result = library_.resolveDialogVtable();
+  if (!vt_result) return false;
+
+  auto* dialog_ctx = handle_.dialogContext();
+  if (dialog_ctx == nullptr) return false;
+
+  auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
+
+  PJ::DialogEngineConfig config;
+  config.non_modal = isNonModal();
+
+  PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
+
+  dialog_running_ = true;
+  auto result = dialog_engine.showDialog(parent);
+  dialog_running_ = false;
+
+  if (result == PJ::DialogResult::kRejected) return false;
+
+  (void)handle_.loadConfig(dialog_engine.savedConfig());
+  flushPending();
+  return true;
+}
+
+std::string ToolboxSession::saveConfig() const {
+  return handle_.valid() ? handle_.saveConfig() : "{}";
+}
+
+void ToolboxSession::flushPending() {
+  if (toolbox_host_) toolbox_host_->flushPending();
+}
+
+bool ToolboxSession::isNonModal() const {
+  return handle_.valid() && (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG) != 0;
+}
+
+PJ_toolbox_runtime_host_t ToolboxSession::makeRuntimeHost(ToolboxSession* self) {
+  return PJ_toolbox_runtime_host_t{
+      .ctx = &self->runtime_state_,
+      .vtable = &kRuntimeVtable,
+  };
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+#include <string>
+
+#include "pj_base/toolbox_protocol.h"
+#include "pj_datastore/engine.hpp"
+#include "pj_datastore/plugin_data_host.hpp"
+#include "pj_plugins/host/toolbox_handle.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
+#include "plugin_registry.hpp"
+
+namespace proto {
+
+class ToolboxSession : public QObject {
+  Q_OBJECT
+
+ public:
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+                 QObject* parent = nullptr);
+
+  /// Bind hosts and load persisted config. Returns false on error.
+  bool init(const std::string& config_json = "{}");
+
+  /// Open the plugin's dialog (modal or non-modal per capability). Returns true if accepted.
+  bool runDialog(QWidget* parent);
+
+  /// Flush any pending writes to the DataEngine.
+  void flushPending();
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] bool hasDialog() const;
+  [[nodiscard]] std::string saveConfig() const;
+
+ signals:
+  void dataChanged();
+
+ public:
+  // Public so the file-scope static vtable lambdas can cast to it.
+  struct RuntimeState {
+    std::string last_error;
+    ToolboxSession* session = nullptr;
+  };
+
+ private:
+  static PJ_toolbox_runtime_host_t makeRuntimeHost(ToolboxSession* self);
+
+  bool isNonModal() const;
+
+  PJ::DataEngine& engine_;
+  PJ::ToolboxLibrary& library_;
+  std::string name_;
+  PJ::ToolboxHandle handle_;
+  std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;
+
+  // Runtime host state — must outlive handle_
+  RuntimeState runtime_state_;
+  bool dialog_running_ = false;
+};
+
+}  // namespace proto


### PR DESCRIPTION
## Summary

- Introduces `ToolboxSession` — a `QObject` that encapsulates the full lifecycle of a toolbox plugin instance inside `pj_proto_app`
- Binds the toolbox host, runtime host, and config; exposes `runDialog()` for the app layer
- `runDialog()` reads `kToolboxCapabilityNonModalDialog` from the plugin capability flags and passes `DialogEngineConfig::non_modal = true` automatically — no per-plugin branching in app code
- `dataChanged()` signal emitted when the plugin calls `notify_data_changed`, enabling reactive UI updates

## Test plan
- [x] Build `pj_proto_app` — no compile errors
- [x] Load the Quaternion toolbox: dialog opens non-modally (main window stays interactive, drag-and-drop from series tree works)
- [x] A toolbox without `kToolboxCapabilityNonModalDialog` still opens a modal dialog (unchanged behaviour)
- [x] Config round-trip: save config → reload → dialog state restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)