### PR TITLE
fix(dialog-sdk): wire buttonBox for QDialog roots

### DIFF
--- a/pj_plugins/dialog_protocol/src/dialog_engine.cpp
+++ b/pj_plugins/dialog_protocol/src/dialog_engine.cpp
@@ -102,7 +102,11 @@ DialogResult DialogEngine::showDialog(QWidget* parent) {
     auto* layout = new QVBoxLayout(dialog);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(loaded);
+  }
 
+  // Wire buttonBox signals — works whether the loaded widget was a QDialog
+  // or a plain QWidget. Needed so Close/OK/Cancel buttons function correctly.
+  {
     auto* button_box = loaded->findChild<QDialogButtonBox*>("buttonBox");
     if (button_box) {
       QObject::connect(button_box, &QDialogButtonBox::accepted, dialog, &QDialog::accept);


### PR DESCRIPTION
## Summary

- When a plugin `.ui` file uses `QDialog` as the root widget (instead of a plain `QWidget`), the `buttonBox` accept/reject signals were not connected — Close/OK/Cancel buttons did nothing
- The wiring code was inside the "wrap in QDialog" branch that only runs for non-QDialog roots
- Fix: move the `buttonBox` connection to its own unconditional block

## Test plan
- [x] Open a plugin dialog whose `.ui` root is a `QDialog` with a `QDialogButtonBox` named `buttonBox` — Close button works
- [x] Open a plugin dialog whose `.ui` root is a plain `QWidget` — OK/Cancel still work as before
