### PR TITLE
feat(proto-app): add toolbox plugin infrastructure and SDK extensions

### DIFF
--- a/pj_plugins/CMakeLists.txt
+++ b/pj_plugins/CMakeLists.txt
@@ -102,6 +102,7 @@ target_compile_options(pj_toolbox_host PRIVATE ${PJ_WARNING_FLAGS})
 target_link_libraries(pj_toolbox_host
   PUBLIC
     pj_base
+    pj_dialog_protocol
   PRIVATE
     ${CMAKE_DL_LIBS}
 )

--- a/pj_plugins/dialog_protocol/CMakeLists.txt
+++ b/pj_plugins/dialog_protocol/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 # --- Qt Dialog Engine (optional — requires Qt6) ---
 
 if(PJ_BUILD_DIALOG_ENGINE_QT)
-  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools Charts)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools Charts SvgWidgets)
   qt_standard_project_setup()
 
   # Workaround: Qt 6.5 links AGL framework which was removed in macOS 15+ SDK.
@@ -163,7 +163,7 @@ if(PJ_BUILD_DIALOG_ENGINE_QT)
   )
   target_compile_options(pj_dialog_engine_qt PRIVATE ${PJ_WARNING_FLAGS})
   target_link_libraries(pj_dialog_engine_qt
-    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools Qt6::Charts
+    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools Qt6::Charts Qt6::SvgWidgets
   )
   target_include_directories(pj_dialog_engine_qt PUBLIC include)
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -184,6 +184,14 @@ class WidgetDataView {
     return getString(name, "plain_text");
   }
 
