### PR TITLE
fix(toolbox): persist config on dialog close regardless of accept/reject

### DIFF
--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -98,10 +98,13 @@ bool ToolboxSession::runDialog(QWidget* parent) {
   auto result = dialog_engine.showDialog(parent);
   dialog_running_ = false;
 
-  if (result == PJ::DialogResult::kRejected) return false;
-
+  // Always persist the plugin's config after the dialog closes, regardless of
+  // whether the user clicked OK or Close/X. Toolbox dialogs (unlike file-open
+  // dialogs) are persistent workspaces — closing them should not discard state.
   (void)handle_.loadConfig(dialog_engine.savedConfig());
   flushPending();
+
+  if (result == PJ::DialogResult::kRejected) return false;
   return true;
 }
 

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -1,0 +1,127 @@
+#include "toolbox_session.hpp"
+
+#include <iostream>
+
+#include "pj_plugins/host_qt/dialog_engine.hpp"
+
+namespace proto {
+
+// ---------------------------------------------------------------------------
+// Runtime host vtable — captureless C callbacks via context pointer
+// ---------------------------------------------------------------------------
+
+static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
+    .protocol_version = PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION,
+    .struct_size = sizeof(PJ_toolbox_runtime_host_vtable_t),
+
+    .get_last_error =
+        [](void* ctx) -> const char* {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          return s->last_error.empty() ? nullptr : s->last_error.c_str();
+        },
+
+    .report_message =
+        [](void* ctx, PJ_toolbox_message_level_t level, PJ_string_view_t msg) {
+          (void)ctx;
+          const char* lvl = level == PJ_TOOLBOX_MESSAGE_ERROR     ? "ERROR"
+                            : level == PJ_TOOLBOX_MESSAGE_WARNING ? "WARNING"
+                                                                  : "INFO";
+          std::cerr << "[Toolbox " << lvl << "] " << std::string(msg.data, msg.size) << "\n";
+        },
+
+    .notify_data_changed =
+        [](void* ctx) {
+          auto* s = static_cast<ToolboxSession::RuntimeState*>(ctx);
+          if (s->session) emit s->session->dataChanged();
+        },
+};
+
+// ---------------------------------------------------------------------------
+// ToolboxSession
+// ---------------------------------------------------------------------------
+
+ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                               std::string name, QObject* parent)
+    : QObject(parent),
+      engine_(engine),
+      library_(library),
+      name_(std::move(name)),
+      handle_(library_.createHandle()) {}
+
+bool ToolboxSession::init(const std::string& config_json) {
+  if (!handle_.valid()) return false;
+
+  toolbox_host_ = std::make_unique<PJ::DatastoreToolboxHost>(engine_);
+  runtime_state_.session = this;
+
+  if (!handle_.bindToolboxHost(toolbox_host_->raw())) {
+    std::cerr << "Toolbox '" << name_ << "': bindToolboxHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  auto runtime_host = makeRuntimeHost(this);
+  if (!handle_.bindRuntimeHost(runtime_host)) {
+    std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!config_json.empty() && config_json != "{}") {
+    (void)handle_.loadConfig(config_json);
+  }
+
+  return true;
+}
+
+bool ToolboxSession::hasDialog() const {
+  return handle_.valid() &&
+         (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_HAS_DIALOG) != 0;
+}
+
+bool ToolboxSession::runDialog(QWidget* parent) {
+  if (!hasDialog()) return false;
+  if (dialog_running_) return false;  // prevent re-entrant opens on non-modal dialogs
+
+  auto vt_result = library_.resolveDialogVtable();
+  if (!vt_result) return false;
+
+  auto* dialog_ctx = handle_.dialogContext();
+  if (dialog_ctx == nullptr) return false;
+
+  auto dialog_handle = PJ::DialogHandle::borrowed(*vt_result, dialog_ctx);
+
+  PJ::DialogEngineConfig config;
+  config.non_modal = isNonModal();
+
+  PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
+
+  dialog_running_ = true;
+  auto result = dialog_engine.showDialog(parent);
+  dialog_running_ = false;
+
+  if (result == PJ::DialogResult::kRejected) return false;
+
+  (void)handle_.loadConfig(dialog_engine.savedConfig());
+  flushPending();
+  return true;
+}
+
+std::string ToolboxSession::saveConfig() const {
+  return handle_.valid() ? handle_.saveConfig() : "{}";
+}
+
+void ToolboxSession::flushPending() {
+  if (toolbox_host_) toolbox_host_->flushPending();
+}
+
+bool ToolboxSession::isNonModal() const {
+  return handle_.valid() && (handle_.capabilities() & PJ_TOOLBOX_CAPABILITY_NON_MODAL_DIALOG) != 0;
+}
+
+PJ_toolbox_runtime_host_t ToolboxSession::makeRuntimeHost(ToolboxSession* self) {
+  return PJ_toolbox_runtime_host_t{
+      .ctx = &self->runtime_state_,
+      .vtable = &kRuntimeVtable,
+  };
+}
+
+}  // namespace proto

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+#include <string>
+
+#include "pj_base/toolbox_protocol.h"
+#include "pj_datastore/engine.hpp"
+#include "pj_datastore/plugin_data_host.hpp"
+#include "pj_plugins/host/toolbox_handle.hpp"
+#include "pj_plugins/host/toolbox_library.hpp"
+#include "plugin_registry.hpp"
+
+namespace proto {
+
+class ToolboxSession : public QObject {
+  Q_OBJECT
+
+ public:
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+                 QObject* parent = nullptr);
+
+  /// Bind hosts and load persisted config. Returns false on error.
+  bool init(const std::string& config_json = "{}");
+
+  /// Open the plugin's dialog (modal or non-modal per capability). Returns true if accepted.
+  bool runDialog(QWidget* parent);
+
+  /// Flush any pending writes to the DataEngine.
+  void flushPending();
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] bool hasDialog() const;
+  [[nodiscard]] std::string saveConfig() const;
+
+ signals:
+  void dataChanged();
+
+ public:
+  // Public so the file-scope static vtable lambdas can cast to it.
+  struct RuntimeState {
+    std::string last_error;
+    ToolboxSession* session = nullptr;
+  };
+
+ private:
+  static PJ_toolbox_runtime_host_t makeRuntimeHost(ToolboxSession* self);
+
+  bool isNonModal() const;
+
+  PJ::DataEngine& engine_;
+  PJ::ToolboxLibrary& library_;
+  std::string name_;
+  PJ::ToolboxHandle handle_;
+  std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;
+
+  // Runtime host state — must outlive handle_
+  RuntimeState runtime_state_;
+  bool dialog_running_ = false;
+};
+
+}  // namespace proto


