### PR TITLE
feat(sdk): add ScatterXY convenience API for non-time-indexed outputs

### DIFF
--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -188,6 +188,14 @@ typedef struct {
   const PJ_parser_write_host_vtable_t* vtable;
 } PJ_parser_write_host_t;
 
+/** Handle returned by register_scatter_xy_series — identifies a two-column (x, y)
+ *  topic registered for convenience ScatterXY ingest. */
+typedef struct {
+  PJ_topic_handle_t topic;
+  uint32_t x_field_id;
+  uint32_t y_field_id;
+} PJ_scatter_xy_handle_t;
+
 typedef struct PJ_toolbox_host_vtable_t {
   uint32_t abi_version;
   uint32_t struct_size;
@@ -206,6 +214,12 @@ typedef struct PJ_toolbox_host_vtable_t {
       void* ctx, PJ_topic_handle_t topic, PJ_bytes_view_t ipc_stream, PJ_string_view_t timestamp_column);
   bool (*acquire_catalog_snapshot)(void* ctx, PJ_catalog_snapshot_t* out_snapshot);
   bool (*read_series)(void* ctx, PJ_field_handle_t field, PJ_materialized_series_t* out_series);
+  /** Register a two-column (x, y) ScatterXY topic. Timestamps are synthetic
+   *  row indices — use for non-time-indexed outputs (e.g. FFT frequency spectrum). */
+  bool (*register_scatter_xy_series)(
+      void* ctx, PJ_data_source_handle_t source, PJ_string_view_t topic_name, PJ_scatter_xy_handle_t* out_handle);
+  /** Append one (x, y) point to a ScatterXY topic. */
+  bool (*append_scatter_xy)(void* ctx, PJ_scatter_xy_handle_t handle, double x, double y);
 } PJ_toolbox_host_vtable_t;
 
 typedef struct {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <initializer_list>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -561,6 +562,31 @@ class ToolboxHostView {
       return unexpected(std::string(lastError()));
     }
     return MaterializedSeries(raw);
+  }
+
+  /// Register a two-column (x, y) ScatterXY topic. Use for non-time-indexed outputs
+  /// (e.g. FFT frequency spectrum: x=Hz, y=amplitude). Timestamps are synthetic row indices.
+  [[nodiscard]] Expected<PJ_scatter_xy_handle_t> registerScatterXYSeries(
+      DataSourceHandle source, std::string_view topic_name) const {
+    PJ_scatter_xy_handle_t handle{};
+    if (host_.vtable->register_scatter_xy_series == nullptr) {
+      return unexpected(std::string("register_scatter_xy_series not supported by this host"));
+    }
+    if (!host_.vtable->register_scatter_xy_series(host_.ctx, source, toAbiString(topic_name), &handle)) {
+      return unexpected(std::string(lastError()));
+    }
+    return handle;
+  }
+
+  /// Append one (x, y) point to a ScatterXY topic registered via registerScatterXYSeries.
+  [[nodiscard]] Status appendScatterXY(PJ_scatter_xy_handle_t handle, double x, double y) const {
+    if (host_.vtable->append_scatter_xy == nullptr) {
+      return unexpected(std::string("append_scatter_xy not supported by this host"));
+    }
+    if (!host_.vtable->append_scatter_xy(host_.ctx, handle, x, y)) {
+      return unexpected(std::string(lastError()));
+    }
+    return okStatus();
   }
 
   [[nodiscard]] std::string_view lastError() const {

--- a/pj_datastore/include/pj_datastore/writer.hpp
+++ b/pj_datastore/include/pj_datastore/writer.hpp
@@ -36,6 +36,14 @@ struct ScalarSeriesHandle {
   PJ::FieldId value_field;
 };
 
+/// Handle for scatter XY convenience API — two columns (x, y) with no semantic timestamp.
+/// Timestamps are synthetic (row index), so the series is indexed by position, not time.
+struct ScatterXYSeriesHandle {
+  PJ::TopicId topic_id;
+  PJ::FieldId x_field;  ///< Column index 0 ("x")
+  PJ::FieldId y_field;  ///< Column index 1 ("y")
+};
+
 /// Describes one column's data for bulk appendColumns().
 struct ColumnData {
   /// Column index in topic schema.
@@ -148,6 +156,14 @@ class DataWriter {
       PJ::DatasetId dataset_id, std::string_view topic_name, PJ::NumericType value_type);
   /// Append one scalar sample.
   void appendScalar(const ScalarSeriesHandle& handle, PJ::Timestamp t, PJ::NumericValue value);
+
+  // ---- Scatter XY convenience API ----
+  /// Create/register a two-column (x, y) topic with synthetic timestamps.
+  /// Use this for data that has no meaningful time axis, e.g. FFT spectrum (Hz vs amplitude).
+  [[nodiscard]] PJ::Expected<ScatterXYSeriesHandle> registerScatterXYSeries(
+      PJ::DatasetId dataset_id, std::string_view topic_name);
+  /// Append one (x, y) pair. Timestamp is assigned automatically as the row index.
+  void appendScatterXY(const ScatterXYSeriesHandle& handle, double x, double y);
 
   // ---- Dynamic column addition ----
   /// Ensure a column with `field_path` and `type` exists for `topic_id`.

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -958,6 +959,9 @@ struct DatastoreParserWriteHostState {
 struct DatastoreToolboxHostState {
   explicit DatastoreToolboxHostState(DataEngine& engine) : core(engine) {}
   ToolboxCore core;
+  // Map of ScatterXY topic handles to their registered field IDs — needed
+  // because the ABI exposes x/y field ids at register time.
+  std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> scatter_xy_fields;
 };
 
 bool sourceEnsureTopic(void* ctx, PJ_string_view_t topic_name, TopicHandle* out_topic) {
@@ -1054,6 +1058,30 @@ bool toolboxReadSeries(void* ctx, FieldHandle field, PJ_materialized_series_t* o
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.readSeries(field, out_series);
 }
 
+bool toolboxRegisterScatterXYSeries(
+    void* ctx, DataSourceHandle source, PJ_string_view_t topic_name, PJ_scatter_xy_handle_t* out_handle) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  auto handle_expected = state->core.write.writer_.registerScatterXYSeries(
+      DatasetId{source.id}, std::string(toStringView(topic_name)));
+  if (!handle_expected) {
+    state->core.write.last_error_ = handle_expected.error();
+    return false;
+  }
+  out_handle->topic.id = handle_expected->topic_id;
+  out_handle->x_field_id = handle_expected->x_field;
+  out_handle->y_field_id = handle_expected->y_field;
+  state->scatter_xy_fields[handle_expected->topic_id] = {handle_expected->x_field, handle_expected->y_field};
+  return true;
+}
+
+bool toolboxAppendScatterXY(void* ctx, PJ_scatter_xy_handle_t handle, double x, double y) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  ScatterXYSeriesHandle writer_handle{TopicId{handle.topic.id}, FieldId{handle.x_field_id},
+                                      FieldId{handle.y_field_id}};
+  state->core.write.writer_.appendScatterXY(writer_handle, x, y);
+  return true;
+}
+
 const char* toolboxLastError(void* ctx) {
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.write.lastError();
 }
@@ -1080,12 +1108,13 @@ const PJ_parser_write_host_vtable_t kParserWriteVTable = {
 };
 
 const PJ_toolbox_host_vtable_t kToolboxVTable = {
-    PJ_PLUGIN_DATA_API_VERSION, sizeof(PJ_toolbox_host_vtable_t),
-    toolboxLastError,           toolboxCreateDataSource,
-    toolboxEnsureTopic,         toolboxEnsureField,
-    toolboxAppendRecord,        toolboxAppendRecordFast,
-    toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
-    toolboxReadSeries,
+    PJ_PLUGIN_DATA_API_VERSION,      sizeof(PJ_toolbox_host_vtable_t),
+    toolboxLastError,                toolboxCreateDataSource,
+    toolboxEnsureTopic,              toolboxEnsureField,
+    toolboxAppendRecord,             toolboxAppendRecordFast,
+    toolboxAppendArrowIpc,           toolboxAcquireCatalogSnapshot,
+    toolboxReadSeries,               toolboxRegisterScatterXYSeries,
+    toolboxAppendScatterXY,
 };
 
 DatastoreSourceWriteHost::DatastoreSourceWriteHost(DataEngine& engine, DataSourceHandle source)

--- a/pj_datastore/src/writer.cpp
+++ b/pj_datastore/src/writer.cpp
@@ -472,6 +472,55 @@ void DataWriter::appendScalar(const ScalarSeriesHandle& handle, Timestamp t, Num
 }
 
 // ---------------------------------------------------------------------------
+// Scatter XY convenience API
+// ---------------------------------------------------------------------------
+
+Expected<ScatterXYSeriesHandle> DataWriter::registerScatterXYSeries(DatasetId dataset_id,
+                                                                      std::string_view topic_name) {
+  TopicDescriptor desc;
+  desc.name = std::string(topic_name);
+  desc.schema_id = 0;
+
+  auto topic_id_or = impl_->engine.createTopic(dataset_id, std::move(desc));
+  if (!topic_id_or.has_value()) {
+    return PJ::unexpected(topic_id_or.error());
+  }
+  TopicId topic_id = *topic_id_or;
+
+  ColumnDescriptor x_desc;
+  x_desc.field_id = 0;
+  x_desc.logical_type = PJ::PrimitiveType::kFloat64;
+  x_desc.field_path = "x";
+
+  ColumnDescriptor y_desc;
+  y_desc.field_id = 1;
+  y_desc.logical_type = PJ::PrimitiveType::kFloat64;
+  y_desc.field_path = "y";
+
+  std::vector<ColumnDescriptor> columns = {x_desc, y_desc};
+  impl_->topic_columns[topic_id] = columns;
+
+  if (auto* storage = impl_->engine.getTopicStorage(topic_id)) {
+    storage->setColumnDescriptors(std::move(columns));
+  }
+
+  return ScatterXYSeriesHandle{topic_id, 0, 1};
+}
+
+void DataWriter::appendScatterXY(const ScatterXYSeriesHandle& handle, double x, double y) {
+  auto& builder = getOrCreateBuilder(handle.topic_id);
+  const auto synthetic_t = static_cast<Timestamp>(builder.rowCount());
+  builder.beginRow(synthetic_t);
+  builder.set(static_cast<std::size_t>(handle.x_field), x);
+  builder.set(static_cast<std::size_t>(handle.y_field), y);
+  builder.finishRow();
+
+  if (builder.isFull()) {
+    autoSeal(handle.topic_id);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Flush
 // ---------------------------------------------------------------------------
 

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -89,6 +89,8 @@ PJ_toolbox_host_t makeToolboxHost(MinimalToolboxHost* recorder) {
       .append_arrow_ipc = MinimalToolboxHost::appendArrowIpc,
       .acquire_catalog_snapshot = MinimalToolboxHost::acquireCatalogSnapshot,
       .read_series = MinimalToolboxHost::readSeries,
+      .register_scatter_xy_series = nullptr,
+      .append_scatter_xy = nullptr,
   };
   return PJ_toolbox_host_t{.ctx = recorder, .vtable = &vtable};
 }


### PR DESCRIPTION
## Summary

- Add a two-column (x, y) topic registration and append API to the toolbox host ABI, designed for data with no meaningful time axis (e.g. FFT frequency spectrum: x=Hz, y=amplitude)
- Timestamps are synthetic row indices, so the series is indexed by position rather than time
- C ABI: `PJ_scatter_xy_handle_t`, `register_scatter_xy_series`, `append_scatter_xy`
- C++ wrapper: `ToolboxHostView::registerScatterXYSeries` / `appendScatterXY` with nullptr guards for older hosts

## Test plan
- [ ] Build `pj_datastore` — no compile errors
- [ ] Register a ScatterXY series from a toolbox plugin — topic appears with `x` and `y` columns
- [ ] Append (x, y) points — rows get synthetic timestamps (0, 1, 2, ...)
- [ ] Existing toolbox host tests still pass