+  // --- Code editor ---
+  [[nodiscard]] std::optional<std::string> codeContent(std::string_view name) const {
+    return getString(name, "code_content");
+  }
+  [[nodiscard]] std::optional<std::string> codeLanguage(std::string_view name) const {
+    return getString(name, "code_language");
+  }
+
   // --- QLabel ---
   [[nodiscard]] std::optional<std::string> label(std::string_view name) const {
     return getString(name, "label");
@@ -192,6 +200,10 @@ class WidgetDataView {
   // --- QPushButton ---
   [[nodiscard]] std::optional<std::string> buttonText(std::string_view name) const {
     return getString(name, "button_text");
+  }
+
+  [[nodiscard]] std::optional<std::string> buttonIconSvg(std::string_view name) const {
+    return getString(name, "button_icon_svg");
   }
 
   [[nodiscard]] std::optional<std::string> shortcut(std::string_view name) const {

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -94,6 +94,13 @@ struct WidgetEventBuilder {
     j["item_double_clicked_index"] = index;
     return j.dump();
   }
+
+  /// Code editor: code changed
+  [[nodiscard]] static std::string codeChanged(std::string_view code) {
+    nlohmann::json j;
+    j["code_changed"] = code;
+    return j.dump();
+  }
 };
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -59,11 +59,18 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  virtual bool onCodeChanged(std::string_view /*widget_name*/, std::string_view /*code*/) {
+    return false;
+  }
+
  private:
   /// Parses event_json and dispatches to the appropriate typed virtual above.
   bool onWidgetEvent(std::string_view widget_name, std::string_view event_json) final {
     WidgetEvent event(event_json);
 
+    if (auto v = event.codeChanged()) {
+      return onCodeChanged(widget_name, *v);
+    }
     if (auto v = event.text()) {
       return onTextChanged(widget_name, *v);
     }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -137,6 +137,21 @@ class WidgetData {
     return *this;
   }
 
+  // --- Code editor (QPlainTextEdit with syntax highlighting) ---
+
+  /// Set the code content of a QPlainTextEdit used as a code editor.
+  /// Unlike setPlainText (read-only), this enables editing and wires onCodeChanged events.
+  WidgetData& setCodeContent(std::string_view name, std::string_view code) {
+    entry(name)["code_content"] = code;
+    return *this;
+  }
+
+  /// Set the language for syntax highlighting (e.g. "lua", "python").
+  WidgetData& setCodeLanguage(std::string_view name, std::string_view lang) {
+    entry(name)["code_language"] = lang;
+    return *this;
+  }
+
   // --- QLabel ---
   WidgetData& setLabel(std::string_view name, std::string_view text) {
     entry(name)["label"] = text;
@@ -146,6 +161,13 @@ class WidgetData {
   // --- QPushButton ---
   WidgetData& setButtonText(std::string_view name, std::string_view text) {
     entry(name)["button_text"] = text;
+    return *this;
+  }
+
+  /// Set an icon on a QPushButton from inline SVG data.
+  /// The SVG string is stored as-is and rendered by the host via QSvgRenderer.
+  WidgetData& setButtonIcon(std::string_view name, std::string_view svg_data) {
+    entry(name)["button_icon_svg"] = svg_data;
     return *this;
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -94,6 +94,11 @@ class WidgetEvent {
     return getInt("item_double_clicked_index");
   }
 
+  /// Code editor: code changed
+  std::optional<std::string> codeChanged() const {
+    return getString("code_changed");
+  }
+
   /// Check if a key exists in the event data
   bool has(std::string_view key) const {
     return data_.contains(std::string(key));

--- a/pj_plugins/dialog_protocol/src/lua_syntax_highlighter.hpp
+++ b/pj_plugins/dialog_protocol/src/lua_syntax_highlighter.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+
+namespace PJ {
+
+/// Minimal Lua syntax highlighter for QPlainTextEdit code editors.
+class LuaSyntaxHighlighter : public QSyntaxHighlighter {
+ public:
+  explicit LuaSyntaxHighlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {
+    // Keywords
+    QTextCharFormat keyword_fmt;
+    keyword_fmt.setForeground(QColor("#0000ff"));
+    keyword_fmt.setFontWeight(QFont::Bold);
+    const char* keywords[] = {"and",    "break", "do",       "else",   "elseif", "end",  "false",
+                              "for",    "function", "goto", "if",     "in",     "local", "nil",
+                              "not",    "or",    "repeat",   "return", "then",   "true", "until", "while"};
+    for (const char* kw : keywords) {
+      rules_.append({QRegularExpression("\\b" + QString(kw) + "\\b"), keyword_fmt});
+    }
+
+    // Numbers
+    QTextCharFormat number_fmt;
+    number_fmt.setForeground(QColor("#098658"));
+    rules_.append({QRegularExpression("\\b[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?\\b"), number_fmt});
+
+    // Strings (double and single quoted)
+    QTextCharFormat string_fmt;
+    string_fmt.setForeground(QColor("#a31515"));
+    rules_.append({QRegularExpression("\"[^\"]*\""), string_fmt});
+    rules_.append({QRegularExpression("'[^']*'"), string_fmt});
+
+    // Single-line comments
+    comment_fmt_.setForeground(QColor("#008000"));
+    comment_fmt_.setFontItalic(true);
+    rules_.append({QRegularExpression("--[^\n]*"), comment_fmt_});
+
+    // Built-in functions
+    QTextCharFormat builtin_fmt;
+    builtin_fmt.setForeground(QColor("#795e26"));
+    const char* builtins[] = {"print", "type", "tostring", "tonumber", "pairs", "ipairs",
+                              "math",  "table", "string", "assert", "error", "pcall"};
+    for (const char* bi : builtins) {
+      rules_.append({QRegularExpression("\\b" + QString(bi) + "\\b"), builtin_fmt});
+    }
+  }
+
+ protected:
+  void highlightBlock(const QString& text) override {
+    for (const auto& rule : rules_) {
+      auto it = rule.pattern.globalMatch(text);
+      while (it.hasNext()) {
+        auto match = it.next();
+        setFormat(static_cast<int>(match.capturedStart()), static_cast<int>(match.capturedLength()), rule.format);
+      }
+    }
+
+    // Multi-line comments: --[[ ... ]]
+    setCurrentBlockState(0);
+    qsizetype start_index = 0;
+    if (previousBlockState() != 1) {
+      start_index = text.indexOf("--[[");
+    }
+    while (start_index >= 0) {
+      qsizetype end_index = text.indexOf("]]", start_index + 4);
+      qsizetype length;
+      if (end_index == -1) {
+        setCurrentBlockState(1);
+        length = text.length() - start_index;
+      } else {
+        length = end_index - start_index + 2;
+      }
+      setFormat(static_cast<int>(start_index), static_cast<int>(length), comment_fmt_);
+      start_index = text.indexOf("--[[", start_index + length);
+    }
+  }
+
+ private:
+  struct Rule {
+    QRegularExpression pattern;
+    QTextCharFormat format;
+  };
+  QList<Rule> rules_;
+  QTextCharFormat comment_fmt_;
+};
+
+}  // namespace PJ

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -13,6 +13,9 @@
 #include <QShortcut>
 #include <QSignalBlocker>
 #include <QSpinBox>
+#include <QSvgRenderer>
+#include <QPainter>
+#include <QPixmap>
 #include <QSplitter>
 #include <QTabWidget>
 #include <QTableWidget>
@@ -20,6 +23,7 @@
 #include <pj_plugins/host/widget_event_builder.hpp>
 #include <pj_plugins/host_qt/chart_preview_widget.hpp>
 #include <pj_plugins/host_qt/widget_binding.hpp>
+#include "lua_syntax_highlighter.hpp"
 #include <set>
 
 namespace PJ {
@@ -55,8 +59,23 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
 
   // --- QPlainTextEdit ---
   if (auto* pte = qobject_cast<QPlainTextEdit*>(w)) {
-    if (auto v = view.plainText(name)) {
-      pte->setPlainText(QString::fromStdString(*v));
+    if (auto code = view.codeContent(name)) {
+      // Code editor mode: only update if content actually differs (preserve cursor).
+      QString new_text = QString::fromStdString(*code);
+      if (pte->toPlainText() != new_text) {
+        pte->setPlainText(new_text);
+      }
+      // Install syntax highlighter on first use.
+      if (auto lang = view.codeLanguage(name)) {
+        if (!pte->property("_pj_code_lang").isValid()) {
+          pte->setProperty("_pj_code_lang", QString::fromStdString(*lang));
+          if (*lang == "lua") {
+            new PJ::LuaSyntaxHighlighter(pte->document());
+          }
+        }
+      }
+    } else if (auto pt = view.plainText(name)) {
+      pte->setPlainText(QString::fromStdString(*pt));
     }
     if (auto v = view.readOnly(name)) {
       pte->setReadOnly(*v);
@@ -211,6 +230,18 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
     if (auto v = view.buttonText(name)) {
       btn->setText(QString::fromStdString(*v));
     }
+    if (auto svg = view.buttonIconSvg(name)) {
+      QByteArray svg_data = QByteArray::fromStdString(*svg);
+      QSvgRenderer renderer(svg_data);
+      if (renderer.isValid()) {
+        int sz = btn->iconSize().height() > 0 ? btn->iconSize().height() : 16;
+        QPixmap pix(sz, sz);
+        pix.fill(Qt::transparent);
+        QPainter painter(&pix);
+        renderer.render(&painter);
+        btn->setIcon(QIcon(pix));
+      }
+    }
     return;
   }
 
@@ -300,6 +331,15 @@ void connectWidgetSignals(QWidget* root, WidgetEventCallback callback) {
       QObject::connect(le, &QLineEdit::textChanged, le, [callback, name](const QString& text) {
         callback(name, WidgetEventBuilder::textChanged(text.toStdString()));
       });
+      continue;
+    }
+    if (auto* pte = qobject_cast<QPlainTextEdit*>(w)) {
+      // Only wire code editors (marked by _pj_code_lang property), not read-only plain text.
+      if (pte->property("_pj_code_lang").isValid()) {
+        QObject::connect(pte, &QPlainTextEdit::textChanged, pte, [callback, name, pte]() {
+          callback(name, WidgetEventBuilder::codeChanged(pte->toPlainText().toStdString()));
+        });
+      }
       continue;
     }
     if (auto* cb = qobject_cast<QComboBox*>(w)) {

--- a/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <pj_base/toolbox_protocol.h>
+#include <pj_plugins/dialog_protocol.h>
 
 #include <pj_plugins/host/toolbox_handle.hpp>
 #include <string>
@@ -59,6 +60,9 @@ class ToolboxLibrary {
   [[nodiscard]] ToolboxHandle createHandle() const {
     return ToolboxHandle(vtable_);
   }
+
+  /// Resolve the dialog vtable from this .so. Returns error if not exported.
+  [[nodiscard]] Expected<const PJ_dialog_vtable_t*> resolveDialogVtable() const;
 
   /// Filesystem path the library was loaded from.
   [[nodiscard]] std::string path() const {

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -2,6 +2,12 @@
 
 #include <utility>
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 #include "detail/library_loader.hpp"
 
 namespace PJ {
@@ -79,6 +85,32 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
   }
 
   return ToolboxLibrary(*handle, vtable, std::string(path));
+}
+
+Expected<const PJ_dialog_vtable_t*> ToolboxLibrary::resolveDialogVtable() const {
+  if (handle_ == nullptr) {
+    return unexpected(std::string("library not loaded"));
+  }
+#if defined(_WIN32)
+  auto symbol = GetProcAddress(reinterpret_cast<HMODULE>(handle_), "PJ_get_dialog_vtable");
+  if (symbol == nullptr) {
+    return unexpected(std::string("PJ_get_dialog_vtable not found"));
+  }
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
+#else
+  dlerror();
+  void* symbol = dlsym(handle_, "PJ_get_dialog_vtable");
+  const char* err = dlerror();
+  if (err != nullptr) {
+    return unexpected(std::string(err));
+  }
+  auto fn = reinterpret_cast<PJ_get_dialog_vtable_fn>(symbol);
+#endif
+  const PJ_dialog_vtable_t* vtable = fn();
+  if (vtable == nullptr) {
+    return unexpected(std::string("PJ_get_dialog_vtable returned null"));
+  }
+  return vtable;
 }
 
 void ToolboxLibrary::reset() {

--- a/pj_proto_app/CMakeLists.txt
+++ b/pj_proto_app/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(pj_proto_app
   src/series_tree_model.cpp
   src/chart_panel.cpp
   src/time_range_slider.cpp
+  src/preferences_dialog.cpp
+  src/toolbox_session.cpp
 )
 
 target_compile_features(pj_proto_app PRIVATE cxx_std_20)

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -1,6 +1,11 @@
 #include "main_window.hpp"
+#include "preferences_dialog.hpp"
 
 #include <QAction>
+#include <QApplication>
+#include <QDesktopServices>
+#include <QDockWidget>
+#include <QHeaderView>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
@@ -114,7 +119,8 @@ ShowMessageBoxCallback makeMessageBoxCallback(QWidget* parent) {
 }  // namespace
 
 MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
-    : QMainWindow(parent), registry_(plugin_dir), tree_model_(engine_) {
+    : QMainWindow(parent), plugin_dir_str_(QString::fromStdString(plugin_dir)),
+      registry_(plugin_dir), tree_model_(engine_) {
   auto td_result = engine_.createTimeDomain("default");
   if (td_result) {
     default_td_id_ = *td_result;
@@ -186,6 +192,8 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
     chart_panel_->updateData(begin, end);
   });
   connect(&refresh_timer_, &QTimer::timeout, this, &MainWindow::onRefreshTimer);
+
+  setupMenuBar();
 
   setWindowTitle("PlotJuggler Proto");
 }
@@ -689,6 +697,170 @@ void MainWindow::onOpenMarketplace() {
   window.exec();
   if (window.installationsChanged()) {
     registry_.reload();
+  }
+}
+
+void MainWindow::onShowPreferences() {
+  PreferencesDialog dlg(plugin_dir_str_, this);
+  dlg.exec();
+}
+
+void MainWindow::setupMenuBar() {
+  // --- App ---
+  auto* app_menu = menuBar()->addMenu("&App");
+
+  auto* act_clear_points = app_menu->addAction("Clear Data &Points", this, &MainWindow::onClearData);
+  act_clear_points->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_C);
+
+  auto* act_delete_all = app_menu->addAction("&Delete Everything", this, [this]() {
+    onClearData();
+    onClearPlots();
+  });
+  act_delete_all->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_X);
+
+  app_menu->addSeparator();
+
+  auto* act_prefs = app_menu->addAction("&Preferences...", this, &MainWindow::onShowPreferences);
+  act_prefs->setShortcut(Qt::CTRL | Qt::Key_Comma);
+
+  app_menu->addSeparator();
+
+  auto* act_exit = app_menu->addAction("E&xit", this, &QMainWindow::close);
+  act_exit->setShortcut(QKeySequence::Quit);
+
+  // --- Tools ---
+  auto* tools_menu = menuBar()->addMenu("&Tools");
+
+  auto* act_stylesheet = tools_menu->addAction("Load &Stylesheet...", this, [this]() {
+    QSettings settings;
+    auto last_dir = settings.value("ProtoApp/lastStylesheetDir", "").toString();
+    auto path = QFileDialog::getOpenFileName(this, "Load Stylesheet", last_dir, "Stylesheets (*.qss);;All files (*)");
+    if (path.isEmpty()) return;
+    settings.setValue("ProtoApp/lastStylesheetDir", QFileInfo(path).absolutePath());
+    QFile file(path);
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+      qApp->setStyleSheet(QString::fromUtf8(file.readAll()));
+    }
+  });
+  (void)act_stylesheet;
+
+  tools_menu->addSeparator();
+
+  // Toolbox plugins discovered dynamically (e.g. ColorMap Editor)
+  setupToolboxPanels(tools_menu);
+
+  tools_menu->addSeparator();
+
+  auto* act_fft = tools_menu->addAction("&Fast Fourier Transform");
+  act_fft->setEnabled(false);
+
+  auto* act_quat = tools_menu->addAction("&Quaternion to RPY");
+  act_quat->setEnabled(false);
+
+  auto* act_lua = tools_menu->addAction("&Reactive Script Editor");
+  act_lua->setEnabled(false);
+
+  // --- Help ---
+  auto* help_menu = menuBar()->addMenu("&Help");
+
+  auto* act_cheatsheet = help_menu->addAction("&Cheatsheet", this, [this]() {
+    auto* dlg = new QDialog(this);
+    dlg->setWindowTitle("Cheatsheet");
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->resize(480, 400);
+
+    struct Row {
+      QString shortcut;
+      QString action;
+    };
+    const std::vector<Row> rows = {
+        {"Ctrl+O", "Load File"},
+        {"Ctrl+R", "Start Stream"},
+        {"Ctrl+Shift+C", "Clear Data Points"},
+        {"Ctrl+Shift+X", "Delete Everything"},
+        {"Ctrl+,", "Preferences"},
+        {"Ctrl+Z", "Undo"},
+        {"Ctrl+Shift+Z", "Redo"},
+        {"F1", "Cheatsheet"},
+    };
+
+    auto* table = new QTableWidget(static_cast<int>(rows.size()), 2, dlg);
+    table->setHorizontalHeaderLabels({"Shortcut", "Action"});
+    table->horizontalHeader()->setStretchLastSection(true);
+    table->verticalHeader()->setVisible(false);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->setSelectionMode(QAbstractItemView::NoSelection);
+    table->setAlternatingRowColors(true);
+
+    for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
+      table->setItem(i, 0, new QTableWidgetItem(rows[i].shortcut));
+      table->setItem(i, 1, new QTableWidgetItem(rows[i].action));
+    }
+    table->resizeColumnToContents(0);
+
+    auto* layout = new QVBoxLayout(dlg);
+    layout->addWidget(table);
+    dlg->exec();
+  });
+  act_cheatsheet->setShortcut(Qt::Key_F1);
+
+  help_menu->addSeparator();
+
+  auto* act_support = help_menu->addAction("&Support PlotJuggler", this, []() {
+    QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler"));
+  });
+  (void)act_support;
+
+  auto* act_love = help_menu->addAction(
+      QApplication::style()->standardIcon(QStyle::SP_DialogApplyButton), "Share the &Love", this, []() {
+        QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler/stargazers"));
+      });
+  (void)act_love;
+
+  auto* act_report = help_menu->addAction(
+      QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning), "&Report a Problem", this, []() {
+        QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler/issues"));
+      });
+  (void)act_report;
+
+  help_menu->addSeparator();
+
+  help_menu->addAction("&About...", this, [this]() {
+    QMessageBox::about(this, "About PlotJuggler Proto",
+                       "<b>PlotJuggler Proto</b><br>"
+                       "Prototype application for testing PlotJuggler plugins.<br><br>"
+                       "Part of the <i>plotjuggler-core</i> project.");
+  });
+}
+
+void MainWindow::setupToolboxPanels(QMenu* tools_menu) {
+  for (const auto& tb : registry_.allToolboxes()) {
+    auto session =
+        std::make_unique<ToolboxSession>(engine_, const_cast<PJ::ToolboxLibrary&>(tb.library), tb.name, this);
+    if (!session->init()) {
+      continue;
+    }
+
+    connect(session.get(), &ToolboxSession::dataChanged, this, [this]() {
+      auto [begin, end] = computeVisibleRange();
+      chart_panel_->updateData(begin, end);
+      tree_model_.rebuildIfChanged();
+    });
+
+    ToolboxSession* raw_session = session.get();
+
+    // Add menu action that opens the dialog directly (like PJ 3.x)
+    tools_menu->addAction(QString::fromStdString(tb.name), this, [this, raw_session]() {
+      if (raw_session->hasDialog()) {
+        if (raw_session->runDialog(this)) {
+          auto [begin, end] = computeVisibleRange();
+          chart_panel_->updateData(begin, end);
+          tree_model_.rebuildIfChanged();
+        }
+      }
+    });
+
+    toolbox_sessions_.push_back(std::move(session));
   }
 }
 

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <QDockWidget>
 #include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
+#include <QString>
 #include <QSpinBox>
 #include <QSplitter>
+#include <QTableWidget>
 #include <QTimer>
 #include <QTreeView>
 #include <memory>
@@ -13,6 +18,7 @@
 #include "pj_datastore/engine.hpp"
 #include "plugin_registry.hpp"
 #include "series_tree_model.hpp"
+#include "toolbox_session.hpp"
 
 #include "pj_marketplace/extension_manager.hpp"
 
@@ -37,12 +43,16 @@ class MainWindow : public QMainWindow {
   void onLoadFile();
   void onStartStream();
   void onOpenMarketplace();
+  void onShowPreferences();
   void onClearData();
   void onClearPlots();
   void onRefreshTimer();
   void onTreeContextMenu(const QPoint& pos);
 
  private:
+  void setupMenuBar();
+  void setupToolboxPanels(QMenu* tools_menu);
+
   /// Compute the current visible time range based on data and streaming state.
   std::pair<PJ::Timestamp, PJ::Timestamp> computeVisibleRange() const;
 
@@ -51,6 +61,8 @@ class MainWindow : public QMainWindow {
 
   void removeSession(DataSourceSession* session);
   void restartSession(DataSourceSession* session);
+
+  QString plugin_dir_str_;
 
   PJ::DataEngine engine_;
   PJ::TimeDomainId default_td_id_ = 0;
@@ -66,6 +78,9 @@ class MainWindow : public QMainWindow {
   QTimer refresh_timer_;
   int refresh_tick_ = 0;
   bool streaming_active_ = false;
+
+  std::vector<std::unique_ptr<ToolboxSession>> toolbox_sessions_;
+  std::vector<QDockWidget*> toolbox_docks_;
 };
 
 }  // namespace proto

--- a/pj_proto_app/src/plugin_registry.cpp
+++ b/pj_proto_app/src/plugin_registry.cpp
@@ -207,6 +207,8 @@ void PluginRegistry::reload() {
     }
   }
 }
+
+
 std::vector<LoadedDataSource*> PluginRegistry::fileImportSources() {
   std::vector<LoadedDataSource*> result;
   for (auto& ds : data_sources_) {

--- a/pj_proto_app/src/preferences_dialog.cpp
+++ b/pj_proto_app/src/preferences_dialog.cpp
@@ -1,0 +1,246 @@
+#include "preferences_dialog.hpp"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPalette>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSettings>
+#include <QSpinBox>
+#include <QStyle>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+namespace proto {
+
+PreferencesDialog::PreferencesDialog(const QString& builtin_plugin_dir, QWidget* parent)
+    : QDialog(parent) {
+  setWindowTitle("Preferences");
+  resize(560, 520);
+
+  QSettings settings;
+
+  auto* tabs = new QTabWidget(this);
+
+  // ================================================================
+  // Tab 1: Appearance
+  // ================================================================
+  {
+    auto* page = new QWidget();
+    auto* form = new QFormLayout(page);
+    form->setContentsMargins(12, 12, 12, 12);
+    form->setVerticalSpacing(10);
+
+    auto* combo_theme = new QComboBox();
+    combo_theme->addItems({"Light Theme", "Dark Theme"});
+    combo_theme->setCurrentText(settings.value("Appearance/theme", "Light Theme").toString());
+    form->addRow("Theme:", combo_theme);
+
+    auto* chk_tree = new QCheckBox("enabled (using separator \"/\" in the name)");
+    chk_tree->setChecked(settings.value("Appearance/treeViewEnabled", true).toBool());
+    form->addRow("Tree view:", chk_tree);
+
+    auto* chk_opengl = new QCheckBox("enabled");
+    chk_opengl->setChecked(settings.value("Appearance/openGLEnabled", true).toBool());
+    form->addRow("OpenGL:", chk_opengl);
+
+    auto* combo_precision = new QComboBox();
+    for (int i = 1; i <= 9; ++i) combo_precision->addItem(QString::number(i));
+    combo_precision->setCurrentIndex(settings.value("Appearance/floatPrecision", 3).toInt() - 1);
+    combo_precision->setFixedWidth(60);
+    form->addRow("Float Precision:", combo_precision);
+
+    auto* chk_splash = new QCheckBox("enabled");
+    chk_splash->setChecked(settings.value("Appearance/skipSplash", false).toBool());
+    form->addRow("Skip Splash Screen on Startup:", chk_splash);
+
+    tabs->addTab(page, "Appearance");
+
+    connect(this, &QDialog::accepted, this, [=]() {
+      QSettings s;
+      s.setValue("Appearance/theme", combo_theme->currentText());
+      s.setValue("Appearance/treeViewEnabled", chk_tree->isChecked());
+      s.setValue("Appearance/openGLEnabled", chk_opengl->isChecked());
+      s.setValue("Appearance/floatPrecision", combo_precision->currentIndex() + 1);
+      s.setValue("Appearance/skipSplash", chk_splash->isChecked());
+
+      // Apply theme immediately
+      if (combo_theme->currentText() == "Dark Theme") {
+        QPalette dark;
+        dark.setColor(QPalette::Window, QColor(53, 53, 53));
+        dark.setColor(QPalette::WindowText, Qt::white);
+        dark.setColor(QPalette::Base, QColor(35, 35, 35));
+        dark.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+        dark.setColor(QPalette::ToolTipBase, QColor(25, 25, 25));
+        dark.setColor(QPalette::ToolTipText, Qt::white);
+        dark.setColor(QPalette::Text, Qt::white);
+        dark.setColor(QPalette::Button, QColor(53, 53, 53));
+        dark.setColor(QPalette::ButtonText, Qt::white);
+        dark.setColor(QPalette::BrightText, Qt::red);
+        dark.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        dark.setColor(QPalette::HighlightedText, Qt::black);
+        qApp->setPalette(dark);
+      } else {
+        qApp->setPalette(qApp->style()->standardPalette());
+      }
+    });
+  }
+
+  // ================================================================
+  // Tab 2: Behavior
+  // ================================================================
+  {
+    auto* page = new QWidget();
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setContentsMargins(12, 12, 12, 12);
+    vbox->setSpacing(6);
+
+    // Reset plot zoom
+    vbox->addWidget(new QLabel("Reset plot zoom when:"));
+    auto* chk_zoom_curve = new QCheckBox("  Curve added to plot");
+    auto* chk_zoom_vis = new QCheckBox("  Curve visibility toggled (in curves legend)");
+    auto* chk_zoom_filter = new QCheckBox("  Filters applied to curves");
+    chk_zoom_curve->setChecked(settings.value("Behavior/zoomOnCurveAdded", true).toBool());
+    chk_zoom_vis->setChecked(settings.value("Behavior/zoomOnVisibilityToggled", true).toBool());
+    chk_zoom_filter->setChecked(settings.value("Behavior/zoomOnFilterApplied", true).toBool());
+    vbox->addWidget(chk_zoom_curve);
+    vbox->addWidget(chk_zoom_vis);
+    vbox->addWidget(chk_zoom_filter);
+
+    // Curves color
+    vbox->addSpacing(6);
+    vbox->addWidget(new QLabel("Curves color:"));
+    auto* radio_global = new QRadioButton("  global color sequence");
+    auto* radio_reset = new QRadioButton("  reset color sequence in each plot area");
+    auto* radio_remember = new QRadioButton("  remember color");
+    int color_mode = settings.value("Behavior/curvesColorMode", 0).toInt();
+    radio_global->setChecked(color_mode == 0);
+    radio_reset->setChecked(color_mode == 1);
+    radio_remember->setChecked(color_mode == 2);
+    vbox->addWidget(radio_global);
+    vbox->addWidget(radio_reset);
+    vbox->addWidget(radio_remember);
+
+    // Export Plots
+    vbox->addSpacing(6);
+    vbox->addWidget(new QLabel("Export Plots:"));
+    auto* form_export = new QFormLayout();
+    auto* spin_w = new QSpinBox();
+    spin_w->setRange(320, 7680);
+    spin_w->setValue(settings.value("Behavior/exportWidth", 1920).toInt());
+    auto* spin_h = new QSpinBox();
+    spin_h->setRange(240, 4320);
+    spin_h->setValue(settings.value("Behavior/exportHeight", 1200).toInt());
+    form_export->addRow("  Width", spin_w);
+    form_export->addRow("  Height", spin_h);
+    vbox->addLayout(form_export);
+
+    // Mouse Interaction
+    vbox->addSpacing(6);
+    vbox->addWidget(new QLabel("Mouse Interaction:"));
+    auto* chk_swap_mouse = new QCheckBox("  Swap pan/zoom mouse action modifiers");
+    chk_swap_mouse->setChecked(settings.value("Behavior/swapMouseModifiers", false).toBool());
+    vbox->addWidget(chk_swap_mouse);
+
+    // Parsing
+    vbox->addSpacing(6);
+    vbox->addWidget(new QLabel("Parsing"));
+    auto* chk_strict = new QCheckBox("  Strict Truncation check (uncheck at your own risk)");
+    chk_strict->setChecked(settings.value("Behavior/strictTruncation", true).toBool());
+    vbox->addWidget(chk_strict);
+
+    vbox->addStretch();
+    tabs->addTab(page, "Behavior");
+
+    connect(this, &QDialog::accepted, this, [=]() {
+      QSettings s;
+      s.setValue("Behavior/zoomOnCurveAdded", chk_zoom_curve->isChecked());
+      s.setValue("Behavior/zoomOnVisibilityToggled", chk_zoom_vis->isChecked());
+      s.setValue("Behavior/zoomOnFilterApplied", chk_zoom_filter->isChecked());
+      int mode = radio_global->isChecked() ? 0 : radio_reset->isChecked() ? 1 : 2;
+      s.setValue("Behavior/curvesColorMode", mode);
+      s.setValue("Behavior/exportWidth", spin_w->value());
+      s.setValue("Behavior/exportHeight", spin_h->value());
+      s.setValue("Behavior/swapMouseModifiers", chk_swap_mouse->isChecked());
+      s.setValue("Behavior/strictTruncation", chk_strict->isChecked());
+    });
+  }
+
+  // ================================================================
+  // Tab 3: Plugins
+  // ================================================================
+  {
+    auto* page = new QWidget();
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setContentsMargins(12, 12, 12, 12);
+    vbox->setSpacing(6);
+
+    // Header row with +/trash buttons
+    auto* hdr = new QHBoxLayout();
+    hdr->addWidget(new QLabel("<b>Plugin folders</b> (will be loaded in this order):"));
+    hdr->addStretch();
+    auto* btn_add = new QPushButton("+");
+    btn_add->setFixedSize(24, 24);
+    auto* btn_remove =
+        new QPushButton(QApplication::style()->standardIcon(QStyle::SP_TrashIcon), QString{});
+    btn_remove->setFixedSize(24, 24);
+    hdr->addWidget(btn_add);
+    hdr->addWidget(btn_remove);
+    vbox->addLayout(hdr);
+
+    vbox->addWidget(new QLabel("Add custom folders. Drag and drop the items to change the order."));
+
+    auto* list_custom = new QListWidget();
+    list_custom->setDragDropMode(QAbstractItemView::InternalMove);
+    list_custom->setSelectionMode(QAbstractItemView::SingleSelection);
+    const QStringList custom_dirs = settings.value("Plugins/customFolders").toStringList();
+    list_custom->addItems(custom_dirs);
+    vbox->addWidget(list_custom);
+
+    vbox->addWidget(new QLabel("List of built-in folders:"));
+    auto* txt_builtin = new QPlainTextEdit(builtin_plugin_dir);
+    txt_builtin->setReadOnly(true);
+    txt_builtin->setMaximumHeight(100);
+    vbox->addWidget(txt_builtin);
+
+    vbox->addWidget(
+        new QLabel("<i>Note: this change will take effect the next time the app is started</i>"));
+
+    connect(btn_add, &QPushButton::clicked, this, [this, list_custom]() {
+      auto dir = QFileDialog::getExistingDirectory(this, "Select Plugin Folder");
+      if (!dir.isEmpty()) list_custom->addItem(dir);
+    });
+    connect(btn_remove, &QPushButton::clicked, this,
+            [list_custom]() { delete list_custom->currentItem(); });
+
+    tabs->addTab(page, "Plugins");
+
+    connect(this, &QDialog::accepted, this, [=]() {
+      QStringList dirs;
+      for (int i = 0; i < list_custom->count(); ++i) dirs << list_custom->item(i)->text();
+      QSettings s;
+      s.setValue("Plugins/customFolders", dirs);
+    });
+  }
+
+  // ================================================================
+  // Dialog buttons
+  // ================================================================
+  auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+  connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout(this);
+  main_layout->addWidget(tabs);
+  main_layout->addWidget(buttons);
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/preferences_dialog.hpp
+++ b/pj_proto_app/src/preferences_dialog.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+namespace proto {
+
+class PreferencesDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit PreferencesDialog(const QString& builtin_plugin_dir, QWidget* parent = nullptr);
+};
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -1,0 +1,127 @@
+#include "toolbox_session.hpp"
+
+#include <iostream>
+
+#include "pj_plugins/host_qt/dialog_engine.hpp"
+
+namespace proto {
+
+// ---------------------------------------------------------------------------
+// Runtime host vtable — captureless C callbacks via context pointer
+// ---------------------------------------------------------------------------
+
+static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
+    .protocol_version = PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION,
+    .struct_size = sizeof(PJ_toolbox_runtime_host_vtable_t),
+
+    .get_last_error =
+        [](void* ctx) -> const char* {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          return s->last_error.empty() ? nullptr : s->last_error.c_str();
+        },
+
+    .report_message =
+        [](void* ctx, PJ_toolbox_message_level_t level, PJ_string_view_t msg) {
+          (void)ctx;
+          const char* lvl = level == PJ_TOOLBOX_MESSAGE_ERROR     ? "ERROR"
+                            : level == PJ_TOOLBOX_MESSAGE_WARNING ? "WARNING"
+                                                                  : "INFO";
+          std::cerr << "[Toolbox " << lvl << "] " << std::string(msg.data, msg.size) << "\n";
+        },
+
+    .notify_data_changed =
+        [](void* ctx) {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          if (s->session) emit s->session->dataChanged();
+        },
+};
+
+// ---------------------------------------------------------------------------
+// ToolboxSession
+// ---------------------------------------------------------------------------
+
+ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                               std::string name, QObject* parent)
+    : QObject(parent),
+      engine_(engine),
+      library_(library),
+      name_(std::move(name)),
+      handle_(library_.createHandle()) {}
+
+bool ToolboxSession::init(const std::string& config_json) {
+  if (!handle_.valid()) return false;
+
+  toolbox_host_ = std::make_unique<PJ::DatastoreToolboxHost>(engine_);
+  runtime_state_.session = this;
+
+  if (!handle_.bindToolboxHost(toolbox_host_->raw())) {
+    std::cerr << "Toolbox '" << name_ << "': bindToolboxHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  auto runtime_host = makeRuntimeHost(this);
+  if (!handle_.bindRuntimeHost(runtime_host)) {
+    std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!config_json.empty() && config_json != "{}") {
+    (void)handle_.loadConfig(config_json);
+  }
+
+  return true;
+}
+
+bool ToolboxSession::hasDialog() const {
+  return handle_.valid() &&
+         (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_HAS_DIALOG) != 0;
+}
+
+bool ToolboxSession::runDialog(QWidget* parent) {
+  if (!hasDialog()) return false;
+  if (dialog_running_) return false;  // prevent re-entrant opens on non-modal dialogs
+
+  auto vt_result = library_.resolveDialogVtable();
+  if (!vt_result) return false;
+
+  auto* dialog_ctx = handle_.dialogContext();
+  if (dialog_ctx == nullptr) return false;
+
+  auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
+
+  PJ::DialogEngineConfig config;
+  config.non_modal = isNonModal();
+
+  PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
+
+  dialog_running_ = true;
+  auto result = dialog_engine.showDialog(parent);
+  dialog_running_ = false;
+
+  if (result == PJ::DialogResult::kRejected) return false;
+
+  (void)handle_.loadConfig(dialog_engine.savedConfig());
+  flushPending();
+  return true;
+}
+
+std::string ToolboxSession::saveConfig() const {
+  return handle_.valid() ? handle_.saveConfig() : "{}";
+}
+
+void ToolboxSession::flushPending() {
+  if (toolbox_host_) toolbox_host_->flushPending();
+}
+
+bool ToolboxSession::isNonModal() const {
+  return handle_.valid() && (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG) != 0;
+}
+
+PJ_toolbox_runtime_host_t ToolboxSession::makeRuntimeHost(ToolboxSession* self) {
+  return PJ_toolbox_runtime_host_t{
+      .ctx = &self->runtime_state_,
+      .vtable = &kRuntimeVtable,
+  };
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+#include <string>
+
+#include "pj_base/toolbox_protocol.h"
+#include "pj_datastore/engine.hpp"
+#include "pj_datastore/plugin_data_host.hpp"
+#include "pj_plugins/host/toolbox_handle.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
+#include "plugin_registry.hpp"
+
+namespace proto {
+
+class ToolboxSession : public QObject {
+  Q_OBJECT
+
+ public:
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+                 QObject* parent = nullptr);
+
+  /// Bind hosts and load persisted config. Returns false on error.
+  bool init(const std::string& config_json = "{}");
+
+  /// Open the plugin's dialog (modal or non-modal per capability). Returns true if accepted.
+  bool runDialog(QWidget* parent);
+
+  /// Flush any pending writes to the DataEngine.
+  void flushPending();
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] bool hasDialog() const;
+  [[nodiscard]] std::string saveConfig() const;
+
+ signals:
+  void dataChanged();
+
+ public:
+  // Public so the file-scope static vtable lambdas can cast to it.
+  struct RuntimeState {
+    std::string last_error;
+    ToolboxSession* session = nullptr;
+  };
+
+ private:
+  static PJ_toolbox_runtime_host_t makeRuntimeHost(ToolboxSession* self);
+
+  bool isNonModal() const;
+
+  PJ::DataEngine& engine_;
+  PJ::ToolboxLibrary& library_;
+  std::string name_;
+  PJ::ToolboxHandle handle_;
+  std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;
+
+  // Runtime host state — must outlive handle_
+  RuntimeState runtime_state_;
+  bool dialog_running_ = false;
+};
+
+}  // namespace proto


### PR DESCRIPTION
## Summary

- Add dockable toolbox panels to proto_app: `PluginRegistry` discovers and loads Toolbox `.so` plugins, `ToolboxSession` wraps the dialog flow with `DatastoreToolboxHost` binding, and `MainWindow` creates one `QDockWidget` per toolbox plugin toggled from the Tools menu
- Extend Dialog SDK with `setButtonIcon()` for inline SVG icons, `setAcceptsFieldDrop()` for drag-and-drop of fields onto dialog widgets (with correct `QAbstractItemView` viewport handling), per-series color support in `ChartSeries`/`ChartPreviewWidget`, and a Lua syntax highlighter for code editor widgets
- Add `PreferencesDialog` for proto_app settings

## Test plan
- [ ] Build `pj_proto_app` — no compile errors
- [ ] Load a Toolbox plugin (e.g. ColorMap) — appears as toggle action in Tools menu, opens dockable panel
- [ ] Drag a field from the series tree onto a dialog widget that declares `setAcceptsFieldDrop` — fires event correctly
- [ ] Chart preview shows per-series colors when specified
