### PR TITLE
feat(sdk): add visibleRange query for zoom-aware toolbox plugins - maybe remove

### DIFF
--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -206,6 +206,9 @@ typedef struct PJ_toolbox_host_vtable_t {
       void* ctx, PJ_topic_handle_t topic, PJ_bytes_view_t ipc_stream, PJ_string_view_t timestamp_column);
   bool (*acquire_catalog_snapshot)(void* ctx, PJ_catalog_snapshot_t* out_snapshot);
   bool (*read_series)(void* ctx, PJ_field_handle_t field, PJ_materialized_series_t* out_series);
+  /** Query the current visible time range from the host's main chart, in ns.
+   *  Returns false if no range is currently available (e.g. no data loaded). */
+  bool (*get_visible_range)(void* ctx, int64_t* out_t_min, int64_t* out_t_max);
 } PJ_toolbox_host_vtable_t;
 
 typedef struct {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <initializer_list>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -561,6 +562,21 @@ class ToolboxHostView {
       return unexpected(std::string(lastError()));
     }
     return MaterializedSeries(raw);
+  }
+
+  /// Query the current visible time range (in nanoseconds) from the host's main chart.
+  /// Returns std::nullopt if no range is currently available (no data loaded yet, or
+  /// the host does not support visible-range reporting).
+  [[nodiscard]] std::optional<std::pair<int64_t, int64_t>> visibleRange() const {
+    if (host_.vtable->get_visible_range == nullptr) {
+      return std::nullopt;
+    }
+    int64_t t_min = 0;
+    int64_t t_max = 0;
+    if (!host_.vtable->get_visible_range(host_.ctx, &t_min, &t_max)) {
+      return std::nullopt;
+    }
+    return std::make_pair(t_min, t_max);
   }
 
   [[nodiscard]] std::string_view lastError() const {

--- a/pj_datastore/include/pj_datastore/plugin_data_host.hpp
+++ b/pj_datastore/include/pj_datastore/plugin_data_host.hpp
@@ -58,6 +58,13 @@ class DatastoreToolboxHost {
   [[nodiscard]] PJ_toolbox_host_t raw() noexcept;
   void flushPending();
 
+  /// Update the visible time range reported to plugins via get_visible_range (in ns).
+  /// Called by the application whenever the main chart's viewport changes.
+  void setVisibleRange(int64_t t_min_ns, int64_t t_max_ns);
+
+  /// Clear the visible range (subsequent get_visible_range calls will return false).
+  void clearVisibleRange();
+
  private:
   std::unique_ptr<DatastoreToolboxHostState> state_;
 };

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -958,6 +958,12 @@ struct DatastoreParserWriteHostState {
 struct DatastoreToolboxHostState {
   explicit DatastoreToolboxHostState(DataEngine& engine) : core(engine) {}
   ToolboxCore core;
+  // Visible time range exposed to plugins via get_visible_range. Updated by
+  // the application (e.g. MainWindow) when the main chart's range changes.
+  // valid=false means no range available.
+  bool visible_range_valid = false;
+  int64_t visible_range_min_ns = 0;
+  int64_t visible_range_max_ns = 0;
 };
 
 bool sourceEnsureTopic(void* ctx, PJ_string_view_t topic_name, TopicHandle* out_topic) {
@@ -1054,6 +1060,16 @@ bool toolboxReadSeries(void* ctx, FieldHandle field, PJ_materialized_series_t* o
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.readSeries(field, out_series);
 }
 
+bool toolboxGetVisibleRange(void* ctx, int64_t* out_t_min, int64_t* out_t_max) {
+  const auto* state = static_cast<const DatastoreToolboxHostState*>(ctx);
+  if (!state->visible_range_valid) {
+    return false;
+  }
+  *out_t_min = state->visible_range_min_ns;
+  *out_t_max = state->visible_range_max_ns;
+  return true;
+}
+
 const char* toolboxLastError(void* ctx) {
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.write.lastError();
 }
@@ -1080,12 +1096,12 @@ const PJ_parser_write_host_vtable_t kParserWriteVTable = {
 };
 
 const PJ_toolbox_host_vtable_t kToolboxVTable = {
-    PJ_PLUGIN_DATA_API_VERSION, sizeof(PJ_toolbox_host_vtable_t),
-    toolboxLastError,           toolboxCreateDataSource,
-    toolboxEnsureTopic,         toolboxEnsureField,
-    toolboxAppendRecord,        toolboxAppendRecordFast,
-    toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
-    toolboxReadSeries,
+    PJ_PLUGIN_DATA_API_VERSION,      sizeof(PJ_toolbox_host_vtable_t),
+    toolboxLastError,                toolboxCreateDataSource,
+    toolboxEnsureTopic,              toolboxEnsureField,
+    toolboxAppendRecord,             toolboxAppendRecordFast,
+    toolboxAppendArrowIpc,           toolboxAcquireCatalogSnapshot,
+    toolboxReadSeries,               toolboxGetVisibleRange,
 };
 
 DatastoreSourceWriteHost::DatastoreSourceWriteHost(DataEngine& engine, DataSourceHandle source)
@@ -1128,6 +1144,16 @@ PJ_toolbox_host_t DatastoreToolboxHost::raw() noexcept {
 
 void DatastoreToolboxHost::flushPending() {
   state_->core.write.flushPending();
+}
+
+void DatastoreToolboxHost::setVisibleRange(int64_t t_min_ns, int64_t t_max_ns) {
+  state_->visible_range_valid = true;
+  state_->visible_range_min_ns = t_min_ns;
+  state_->visible_range_max_ns = t_max_ns;
+}
+
+void DatastoreToolboxHost::clearVisibleRange() {
+  state_->visible_range_valid = false;
 }
 
 }  // namespace PJ

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -89,6 +89,7 @@ PJ_toolbox_host_t makeToolboxHost(MinimalToolboxHost* recorder) {
       .append_arrow_ipc = MinimalToolboxHost::appendArrowIpc,
       .acquire_catalog_snapshot = MinimalToolboxHost::acquireCatalogSnapshot,
       .read_series = MinimalToolboxHost::readSeries,
+      .get_visible_range = nullptr,
   };
   return PJ_toolbox_host_t{.ctx = recorder, .vtable = &vtable};
 }

--- a/pj_proto_app/src/chart_panel.cpp
+++ b/pj_proto_app/src/chart_panel.cpp
@@ -170,6 +170,7 @@ void ChartPanel::wheelEvent(QWheelEvent* event) {
   double x_max = x_axis_->max();
   x_axis_->setRange(mouse_x_s - (mouse_x_s - x_min) * factor, mouse_x_s + (x_max - mouse_x_s) * factor);
   user_zoom_ = true;
+  emitVisibleRange();
   event->accept();
 }
 
@@ -221,10 +222,17 @@ void ChartPanel::mouseReleaseEvent(QMouseEvent* event) {
   if (event->button() == Qt::MiddleButton && is_panning_) {
     is_panning_ = false;
     setCursor(Qt::ArrowCursor);
+    emitVisibleRange();
     event->accept();
     return;
   }
   QChartView::mouseReleaseEvent(event);
+}
+
+void ChartPanel::emitVisibleRange() {
+  auto t_min = first_timestamp_ + static_cast<PJ::Timestamp>(x_axis_->min() * 1e9);
+  auto t_max = first_timestamp_ + static_cast<PJ::Timestamp>(x_axis_->max() * 1e9);
+  emit visibleRangeChanged(t_min, t_max);
 }
 
 }  // namespace proto

--- a/pj_proto_app/src/chart_panel.hpp
+++ b/pj_proto_app/src/chart_panel.hpp
@@ -37,6 +37,8 @@ class ChartPanel : public QChartView {
 
  signals:
   void seriesDropped();
+  /// Emitted when the user zooms or pans the chart. Values are absolute timestamps.
+  void visibleRangeChanged(PJ::Timestamp t_min, PJ::Timestamp t_max);
 
  protected:
   void dragEnterEvent(QDragEnterEvent* event) override;
@@ -50,6 +52,8 @@ class ChartPanel : public QChartView {
   void mouseDoubleClickEvent(QMouseEvent* event) override;
 
  private:
+  void emitVisibleRange();
+
   const PJ::DataEngine& engine_;
   QValueAxis* x_axis_;
   QValueAxis* y_axis_;


### PR DESCRIPTION
## Motivation

In PJ 3.x, the FFT toolbox has a "Only data in zoomed area" radio button. When selected, the FFT is computed only on the time window currently visible in the main chart — so zooming into a 2-second region and clicking Calculate gives the frequency spectrum of just those 2 seconds, not the entire recording.

To port this feature, toolbox plugins need a way to ask the host: "what time range is the user looking at right now?" Without this API, the plugin has no access to the main chart's viewport — it can only process all data or rely on the user to manually type a time range.

## Summary

- Add `get_visible_range` to the toolbox host C ABI — returns the current viewport as `(t_min_ns, t_max_ns)`, or `false` if no data is loaded
- C++ wrapper: `ToolboxHostView::visibleRange()` returns `std::optional<pair<int64_t, int64_t>>` with `nullptr` guard for older hosts
- `DatastoreToolboxHost::setVisibleRange` / `clearVisibleRange` for the application to push viewport updates
- `ChartPanel` emits `visibleRangeChanged` on wheel zoom and pan release

## How the FFT uses it

```cpp
// FFTToolbox::refreshInputPreview()
auto host = toolboxHost();
const auto visible = host.visibleRange();

// If "Only data in zoomed area" is selected and we have a valid range:
if (dialog_.rangeZoomed() && visible && visible->second > visible->first) {
    t_min = std::max(t_min, visible->first);
    t_max = std::min(t_max, visible->second);
}
// Then only samples within [t_min, t_max] are used for the FFT
```

The preview chart and the FFT computation both honor this range, updating dynamically as the user zooms or pans the main chart.

## Test plan
- [x] Build `pj_datastore` and `pj_proto_app` — no compile errors
- [x] Zoom/pan the main chart — `visibleRange()` returns updated values from a toolbox plugin
- [x] No data loaded — `visibleRange()` returns `std::nullopt`
- [x] Existing toolbox host tests still pass
