### PR TITLE
feat(dialog-sdk): add per-series color and interactive chart legend

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -143,6 +143,7 @@ class WidgetDataView {
   struct ChartSeriesView {
     std::string label;
     std::vector<std::pair<double, double>> points;  // {x, y}
+    std::string color;  // optional hex "#rrggbb"; empty means use chart theme default
   };
 
   [[nodiscard]] std::optional<std::vector<ChartSeriesView>> chartSeries(std::string_view name) const {
@@ -174,6 +175,10 @@ class WidgetDataView {
           }
         }
       }
+      auto color_it = s.find("color");
+      if (color_it != s.end() && color_it->is_string()) {
+        sv.color = color_it->get<std::string>();
+      }
       result.push_back(std::move(sv));
     }
     return result;
@@ -182,6 +187,14 @@ class WidgetDataView {
   // --- QPlainTextEdit ---
   [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
     return getString(name, "plain_text");
+  }
+
+  // --- Code editor ---
+  [[nodiscard]] std::optional<std::string> codeContent(std::string_view name) const {
+    return getString(name, "code_content");
+  }
+  [[nodiscard]] std::optional<std::string> codeLanguage(std::string_view name) const {
+    return getString(name, "code_language");
   }
 
   // --- QLabel ---

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -189,14 +189,6 @@ class WidgetDataView {
     return getString(name, "plain_text");
   }
 
-  // --- Code editor ---
-  [[nodiscard]] std::optional<std::string> codeContent(std::string_view name) const {
-    return getString(name, "code_content");
-  }
-  [[nodiscard]] std::optional<std::string> codeLanguage(std::string_view name) const {
-    return getString(name, "code_language");
-  }
-
   // --- QLabel ---
   [[nodiscard]] std::optional<std::string> label(std::string_view name) const {
     return getString(name, "label");

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
@@ -22,6 +22,7 @@ class ChartPreviewWidget : public QChartView {
   struct Series {
     std::string label;
     std::vector<std::pair<double, double>> points;
+    std::string color;  // optional hex "#rrggbb"; empty means use chart theme default
   };
 
   void setSeries(const std::vector<Series>& series);

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -14,9 +14,12 @@ struct ChartPoint {
 };
 
 /// A named series of XY points for chart display (used by setChartSeries).
+/// If `color` is non-empty (e.g. "#ff7f0e"), it overrides the chart theme color
+/// for this series; otherwise the Qt Charts theme picks one.
 struct ChartSeries {
   std::string label;
   std::vector<ChartPoint> points;
+  std::string color;  // optional hex "#rrggbb"
 };
 
 /// Builder for the JSON string returned by get_widget_data().
@@ -119,7 +122,11 @@ class WidgetData {
       for (const auto& p : s.points) {
         pts.push_back({p.x, p.y});
       }
-      arr.push_back({{"label", s.label}, {"points", std::move(pts)}});
+      nlohmann::json entry = {{"label", s.label}, {"points", std::move(pts)}};
+      if (!s.color.empty()) {
+        entry["color"] = s.color;
+      }
+      arr.push_back(std::move(entry));
     }
     e["chart_series"] = std::move(arr);
     return *this;
@@ -134,6 +141,21 @@ class WidgetData {
   // --- QPlainTextEdit ---
   WidgetData& setPlainText(std::string_view name, std::string_view text) {
     entry(name)["plain_text"] = text;
+    return *this;
+  }
+
+  // --- Code editor (QPlainTextEdit with syntax highlighting) ---
+
+  /// Set the code content of a QPlainTextEdit used as a code editor.
+  /// Unlike setPlainText (read-only), this enables editing and wires onCodeChanged events.
+  WidgetData& setCodeContent(std::string_view name, std::string_view code) {
+    entry(name)["code_content"] = code;
+    return *this;
+  }
+
+  /// Set the language for syntax highlighting (e.g. "lua", "python").
+  WidgetData& setCodeLanguage(std::string_view name, std::string_view lang) {
+    entry(name)["code_language"] = lang;
     return *this;
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -144,21 +144,6 @@ class WidgetData {
     return *this;
   }
 
-  // --- Code editor (QPlainTextEdit with syntax highlighting) ---
-
-  /// Set the code content of a QPlainTextEdit used as a code editor.
-  /// Unlike setPlainText (read-only), this enables editing and wires onCodeChanged events.
-  WidgetData& setCodeContent(std::string_view name, std::string_view code) {
-    entry(name)["code_content"] = code;
-    return *this;
-  }
-
-  /// Set the language for syntax highlighting (e.g. "lua", "python").
-  WidgetData& setCodeLanguage(std::string_view name, std::string_view lang) {
-    entry(name)["code_language"] = lang;
-    return *this;
-  }
-
   // --- QLabel ---
   WidgetData& setLabel(std::string_view name, std::string_view text) {
     entry(name)["label"] = text;

--- a/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
+++ b/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
@@ -1,12 +1,28 @@
 #include <pj_plugins/host_qt/chart_preview_widget.hpp>
 
+#include <QColor>
+#include <QPen>
 #include <QPointF>
 #include <QtCharts/QChart>
+#include <QtCharts/QLegendMarker>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <limits>
 
 namespace PJ {
+
+namespace {
+/// Default matplotlib "tab10" palette — 10 distinct colors.
+const std::vector<QColor>& kDefaultPalette() {
+  static const std::vector<QColor> kPalette = {
+      QColor(0x1f, 0x77, 0xb4), QColor(0xff, 0x7f, 0x0e), QColor(0x2c, 0xa0, 0x2c),
+      QColor(0xd6, 0x27, 0x28), QColor(0x94, 0x67, 0xbd), QColor(0x8c, 0x56, 0x4b),
+      QColor(0xe3, 0x77, 0xc2), QColor(0x7f, 0x7f, 0x7f), QColor(0xbc, 0xbd, 0x22),
+      QColor(0x17, 0xbe, 0xcf),
+  };
+  return kPalette;
+}
+}  // namespace
 
 ChartPreviewWidget::ChartPreviewWidget(QWidget* parent) : QChartView(new QChart(), parent) {
   setRenderHint(QPainter::Antialiasing);
@@ -29,7 +45,10 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
   double y_min = std::numeric_limits<double>::max();
   double y_max = std::numeric_limits<double>::lowest();
 
-  for (const auto& s : series) {
+  const auto& palette = kDefaultPalette();
+
+  for (size_t i = 0; i < series.size(); ++i) {
+    const auto& s = series[i];
     auto* line = new QLineSeries();
     line->setName(QString::fromStdString(s.label));
 
@@ -47,7 +66,20 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
     chart()->addSeries(line);
     line->attachAxis(x_axis_);
     line->attachAxis(y_axis_);
+    // Color precedence:
+    //  1. If the series carries an explicit hex color, apply it (after addSeries
+    //     so Qt's theme assignment doesn't win).
+    //  2. Otherwise leave whatever Qt Charts chose from the active theme.
+    if (!s.color.empty()) {
+      QColor c(QString::fromStdString(s.color));
+      if (c.isValid()) {
+        QPen pen(c);
+        pen.setWidthF(1.4);
+        line->setPen(pen);
+      }
+    }
   }
+  (void)palette;  // palette reserved for future per-series override API
 
   if (x_min < x_max) {
     x_axis_->setRange(x_min, x_max);
@@ -58,6 +90,22 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
       margin = 1.0;
     }
     y_axis_->setRange(y_min - margin, y_max + margin);
+  }
+
+  // Interactive legend: click a marker to toggle its series visibility.
+  const auto markers = chart()->legend()->markers();
+  for (auto* marker : markers) {
+    QObject::disconnect(marker, nullptr, this, nullptr);
+    QObject::connect(marker, &QLegendMarker::clicked, this, [marker]() {
+      auto* s = marker->series();
+      if (s) {
+        s->setVisible(!s->isVisible());
+        // Fade the legend label when series is hidden.
+        QColor color = marker->labelBrush().color();
+        color.setAlphaF(s->isVisible() ? 1.0F : 0.4F);
+        marker->setLabelBrush(QBrush(color));
+      }
+    });
   }
 }
 

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -250,7 +250,7 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
       std::vector<PJ::ChartPreviewWidget::Series> chart_series;
       chart_series.reserve(series_data->size());
       for (const auto& s : *series_data) {
-        chart_series.push_back({s.label, s.points});
+        chart_series.push_back({s.label, s.points, s.color});
       }
       chart->setSeries(chart_series);
     }


### PR DESCRIPTION
## Summary

- `ChartSeries::color` optional hex field (`"#rrggbb"`) — when set, overrides the Qt Charts theme color for that series
- `ChartPreviewWidget` applies a `QPen` with the specified color after `addSeries` so the theme assignment does not win
- Interactive legend: clicking a legend marker toggles the corresponding series visibility (label fades when hidden)
- Matplotlib tab10 10-color palette defined for consistent default colors

## Test plan
- [x] Build `pj_plugins` — no compile errors
- [x] Set `color: "#ff7f0e"` on a ChartSeries — chart preview renders the series in orange
- [x] Omit color — chart uses Qt Charts theme default
- [x] Click a legend marker — toggles series visibility, label fades
