### PR TITLE
feat(sdk): add ScatterXY, visibleRange and per-series chart color APIs

### DIFF
--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -188,6 +188,14 @@ typedef struct {
   const PJ_parser_write_host_vtable_t* vtable;
 } PJ_parser_write_host_t;
 
+/** Handle returned by register_scatter_xy_series — identifies a two-column (x, y)
+ *  topic registered for convenience ScatterXY ingest. */
+typedef struct {
+  PJ_topic_handle_t topic;
+  uint32_t x_field_id;
+  uint32_t y_field_id;
+} PJ_scatter_xy_handle_t;
+
 typedef struct PJ_toolbox_host_vtable_t {
   uint32_t abi_version;
   uint32_t struct_size;
@@ -206,6 +214,15 @@ typedef struct PJ_toolbox_host_vtable_t {
       void* ctx, PJ_topic_handle_t topic, PJ_bytes_view_t ipc_stream, PJ_string_view_t timestamp_column);
   bool (*acquire_catalog_snapshot)(void* ctx, PJ_catalog_snapshot_t* out_snapshot);
   bool (*read_series)(void* ctx, PJ_field_handle_t field, PJ_materialized_series_t* out_series);
+  /** Register a two-column (x, y) ScatterXY topic. Timestamps are synthetic
+   *  row indices — use for non-time-indexed outputs (e.g. FFT frequency spectrum). */
+  bool (*register_scatter_xy_series)(
+      void* ctx, PJ_data_source_handle_t source, PJ_string_view_t topic_name, PJ_scatter_xy_handle_t* out_handle);
+  /** Append one (x, y) point to a ScatterXY topic. */
+  bool (*append_scatter_xy)(void* ctx, PJ_scatter_xy_handle_t handle, double x, double y);
+  /** Query the current visible time range from the host's main chart, in ns.
+   *  Returns false if no range is currently available (e.g. no data loaded). */
+  bool (*get_visible_range)(void* ctx, int64_t* out_t_min, int64_t* out_t_max);
 } PJ_toolbox_host_vtable_t;
 
 typedef struct {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <initializer_list>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -561,6 +562,46 @@ class ToolboxHostView {
       return unexpected(std::string(lastError()));
     }
     return MaterializedSeries(raw);
+  }
+
+  /// Register a two-column (x, y) ScatterXY topic. Use for non-time-indexed outputs
+  /// (e.g. FFT frequency spectrum: x=Hz, y=amplitude). Timestamps are synthetic row indices.
+  [[nodiscard]] Expected<PJ_scatter_xy_handle_t> registerScatterXYSeries(
+      DataSourceHandle source, std::string_view topic_name) const {
+    PJ_scatter_xy_handle_t handle{};
+    if (host_.vtable->register_scatter_xy_series == nullptr) {
+      return unexpected(std::string("register_scatter_xy_series not supported by this host"));
+    }
+    if (!host_.vtable->register_scatter_xy_series(host_.ctx, source, toAbiString(topic_name), &handle)) {
+      return unexpected(std::string(lastError()));
+    }
+    return handle;
+  }
+
+  /// Append one (x, y) point to a ScatterXY topic registered via registerScatterXYSeries.
+  [[nodiscard]] Status appendScatterXY(PJ_scatter_xy_handle_t handle, double x, double y) const {
+    if (host_.vtable->append_scatter_xy == nullptr) {
+      return unexpected(std::string("append_scatter_xy not supported by this host"));
+    }
+    if (!host_.vtable->append_scatter_xy(host_.ctx, handle, x, y)) {
+      return unexpected(std::string(lastError()));
+    }
+    return okStatus();
+  }
+
+  /// Query the current visible time range (in nanoseconds) from the host's main chart.
+  /// Returns std::nullopt if no range is currently available (no data loaded yet, or
+  /// the host does not support visible-range reporting).
+  [[nodiscard]] std::optional<std::pair<int64_t, int64_t>> visibleRange() const {
+    if (host_.vtable->get_visible_range == nullptr) {
+      return std::nullopt;
+    }
+    int64_t t_min = 0;
+    int64_t t_max = 0;
+    if (!host_.vtable->get_visible_range(host_.ctx, &t_min, &t_max)) {
+      return std::nullopt;
+    }
+    return std::make_pair(t_min, t_max);
   }
 
   [[nodiscard]] std::string_view lastError() const {

--- a/pj_datastore/include/pj_datastore/plugin_data_host.hpp
+++ b/pj_datastore/include/pj_datastore/plugin_data_host.hpp
@@ -58,6 +58,13 @@ class DatastoreToolboxHost {
   [[nodiscard]] PJ_toolbox_host_t raw() noexcept;
   void flushPending();
 
+  /// Update the visible time range reported to plugins via get_visible_range (in ns).
+  /// Called by the application whenever the main chart's viewport changes.
+  void setVisibleRange(int64_t t_min_ns, int64_t t_max_ns);
+
+  /// Clear the visible range (subsequent get_visible_range calls will return false).
+  void clearVisibleRange();
+
  private:
   std::unique_ptr<DatastoreToolboxHostState> state_;
 };

--- a/pj_datastore/include/pj_datastore/writer.hpp
+++ b/pj_datastore/include/pj_datastore/writer.hpp
@@ -36,6 +36,14 @@ struct ScalarSeriesHandle {
   PJ::FieldId value_field;
 };
 
+/// Handle for scatter XY convenience API — two columns (x, y) with no semantic timestamp.
+/// Timestamps are synthetic (row index), so the series is indexed by position, not time.
+struct ScatterXYSeriesHandle {
+  PJ::TopicId topic_id;
+  PJ::FieldId x_field;  ///< Column index 0 ("x")
+  PJ::FieldId y_field;  ///< Column index 1 ("y")
+};
+
 /// Describes one column's data for bulk appendColumns().
 struct ColumnData {
   /// Column index in topic schema.
@@ -148,6 +156,14 @@ class DataWriter {
       PJ::DatasetId dataset_id, std::string_view topic_name, PJ::NumericType value_type);
   /// Append one scalar sample.
   void appendScalar(const ScalarSeriesHandle& handle, PJ::Timestamp t, PJ::NumericValue value);
+
+  // ---- Scatter XY convenience API ----
+  /// Create/register a two-column (x, y) topic with synthetic timestamps.
+  /// Use this for data that has no meaningful time axis, e.g. FFT spectrum (Hz vs amplitude).
+  [[nodiscard]] PJ::Expected<ScatterXYSeriesHandle> registerScatterXYSeries(
+      PJ::DatasetId dataset_id, std::string_view topic_name);
+  /// Append one (x, y) pair. Timestamp is assigned automatically as the row index.
+  void appendScatterXY(const ScatterXYSeriesHandle& handle, double x, double y);
 
   // ---- Dynamic column addition ----
   /// Ensure a column with `field_path` and `type` exists for `topic_id`.

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -958,6 +959,15 @@ struct DatastoreParserWriteHostState {
 struct DatastoreToolboxHostState {
   explicit DatastoreToolboxHostState(DataEngine& engine) : core(engine) {}
   ToolboxCore core;
+  // Visible time range exposed to plugins via get_visible_range. Updated by
+  // the application (e.g. MainWindow) when the main chart's range changes.
+  // valid=false means no range available.
+  bool visible_range_valid = false;
+  int64_t visible_range_min_ns = 0;
+  int64_t visible_range_max_ns = 0;
+  // Map of ScatterXY topic handles to their registered field IDs — needed
+  // because the ABI exposes x/y field ids at register time.
+  std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> scatter_xy_fields;
 };
 
 bool sourceEnsureTopic(void* ctx, PJ_string_view_t topic_name, TopicHandle* out_topic) {
@@ -1054,6 +1064,40 @@ bool toolboxReadSeries(void* ctx, FieldHandle field, PJ_materialized_series_t* o
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.readSeries(field, out_series);
 }
 
+bool toolboxRegisterScatterXYSeries(
+    void* ctx, DataSourceHandle source, PJ_string_view_t topic_name, PJ_scatter_xy_handle_t* out_handle) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  auto handle_expected = state->core.write.writer_.registerScatterXYSeries(
+      DatasetId{source.id}, std::string(toStringView(topic_name)));
+  if (!handle_expected) {
+    state->core.write.last_error_ = handle_expected.error();
+    return false;
+  }
+  out_handle->topic.id = handle_expected->topic_id;
+  out_handle->x_field_id = handle_expected->x_field;
+  out_handle->y_field_id = handle_expected->y_field;
+  state->scatter_xy_fields[handle_expected->topic_id] = {handle_expected->x_field, handle_expected->y_field};
+  return true;
+}
+
+bool toolboxAppendScatterXY(void* ctx, PJ_scatter_xy_handle_t handle, double x, double y) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  ScatterXYSeriesHandle writer_handle{TopicId{handle.topic.id}, FieldId{handle.x_field_id},
+                                      FieldId{handle.y_field_id}};
+  state->core.write.writer_.appendScatterXY(writer_handle, x, y);
+  return true;
+}
+
+bool toolboxGetVisibleRange(void* ctx, int64_t* out_t_min, int64_t* out_t_max) {
+  const auto* state = static_cast<const DatastoreToolboxHostState*>(ctx);
+  if (!state->visible_range_valid) {
+    return false;
+  }
+  *out_t_min = state->visible_range_min_ns;
+  *out_t_max = state->visible_range_max_ns;
+  return true;
+}
+
 const char* toolboxLastError(void* ctx) {
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.write.lastError();
 }
@@ -1080,12 +1124,13 @@ const PJ_parser_write_host_vtable_t kParserWriteVTable = {
 };
 
 const PJ_toolbox_host_vtable_t kToolboxVTable = {
-    PJ_PLUGIN_DATA_API_VERSION, sizeof(PJ_toolbox_host_vtable_t),
-    toolboxLastError,           toolboxCreateDataSource,
-    toolboxEnsureTopic,         toolboxEnsureField,
-    toolboxAppendRecord,        toolboxAppendRecordFast,
-    toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
-    toolboxReadSeries,
+    PJ_PLUGIN_DATA_API_VERSION,      sizeof(PJ_toolbox_host_vtable_t),
+    toolboxLastError,                toolboxCreateDataSource,
+    toolboxEnsureTopic,              toolboxEnsureField,
+    toolboxAppendRecord,             toolboxAppendRecordFast,
+    toolboxAppendArrowIpc,           toolboxAcquireCatalogSnapshot,
+    toolboxReadSeries,               toolboxRegisterScatterXYSeries,
+    toolboxAppendScatterXY,          toolboxGetVisibleRange,
 };
 
 DatastoreSourceWriteHost::DatastoreSourceWriteHost(DataEngine& engine, DataSourceHandle source)
@@ -1128,6 +1173,16 @@ PJ_toolbox_host_t DatastoreToolboxHost::raw() noexcept {
 
 void DatastoreToolboxHost::flushPending() {
   state_->core.write.flushPending();
+}
+
+void DatastoreToolboxHost::setVisibleRange(int64_t t_min_ns, int64_t t_max_ns) {
+  state_->visible_range_valid = true;
+  state_->visible_range_min_ns = t_min_ns;
+  state_->visible_range_max_ns = t_max_ns;
+}
+
+void DatastoreToolboxHost::clearVisibleRange() {
+  state_->visible_range_valid = false;
 }
 
 }  // namespace PJ

--- a/pj_datastore/src/writer.cpp
+++ b/pj_datastore/src/writer.cpp
@@ -472,6 +472,55 @@ void DataWriter::appendScalar(const ScalarSeriesHandle& handle, Timestamp t, Num
 }
 
 // ---------------------------------------------------------------------------
+// Scatter XY convenience API
+// ---------------------------------------------------------------------------
+
+Expected<ScatterXYSeriesHandle> DataWriter::registerScatterXYSeries(DatasetId dataset_id,
+                                                                      std::string_view topic_name) {
+  TopicDescriptor desc;
+  desc.name = std::string(topic_name);
+  desc.schema_id = 0;
+
+  auto topic_id_or = impl_->engine.createTopic(dataset_id, std::move(desc));
+  if (!topic_id_or.has_value()) {
+    return PJ::unexpected(topic_id_or.error());
+  }
+  TopicId topic_id = *topic_id_or;
+
+  ColumnDescriptor x_desc;
+  x_desc.field_id = 0;
+  x_desc.logical_type = PJ::PrimitiveType::kFloat64;
+  x_desc.field_path = "x";
+
+  ColumnDescriptor y_desc;
+  y_desc.field_id = 1;
+  y_desc.logical_type = PJ::PrimitiveType::kFloat64;
+  y_desc.field_path = "y";
+
+  std::vector<ColumnDescriptor> columns = {x_desc, y_desc};
+  impl_->topic_columns[topic_id] = columns;
+
+  if (auto* storage = impl_->engine.getTopicStorage(topic_id)) {
+    storage->setColumnDescriptors(std::move(columns));
+  }
+
+  return ScatterXYSeriesHandle{topic_id, 0, 1};
+}
+
+void DataWriter::appendScatterXY(const ScatterXYSeriesHandle& handle, double x, double y) {
+  auto& builder = getOrCreateBuilder(handle.topic_id);
+  const auto synthetic_t = static_cast<Timestamp>(builder.rowCount());
+  builder.beginRow(synthetic_t);
+  builder.set(static_cast<std::size_t>(handle.x_field), x);
+  builder.set(static_cast<std::size_t>(handle.y_field), y);
+  builder.finishRow();
+
+  if (builder.isFull()) {
+    autoSeal(handle.topic_id);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Flush
 // ---------------------------------------------------------------------------
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -143,6 +143,7 @@ class WidgetDataView {
   struct ChartSeriesView {
     std::string label;
     std::vector<std::pair<double, double>> points;  // {x, y}
+    std::string color;  // optional hex "#rrggbb"; empty means use chart theme default
   };
 
   [[nodiscard]] std::optional<std::vector<ChartSeriesView>> chartSeries(std::string_view name) const {
@@ -174,6 +175,10 @@ class WidgetDataView {
           }
         }
       }
+      auto color_it = s.find("color");
+      if (color_it != s.end() && color_it->is_string()) {
+        sv.color = color_it->get<std::string>();
+      }
       result.push_back(std::move(sv));
     }
     return result;
@@ -182,6 +187,14 @@ class WidgetDataView {
   // --- QPlainTextEdit ---
   [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
     return getString(name, "plain_text");
+  }
+
+  // --- Code editor ---
+  [[nodiscard]] std::optional<std::string> codeContent(std::string_view name) const {
+    return getString(name, "code_content");
+  }
+  [[nodiscard]] std::optional<std::string> codeLanguage(std::string_view name) const {
+    return getString(name, "code_language");
   }
 
   // --- QLabel ---

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
@@ -22,6 +22,7 @@ class ChartPreviewWidget : public QChartView {
   struct Series {
     std::string label;
     std::vector<std::pair<double, double>> points;
+    std::string color;  // optional hex "#rrggbb"; empty means use chart theme default
   };
 
   void setSeries(const std::vector<Series>& series);

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -14,9 +14,12 @@ struct ChartPoint {
 };
 
 /// A named series of XY points for chart display (used by setChartSeries).
+/// If `color` is non-empty (e.g. "#ff7f0e"), it overrides the chart theme color
+/// for this series; otherwise the Qt Charts theme picks one.
 struct ChartSeries {
   std::string label;
   std::vector<ChartPoint> points;
+  std::string color;  // optional hex "#rrggbb"
 };
 
 /// Builder for the JSON string returned by get_widget_data().
@@ -119,7 +122,11 @@ class WidgetData {
       for (const auto& p : s.points) {
         pts.push_back({p.x, p.y});
       }
-      arr.push_back({{"label", s.label}, {"points", std::move(pts)}});
+      nlohmann::json entry = {{"label", s.label}, {"points", std::move(pts)}};
+      if (!s.color.empty()) {
+        entry["color"] = s.color;
+      }
+      arr.push_back(std::move(entry));
     }
     e["chart_series"] = std::move(arr);
     return *this;
@@ -137,6 +144,21 @@ class WidgetData {
     return *this;
   }
 
+  // --- Code editor (QPlainTextEdit with syntax highlighting) ---
+
+  /// Set the code content of a QPlainTextEdit used as a code editor.
+  /// Unlike setPlainText (read-only), this enables editing and wires onCodeChanged events.
+  WidgetData& setCodeContent(std::string_view name, std::string_view code) {
+    entry(name)["code_content"] = code;
+    return *this;
+  }
+
+  /// Set the language for syntax highlighting (e.g. "lua", "python").
+  WidgetData& setCodeLanguage(std::string_view name, std::string_view lang) {
+    entry(name)["code_language"] = lang;
+    return *this;
+  }
+
   // --- QLabel ---
   WidgetData& setLabel(std::string_view name, std::string_view text) {
     entry(name)["label"] = text;
@@ -148,6 +170,7 @@ class WidgetData {
     entry(name)["button_text"] = text;
     return *this;
   }
+
 
   /// Assign a keyboard shortcut to a QPushButton (e.g. "Ctrl+A", "Ctrl+Shift+A").
   /// The host creates a QShortcut that triggers click() on the button.

--- a/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
+++ b/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
@@ -1,12 +1,28 @@
 #include <pj_plugins/host_qt/chart_preview_widget.hpp>
 
+#include <QColor>
+#include <QPen>
 #include <QPointF>
 #include <QtCharts/QChart>
+#include <QtCharts/QLegendMarker>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <limits>
 
 namespace PJ {
+
+namespace {
+/// Default matplotlib "tab10" palette — 10 distinct colors.
+const std::vector<QColor>& kDefaultPalette() {
+  static const std::vector<QColor> kPalette = {
+      QColor(0x1f, 0x77, 0xb4), QColor(0xff, 0x7f, 0x0e), QColor(0x2c, 0xa0, 0x2c),
+      QColor(0xd6, 0x27, 0x28), QColor(0x94, 0x67, 0xbd), QColor(0x8c, 0x56, 0x4b),
+      QColor(0xe3, 0x77, 0xc2), QColor(0x7f, 0x7f, 0x7f), QColor(0xbc, 0xbd, 0x22),
+      QColor(0x17, 0xbe, 0xcf),
+  };
+  return kPalette;
+}
+}  // namespace
 
 ChartPreviewWidget::ChartPreviewWidget(QWidget* parent) : QChartView(new QChart(), parent) {
   setRenderHint(QPainter::Antialiasing);
@@ -29,7 +45,10 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
   double y_min = std::numeric_limits<double>::max();
   double y_max = std::numeric_limits<double>::lowest();
 
-  for (const auto& s : series) {
+  const auto& palette = kDefaultPalette();
+
+  for (size_t i = 0; i < series.size(); ++i) {
+    const auto& s = series[i];
     auto* line = new QLineSeries();
     line->setName(QString::fromStdString(s.label));
 
@@ -47,7 +66,20 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
     chart()->addSeries(line);
     line->attachAxis(x_axis_);
     line->attachAxis(y_axis_);
+    // Color precedence:
+    //  1. If the series carries an explicit hex color, apply it (after addSeries
+    //     so Qt's theme assignment doesn't win).
+    //  2. Otherwise leave whatever Qt Charts chose from the active theme.
+    if (!s.color.empty()) {
+      QColor c(QString::fromStdString(s.color));
+      if (c.isValid()) {
+        QPen pen(c);
+        pen.setWidthF(1.4);
+        line->setPen(pen);
+      }
+    }
   }
+  (void)palette;  // palette reserved for future per-series override API
 
   if (x_min < x_max) {
     x_axis_->setRange(x_min, x_max);
@@ -58,6 +90,22 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
       margin = 1.0;
     }
     y_axis_->setRange(y_min - margin, y_max + margin);
+  }
+
+  // Interactive legend: click a marker to toggle its series visibility.
+  const auto markers = chart()->legend()->markers();
+  for (auto* marker : markers) {
+    QObject::disconnect(marker, nullptr, this, nullptr);
+    QObject::connect(marker, &QLegendMarker::clicked, this, [marker]() {
+      auto* s = marker->series();
+      if (s) {
+        s->setVisible(!s->isVisible());
+        // Fade the legend label when series is hidden.
+        QColor color = marker->labelBrush().color();
+        color.setAlphaF(s->isVisible() ? 1.0F : 0.4F);
+        marker->setLabelBrush(QBrush(color));
+      }
+    });
   }
 }
 

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -89,6 +89,9 @@ PJ_toolbox_host_t makeToolboxHost(MinimalToolboxHost* recorder) {
       .append_arrow_ipc = MinimalToolboxHost::appendArrowIpc,
       .acquire_catalog_snapshot = MinimalToolboxHost::acquireCatalogSnapshot,
       .read_series = MinimalToolboxHost::readSeries,
+      .register_scatter_xy_series = nullptr,
+      .append_scatter_xy = nullptr,
+      .get_visible_range = nullptr,
   };
   return PJ_toolbox_host_t{.ctx = recorder, .vtable = &vtable};
 }

--- a/pj_proto_app/src/chart_panel.cpp
+++ b/pj_proto_app/src/chart_panel.cpp
@@ -170,6 +170,7 @@ void ChartPanel::wheelEvent(QWheelEvent* event) {
   double x_max = x_axis_->max();
   x_axis_->setRange(mouse_x_s - (mouse_x_s - x_min) * factor, mouse_x_s + (x_max - mouse_x_s) * factor);
   user_zoom_ = true;
+  emitVisibleRange();
   event->accept();
 }
 
@@ -221,10 +222,17 @@ void ChartPanel::mouseReleaseEvent(QMouseEvent* event) {
   if (event->button() == Qt::MiddleButton && is_panning_) {
     is_panning_ = false;
     setCursor(Qt::ArrowCursor);
+    emitVisibleRange();
     event->accept();
     return;
   }
   QChartView::mouseReleaseEvent(event);
+}
+
+void ChartPanel::emitVisibleRange() {
+  auto t_min = first_timestamp_ + static_cast<PJ::Timestamp>(x_axis_->min() * 1e9);
+  auto t_max = first_timestamp_ + static_cast<PJ::Timestamp>(x_axis_->max() * 1e9);
+  emit visibleRangeChanged(t_min, t_max);
 }
 
 }  // namespace proto

--- a/pj_proto_app/src/chart_panel.hpp
+++ b/pj_proto_app/src/chart_panel.hpp
@@ -37,6 +37,8 @@ class ChartPanel : public QChartView {
 
  signals:
   void seriesDropped();
+  /// Emitted when the user zooms or pans the chart. Values are absolute timestamps.
+  void visibleRangeChanged(PJ::Timestamp t_min, PJ::Timestamp t_max);
 
  protected:
   void dragEnterEvent(QDragEnterEvent* event) override;
@@ -50,6 +52,8 @@ class ChartPanel : public QChartView {
   void mouseDoubleClickEvent(QMouseEvent* event) override;
 
  private:
+  void emitVisibleRange();
+
   const PJ::DataEngine& engine_;
   QValueAxis* x_axis_;
   QValueAxis* y_axis_;

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -1,6 +1,11 @@
 #include "main_window.hpp"
+#include "preferences_dialog.hpp"
 
 #include <QAction>
+#include <QApplication>
+#include <QDesktopServices>
+#include <QDockWidget>
+#include <QHeaderView>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
@@ -114,7 +119,8 @@ ShowMessageBoxCallback makeMessageBoxCallback(QWidget* parent) {
 }  // namespace
 
 MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
-    : QMainWindow(parent), registry_(plugin_dir), tree_model_(engine_) {
+    : QMainWindow(parent), plugin_dir_str_(QString::fromStdString(plugin_dir)),
+      registry_(plugin_dir), tree_model_(engine_) {
   auto td_result = engine_.createTimeDomain("default");
   if (td_result) {
     default_td_id_ = *td_result;
@@ -186,6 +192,8 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
     chart_panel_->updateData(begin, end);
   });
   connect(&refresh_timer_, &QTimer::timeout, this, &MainWindow::onRefreshTimer);
+
+  setupMenuBar();
 
   setWindowTitle("PlotJuggler Proto");
 }
@@ -689,6 +697,183 @@ void MainWindow::onOpenMarketplace() {
   window.exec();
   if (window.installationsChanged()) {
     registry_.reload();
+  }
+}
+
+void MainWindow::onShowPreferences() {
+  PreferencesDialog dlg(plugin_dir_str_, this);
+  dlg.exec();
+}
+
+void MainWindow::setupMenuBar() {
+  // --- App ---
+  auto* app_menu = menuBar()->addMenu("&App");
+
+  auto* act_clear_points = app_menu->addAction("Clear Data &Points", this, &MainWindow::onClearData);
+  act_clear_points->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_C);
+
+  auto* act_delete_all = app_menu->addAction("&Delete Everything", this, [this]() {
+    onClearData();
+    onClearPlots();
+  });
+  act_delete_all->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_X);
+
+  app_menu->addSeparator();
+
+  auto* act_prefs = app_menu->addAction("&Preferences...", this, &MainWindow::onShowPreferences);
+  act_prefs->setShortcut(Qt::CTRL | Qt::Key_Comma);
+
+  app_menu->addSeparator();
+
+  auto* act_exit = app_menu->addAction("E&xit", this, &QMainWindow::close);
+  act_exit->setShortcut(QKeySequence::Quit);
+
+  // --- Tools ---
+  auto* tools_menu = menuBar()->addMenu("&Tools");
+
+  auto* act_stylesheet = tools_menu->addAction("Load &Stylesheet...", this, [this]() {
+    QSettings settings;
+    auto last_dir = settings.value("ProtoApp/lastStylesheetDir", "").toString();
+    auto path = QFileDialog::getOpenFileName(this, "Load Stylesheet", last_dir, "Stylesheets (*.qss);;All files (*)");
+    if (path.isEmpty()) return;
+    settings.setValue("ProtoApp/lastStylesheetDir", QFileInfo(path).absolutePath());
+    QFile file(path);
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+      qApp->setStyleSheet(QString::fromUtf8(file.readAll()));
+    }
+  });
+  (void)act_stylesheet;
+
+  tools_menu->addSeparator();
+
+  // Toolbox plugins discovered dynamically (e.g. ColorMap Editor)
+  setupToolboxPanels(tools_menu);
+
+  tools_menu->addSeparator();
+
+  auto* act_fft = tools_menu->addAction("&Fast Fourier Transform");
+  act_fft->setEnabled(false);
+
+  auto* act_quat = tools_menu->addAction("&Quaternion to RPY");
+  act_quat->setEnabled(false);
+
+  auto* act_lua = tools_menu->addAction("&Reactive Script Editor");
+  act_lua->setEnabled(false);
+
+  // --- Help ---
+  auto* help_menu = menuBar()->addMenu("&Help");
+
+  auto* act_cheatsheet = help_menu->addAction("&Cheatsheet", this, [this]() {
+    auto* dlg = new QDialog(this);
+    dlg->setWindowTitle("Cheatsheet");
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->resize(480, 400);
+
+    struct Row {
+      QString shortcut;
+      QString action;
+    };
+    const std::vector<Row> rows = {
+        {"Ctrl+O", "Load File"},
+        {"Ctrl+R", "Start Stream"},
+        {"Ctrl+Shift+C", "Clear Data Points"},
+        {"Ctrl+Shift+X", "Delete Everything"},
+        {"Ctrl+,", "Preferences"},
+        {"Ctrl+Z", "Undo"},
+        {"Ctrl+Shift+Z", "Redo"},
+        {"F1", "Cheatsheet"},
+    };
+
+    auto* table = new QTableWidget(static_cast<int>(rows.size()), 2, dlg);
+    table->setHorizontalHeaderLabels({"Shortcut", "Action"});
+    table->horizontalHeader()->setStretchLastSection(true);
+    table->verticalHeader()->setVisible(false);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->setSelectionMode(QAbstractItemView::NoSelection);
+    table->setAlternatingRowColors(true);
+
+    for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
+      table->setItem(i, 0, new QTableWidgetItem(rows[i].shortcut));
+      table->setItem(i, 1, new QTableWidgetItem(rows[i].action));
+    }
+    table->resizeColumnToContents(0);
+
+    auto* layout = new QVBoxLayout(dlg);
+    layout->addWidget(table);
+    dlg->exec();
+  });
+  act_cheatsheet->setShortcut(Qt::Key_F1);
+
+  help_menu->addSeparator();
+
+  auto* act_support = help_menu->addAction("&Support PlotJuggler", this, []() {
+    QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler"));
+  });
+  (void)act_support;
+
+  auto* act_love = help_menu->addAction(
+      QApplication::style()->standardIcon(QStyle::SP_DialogApplyButton), "Share the &Love", this, []() {
+        QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler/stargazers"));
+      });
+  (void)act_love;
+
+  auto* act_report = help_menu->addAction(
+      QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning), "&Report a Problem", this, []() {
+        QDesktopServices::openUrl(QUrl("https://github.com/facontidavide/PlotJuggler/issues"));
+      });
+  (void)act_report;
+
+  help_menu->addSeparator();
+
+  help_menu->addAction("&About...", this, [this]() {
+    QMessageBox::about(this, "About PlotJuggler Proto",
+                       "<b>PlotJuggler Proto</b><br>"
+                       "Prototype application for testing PlotJuggler plugins.<br><br>"
+                       "Part of the <i>plotjuggler-core</i> project.");
+  });
+}
+
+void MainWindow::setupToolboxPanels(QMenu* tools_menu) {
+  for (const auto& tb : registry_.allToolboxes()) {
+    auto session =
+        std::make_unique<ToolboxSession>(engine_, const_cast<PJ::ToolboxLibrary&>(tb.library), tb.name, this);
+    if (!session->init()) {
+      continue;
+    }
+
+    connect(session.get(), &ToolboxSession::dataChanged, this, [this]() {
+      auto [begin, end] = computeVisibleRange();
+      chart_panel_->updateData(begin, end);
+      tree_model_.rebuildIfChanged();
+    });
+
+    // Forward visible-range updates from the main chart to the plugin's toolbox host,
+    // so plugins can implement zoom-aware features (e.g. FFT's "only zoomed area" mode).
+    ToolboxSession* session_ptr = session.get();
+    connect(chart_panel_, &ChartPanel::visibleRangeChanged, session_ptr,
+            [session_ptr](PJ::Timestamp t_min, PJ::Timestamp t_max) {
+              session_ptr->setVisibleRange(t_min, t_max);
+            });
+    // Seed with the current range so plugins started after data was loaded see a valid range.
+    {
+      auto [t_min, t_max] = computeVisibleRange();
+      session_ptr->setVisibleRange(t_min, t_max);
+    }
+
+    ToolboxSession* raw_session = session.get();
+
+    // Add menu action that opens the dialog directly (like PJ 3.x)
+    tools_menu->addAction(QString::fromStdString(tb.name), this, [this, raw_session]() {
+      if (raw_session->hasDialog()) {
+        if (raw_session->runDialog(this)) {
+          auto [begin, end] = computeVisibleRange();
+          chart_panel_->updateData(begin, end);
+          tree_model_.rebuildIfChanged();
+        }
+      }
+    });
+
+    toolbox_sessions_.push_back(std::move(session));
   }
 }
 

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -1,0 +1,134 @@
+#include "toolbox_session.hpp"
+
+#include <iostream>
+
+#include "pj_plugins/host_qt/dialog_engine.hpp"
+
+namespace proto {
+
+// ---------------------------------------------------------------------------
+// Runtime host vtable — captureless C callbacks via context pointer
+// ---------------------------------------------------------------------------
+
+static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
+    .protocol_version = PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION,
+    .struct_size = sizeof(PJ_toolbox_runtime_host_vtable_t),
+
+    .get_last_error =
+        [](void* ctx) -> const char* {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          return s->last_error.empty() ? nullptr : s->last_error.c_str();
+        },
+
+    .report_message =
+        [](void* ctx, PJ_toolbox_message_level_t level, PJ_string_view_t msg) {
+          (void)ctx;
+          const char* lvl = level == PJ_TOOLBOX_MESSAGE_ERROR     ? "ERROR"
+                            : level == PJ_TOOLBOX_MESSAGE_WARNING ? "WARNING"
+                                                                  : "INFO";
+          std::cerr << "[Toolbox " << lvl << "] " << std::string(msg.data, msg.size) << "\n";
+        },
+
+    .notify_data_changed =
+        [](void* ctx) {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          if (s->session) emit s->session->dataChanged();
+        },
+};
+
+// ---------------------------------------------------------------------------
+// ToolboxSession
+// ---------------------------------------------------------------------------
+
+ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                               std::string name, QObject* parent)
+    : QObject(parent),
+      engine_(engine),
+      library_(library),
+      name_(std::move(name)),
+      handle_(library_.createHandle()) {}
+
+bool ToolboxSession::init(const std::string& config_json) {
+  if (!handle_.valid()) return false;
+
+  toolbox_host_ = std::make_unique<PJ::DatastoreToolboxHost>(engine_);
+  runtime_state_.session = this;
+
+  if (!handle_.bindToolboxHost(toolbox_host_->raw())) {
+    std::cerr << "Toolbox '" << name_ << "': bindToolboxHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  auto runtime_host = makeRuntimeHost(this);
+  if (!handle_.bindRuntimeHost(runtime_host)) {
+    std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!config_json.empty() && config_json != "{}") {
+    (void)handle_.loadConfig(config_json);
+  }
+
+  return true;
+}
+
+bool ToolboxSession::hasDialog() const {
+  return handle_.valid() &&
+         (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_HAS_DIALOG) != 0;
+}
+
+bool ToolboxSession::runDialog(QWidget* parent) {
+  if (!hasDialog()) return false;
+  if (dialog_running_) return false;  // prevent re-entrant opens on non-modal dialogs
+
+  auto vt_result = library_.resolveDialogVtable();
+  if (!vt_result) return false;
+
+  auto* dialog_ctx = handle_.dialogContext();
+  if (dialog_ctx == nullptr) return false;
+
+  auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
+
+  PJ::DialogEngineConfig config;
+  config.non_modal = isNonModal();
+
+  PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
+
+  dialog_running_ = true;
+  auto result = dialog_engine.showDialog(parent);
+  dialog_running_ = false;
+
+  // Always persist the plugin's config after the dialog closes, regardless of
+  // whether the user clicked OK or Close/X. Toolbox dialogs (unlike file-open
+  // dialogs) are persistent workspaces — closing them should not discard state.
+  (void)handle_.loadConfig(dialog_engine.savedConfig());
+  flushPending();
+
+  if (result == PJ::DialogResult::kRejected) return false;
+  return true;
+}
+
+std::string ToolboxSession::saveConfig() const {
+  return handle_.valid() ? handle_.saveConfig() : "{}";
+}
+
+void ToolboxSession::flushPending() {
+  if (toolbox_host_) toolbox_host_->flushPending();
+}
+
+void ToolboxSession::setVisibleRange(int64_t t_min_ns, int64_t t_max_ns) {
+  if (toolbox_host_) toolbox_host_->setVisibleRange(t_min_ns, t_max_ns);
+}
+
+bool ToolboxSession::isNonModal() const {
+  return handle_.valid() && (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG) != 0;
+}
+
+PJ_toolbox_runtime_host_t ToolboxSession::makeRuntimeHost(ToolboxSession* self) {
+  return PJ_toolbox_runtime_host_t{
+      .ctx = &self->runtime_state_,
+      .vtable = &kRuntimeVtable,
+  };
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+#include <string>
+
+#include "pj_base/toolbox_protocol.h"
+#include "pj_datastore/engine.hpp"
+#include "pj_datastore/plugin_data_host.hpp"
+#include "pj_plugins/host/toolbox_handle.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
+#include "plugin_registry.hpp"
+
+namespace proto {
+
+class ToolboxSession : public QObject {
+  Q_OBJECT
+
+ public:
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+                 QObject* parent = nullptr);
+
+  /// Bind hosts and load persisted config. Returns false on error.
+  bool init(const std::string& config_json = "{}");
+
+  /// Open the plugin's dialog (modal or non-modal per capability). Returns true if accepted.
+  bool runDialog(QWidget* parent);
+
+  /// Flush any pending writes to the DataEngine.
+  void flushPending();
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] bool hasDialog() const;
+  [[nodiscard]] std::string saveConfig() const;
+
+  /// Forward the current visible time range to the plugin's toolbox host,
+  /// so plugins can implement zoom-aware features via toolboxHost().visibleRange().
+  void setVisibleRange(int64_t t_min_ns, int64_t t_max_ns);
+
+ signals:
+  void dataChanged();
+
+ public:
+  // Public so the file-scope static vtable lambdas can cast to it.
+  struct RuntimeState {
+    std::string last_error;
+    ToolboxSession* session = nullptr;
+  };
+
+ private:
+  static PJ_toolbox_runtime_host_t makeRuntimeHost(ToolboxSession* self);
+
+  bool isNonModal() const;
+
+  PJ::DataEngine& engine_;
+  PJ::ToolboxLibrary& library_;
+  std::string name_;
+  PJ::ToolboxHandle handle_;
+  std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;
+
+  // Runtime host state — must outlive handle_
+  RuntimeState runtime_state_;
+  bool dialog_running_ = false;
+};
+
+}  // namespace proto


### PR DESCRIPTION
## Summary

- **ScatterXY convenience API**: `registerScatterXYSeries()` / `appendScatterXY()` in the toolbox host ABI — two-column (x, y) topics with synthetic row-index timestamps, designed for non-time-indexed outputs like FFT frequency spectra or scatter plots
- **Visible range query**: `get_visible_range` in the toolbox host ABI lets plugins query the main chart viewport; `ChartPanel` emits `visibleRangeChanged` on zoom/pan and `ToolboxSession` forwards it to the plugin host
- **Per-series color in embedded charts**: `ChartSeries::color` optional hex field; `ChartPreviewWidget` applies the color via `QPen` and adds an interactive legend (click marker to toggle series visibility)

## Test plan
- [ ] Build `pj_proto_app` and `pj_datastore` — no compile errors
- [ ] Register a ScatterXY series from a toolbox plugin — topic appears with x and y fields
- [ ] Zoom/pan the main chart — `visibleRange()` returns updated values in the plugin
- [ ] Set `color: "#ff7f0e"` on a ChartSeries — chart preview renders the series in orange
- [ ] Click a legend marker — toggles series visibility
