### PR TITLE
feat(dialog-sdk): add setButtonIcon for inline SVG on buttons

### DIFF
--- a/pj_plugins/dialog_protocol/CMakeLists.txt
+++ b/pj_plugins/dialog_protocol/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 # --- Qt Dialog Engine (optional — requires Qt6) ---
 
 if(PJ_BUILD_DIALOG_ENGINE_QT)
-  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools Charts)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets UiTools Charts SvgWidgets)
   qt_standard_project_setup()
 
   # Workaround: Qt 6.5 links AGL framework which was removed in macOS 15+ SDK.
@@ -163,7 +163,7 @@ if(PJ_BUILD_DIALOG_ENGINE_QT)
   )
   target_compile_options(pj_dialog_engine_qt PRIVATE ${PJ_WARNING_FLAGS})
   target_link_libraries(pj_dialog_engine_qt
-    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools Qt6::Charts
+    PUBLIC pj_dialog_host Qt6::Widgets Qt6::UiTools Qt6::Charts Qt6::SvgWidgets
   )
   target_include_directories(pj_dialog_engine_qt PUBLIC include)
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -194,6 +194,10 @@ class WidgetDataView {
     return getString(name, "button_text");
   }
 
+  [[nodiscard]] std::optional<std::string> buttonIconSvg(std::string_view name) const {
+    return getString(name, "button_icon_svg");
+  }
+
   [[nodiscard]] std::optional<std::string> shortcut(std::string_view name) const {
     return getString(name, "shortcut");
   }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -149,6 +149,13 @@ class WidgetData {
     return *this;
   }
 
+  /// Set an icon on a QPushButton from inline SVG data.
+  /// The SVG string is stored as-is and rendered by the host via QSvgRenderer.
+  WidgetData& setButtonIcon(std::string_view name, std::string_view svg_data) {
+    entry(name)["button_icon_svg"] = svg_data;
+    return *this;
+  }
+
   /// Assign a keyboard shortcut to a QPushButton (e.g. "Ctrl+A", "Ctrl+Shift+A").
   /// The host creates a QShortcut that triggers click() on the button.
   WidgetData& setShortcut(std::string_view name, std::string_view key_sequence) {

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -7,6 +7,8 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
+#include <QPainter>
+#include <QPixmap>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QRadioButton>
@@ -14,6 +16,7 @@
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QSplitter>
+#include <QSvgRenderer>
 #include <QTabWidget>
 #include <QTableWidget>
 #include <QVBoxLayout>
@@ -210,6 +213,18 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
   if (auto* btn = qobject_cast<QPushButton*>(w)) {
     if (auto v = view.buttonText(name)) {
       btn->setText(QString::fromStdString(*v));
+    }
+    if (auto svg = view.buttonIconSvg(name)) {
+      QByteArray svg_data = QByteArray::fromStdString(*svg);
+      QSvgRenderer renderer(svg_data);
+      if (renderer.isValid()) {
+        int sz = btn->iconSize().height() > 0 ? btn->iconSize().height() : 16;
+        QPixmap pix(sz, sz);
+        pix.fill(Qt::transparent);
+        QPainter painter(&pix);
+        renderer.render(&painter);
+        btn->setIcon(QIcon(pix));
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

- Add `setButtonIcon(name, svg_string)` to `WidgetData` — allows plugins to set an icon on `QPushButton` widgets from inline SVG data
- The host renders the SVG with `QSvgRenderer` at the button's icon size and applies it as a `QIcon`
- Adds `Qt6::SvgWidgets` dependency to `pj_dialog_engine_qt`

## Test plan
- [x] Build `pj_plugins` — no compile errors
- [x] Call `setButtonIcon("myBtn", "<svg>...</svg>")` from a plugin — button shows the SVG icon
- [x] Omit `setButtonIcon` — button shows no icon (unchanged behavior)
- [x] Pass invalid SVG — no crash, icon simply not set