### PR DESCRIPTION
## Motivation

Toolbox plugins (FFT, Quaternion, ColorMap, etc.) are persistent workspaces — unlike file-open dialogs where Cancel means "don't load", a toolbox dialog is a work area where the user configures parameters, selects fields, adjusts settings, and may run computations. Closing the dialog (whether with OK, Close, or the X button) should not discard that work.

**The bug:** In the current code, `loadConfig` (which persists the plugin's state) only runs if the user clicks OK. If the user clicks Close or the X button, `runDialog` returns early before saving, and the plugin's configuration is lost. The next time the user opens the toolbox, it starts from scratch.

**In PJ 3.x**, toolbox panels were permanently visible in the main window — there was no "close and lose state" problem. In the new SDK, toolboxes open as dialogs that can be closed, so we need to explicitly persist state on every close.

**Concrete example:** The FFT toolbox lets the user select fields, toggle "Remove DC", choose "All data" vs "Only zoomed area", and set a suffix for saved curves. If the user configures all of this, runs an FFT, then closes the dialog to look at the chart, they expect to reopen the FFT dialog and find everything as they left it — not a blank slate.

## Summary

- Move `loadConfig` and `flushPending` before the rejected-early-return so config is always saved after the dialog closes
- The return value of `runDialog` still distinguishes accept vs reject for callers that care

## Test plan
- [x] Open a toolbox dialog, change parameters, click Close (X) — reopen, parameters preserved
- [x] Open a toolbox dialog, change parameters, click OK — parameters preserved (unchanged)
- [x] Open a toolbox dialog, change nothing, click Close — no crash, no side effects
