### PR TITLE
feat(proto-app): add Tools menu with dynamic toolbox plugin discovery

### DIFF
--- a/pj_proto_app/CMakeLists.txt
+++ b/pj_proto_app/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(pj_proto_app
   src/main_window.cpp
   src/plugin_registry.cpp
   src/data_source_session.cpp
+  src/toolbox_session.cpp
   src/series_tree_model.cpp
   src/chart_panel.cpp
   src/time_range_slider.cpp

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -187,6 +187,10 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
   });
   connect(&refresh_timer_, &QTimer::timeout, this, &MainWindow::onRefreshTimer);
 
+  // --- Tools menu ---
+  auto* tools_menu = menuBar()->addMenu("&Tools");
+  setupToolboxPanels(tools_menu);
+
   setWindowTitle("PlotJuggler Proto");
 }
 
@@ -689,6 +693,36 @@ void MainWindow::onOpenMarketplace() {
   window.exec();
   if (window.installationsChanged()) {
     registry_.reload();
+  }
+}
+
+void MainWindow::setupToolboxPanels(QMenu* tools_menu) {
+  for (const auto& tb : registry_.allToolboxes()) {
+    auto session =
+        std::make_unique<ToolboxSession>(engine_, const_cast<PJ::ToolboxLibrary&>(tb.library), tb.name, this);
+    if (!session->init()) {
+      continue;
+    }
+
+    connect(session.get(), &ToolboxSession::dataChanged, this, [this]() {
+      auto [begin, end] = computeVisibleRange();
+      chart_panel_->updateData(begin, end);
+      tree_model_.rebuildIfChanged();
+    });
+
+    ToolboxSession* raw_session = session.get();
+
+    tools_menu->addAction(QString::fromStdString(tb.name), this, [this, raw_session]() {
+      if (raw_session->hasDialog()) {
+        if (raw_session->runDialog(this)) {
+          auto [begin, end] = computeVisibleRange();
+          chart_panel_->updateData(begin, end);
+          tree_model_.rebuildIfChanged();
+        }
+      }
+    });
+
+    toolbox_sessions_.push_back(std::move(session));
   }
 }
 

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
 #include <QSpinBox>
 #include <QSplitter>
 #include <QTimer>
@@ -13,6 +15,7 @@
 #include "pj_datastore/engine.hpp"
 #include "plugin_registry.hpp"
 #include "series_tree_model.hpp"
+#include "toolbox_session.hpp"
 
 #include "pj_marketplace/extension_manager.hpp"
 
@@ -43,6 +46,8 @@ class MainWindow : public QMainWindow {
   void onTreeContextMenu(const QPoint& pos);
 
  private:
+  void setupToolboxPanels(QMenu* tools_menu);
+
   /// Compute the current visible time range based on data and streaming state.
   std::pair<PJ::Timestamp, PJ::Timestamp> computeVisibleRange() const;
 
@@ -66,6 +71,8 @@ class MainWindow : public QMainWindow {
   QTimer refresh_timer_;
   int refresh_tick_ = 0;
   bool streaming_active_ = false;
+
+  std::vector<std::unique_ptr<ToolboxSession>> toolbox_sessions_;
 };
 
 }  // namespace proto


### PR DESCRIPTION
## Motivation

Without this change, there is no way to open toolbox plugins (FFT, Quaternion, ColorMap, etc.) from the application UI. The `ToolboxSession` and `PluginRegistry` infrastructure exists, but nothing in `MainWindow` wires them to the user interface.

In PJ 3.x, toolbox plugins appear under a "Tools" menu. This PR adds the equivalent to proto_app.

## Summary

- Add a **Tools** menu to `MainWindow` via `menuBar()->addMenu("&Tools")`
- `setupToolboxPanels()` iterates `registry_.allToolboxes()`, creates a `ToolboxSession` per plugin, and adds a menu action that opens the plugin's dialog via `runDialog()`
- After the dialog closes, the chart and series tree are refreshed to reflect any data changes the toolbox produced
- Toolbox plugins are discovered dynamically at startup — no hardcoded list

## Test plan
- [x] Build `pj_proto_app` — no compile errors
- [x] Place a Toolbox `.so` plugin in the plugin directory — it appears in the Tools menu
- [x] Click the menu action — the plugin's dialog opens
- [x] Close the dialog after making changes — chart and series tree refresh
- [x] No toolbox plugins installed — Tools menu is empty (no crash)
