### PR TITLE
feat(dialog-sdk): interactive zoom on ChartPreviewWidget with onChartViewChanged event

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -184,6 +184,11 @@ class WidgetDataView {
     return result;
   }
 
+  /// Returns whether interactive zoom is enabled on this chart widget.
+  [[nodiscard]] std::optional<bool> chartZoomEnabled(std::string_view name) const {
+    return getBool(name, "chart_zoom_enabled");
+  }
+
   // --- QPlainTextEdit ---
   [[nodiscard]] std::optional<std::string> plainText(std::string_view name) const {
     return getString(name, "plain_text");

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -108,6 +108,16 @@ struct WidgetEventBuilder {
     j["items_dropped"] = labels;
     return j.dump();
   }
+
+  /// ChartPreviewWidget: visible range changed via zoom or pan.
+  [[nodiscard]] static std::string chartViewChanged(double x_min, double x_max, double y_min, double y_max) {
+    nlohmann::json j;
+    j["chart_x_min"] = x_min;
+    j["chart_x_max"] = x_max;
+    j["chart_y_min"] = y_min;
+    j["chart_y_max"] = y_max;
+    return j.dump();
+  }
 };
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host_qt/chart_preview_widget.hpp
@@ -7,6 +7,7 @@
 
 QT_BEGIN_NAMESPACE
 class QValueAxis;
+class QWheelEvent;
 QT_END_NAMESPACE
 
 namespace PJ {
@@ -28,9 +29,24 @@ class ChartPreviewWidget : public QChartView {
   void setSeries(const std::vector<Series>& series);
   void clearSeries();
 
+  /// Enable or disable interactive zoom (rubber band + mouse wheel).
+  /// When enabled, viewChanged() is emitted whenever the user zooms or pans.
+  void setZoomEnabled(bool enabled);
+
+ signals:
+  /// Emitted when the visible axes range changes due to user zoom or pan.
+  /// Only emitted when zoom is enabled via setZoomEnabled(true).
+  void viewChanged(double x_min, double x_max, double y_min, double y_max);
+
+ protected:
+  void wheelEvent(QWheelEvent* event) override;
+
  private:
   QValueAxis* x_axis_ = nullptr;
   QValueAxis* y_axis_ = nullptr;
+  bool zoom_enabled_ = false;
+
+  void emitViewChanged();
 };
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -67,11 +67,21 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  /// ChartPreviewWidget: zoom or pan changed the visible range.
+  /// Only called when the plugin has declared setChartZoomEnabled for this widget.
+  virtual bool onChartViewChanged(std::string_view /*widget_name*/, double /*x_min*/, double /*x_max*/,
+                                  double /*y_min*/, double /*y_max*/) {
+    return false;
+  }
+
  private:
   /// Parses event_json and dispatches to the appropriate typed virtual above.
   bool onWidgetEvent(std::string_view widget_name, std::string_view event_json) final {
     WidgetEvent event(event_json);
 
+    if (auto v = event.chartViewChanged()) {
+      return onChartViewChanged(widget_name, v->x_min, v->x_max, v->y_min, v->y_max);
+    }
     if (auto v = event.itemsDropped()) {
       return onItemsDropped(widget_name, *v);
     }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -138,6 +138,13 @@ class WidgetData {
     return *this;
   }
 
+  /// Enable interactive zoom (rubber band + mouse wheel) on the chart inside the named QFrame.
+  /// When enabled, onChartViewChanged() is called whenever the user zooms or pans.
+  WidgetData& setChartZoomEnabled(std::string_view name, bool enabled = true) {
+    entry(name)["chart_zoom_enabled"] = enabled;
+    return *this;
+  }
+
   // --- QPlainTextEdit ---
   WidgetData& setPlainText(std::string_view name, std::string_view text) {
     entry(name)["plain_text"] = text;

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -115,6 +115,26 @@ class WidgetEvent {
     return result;
   }
 
+  /// ChartPreviewWidget: visible range changed via zoom or pan.
+  struct ChartViewState {
+    double x_min;
+    double x_max;
+    double y_min;
+    double y_max;
+  };
+
+  std::optional<ChartViewState> chartViewChanged() const {
+    auto xmin = data_.find("chart_x_min");
+    auto xmax = data_.find("chart_x_max");
+    auto ymin = data_.find("chart_y_min");
+    auto ymax = data_.find("chart_y_max");
+    if (xmin == data_.end() || !xmin->is_number() || xmax == data_.end() || !xmax->is_number() ||
+        ymin == data_.end() || !ymin->is_number() || ymax == data_.end() || !ymax->is_number()) {
+      return std::nullopt;
+    }
+    return ChartViewState{xmin->get<double>(), xmax->get<double>(), ymin->get<double>(), ymax->get<double>()};
+  }
+
   /// Check if a key exists in the event data
   bool has(std::string_view key) const {
     return data_.contains(std::string(key));

--- a/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
+++ b/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
@@ -3,6 +3,8 @@
 #include <QColor>
 #include <QPen>
 #include <QPointF>
+#include <QSignalBlocker>
+#include <QWheelEvent>
 #include <QtCharts/QChart>
 #include <QtCharts/QLegendMarker>
 #include <QtCharts/QLineSeries>
@@ -35,9 +37,15 @@ ChartPreviewWidget::ChartPreviewWidget(QWidget* parent) : QChartView(new QChart(
   chart()->legend()->setVisible(true);
   chart()->legend()->setAlignment(Qt::AlignBottom);
   chart()->setMargins(QMargins(4, 4, 4, 4));
+
+  // Emit viewChanged when axes change. QSignalBlocker(this) in setSeries/clearSeries
+  // suppresses spurious emissions during programmatic data updates.
+  QObject::connect(x_axis_, &QValueAxis::rangeChanged, this, [this](qreal, qreal) { emitViewChanged(); });
+  QObject::connect(y_axis_, &QValueAxis::rangeChanged, this, [this](qreal, qreal) { emitViewChanged(); });
 }
 
 void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
+  const QSignalBlocker blocker(this);  // suppress viewChanged during programmatic data update
   chart()->removeAllSeries();
 
   double x_min = std::numeric_limits<double>::max();
@@ -110,7 +118,33 @@ void ChartPreviewWidget::setSeries(const std::vector<Series>& series) {
 }
 
 void ChartPreviewWidget::clearSeries() {
+  const QSignalBlocker blocker(this);  // suppress viewChanged during programmatic data clear
   chart()->removeAllSeries();
+}
+
+void ChartPreviewWidget::setZoomEnabled(bool enabled) {
+  zoom_enabled_ = enabled;
+  setRubberBand(enabled ? QChartView::RectangleRubberBand : QChartView::NoRubberBand);
+}
+
+void ChartPreviewWidget::wheelEvent(QWheelEvent* event) {
+  if (!zoom_enabled_) {
+    QChartView::wheelEvent(event);
+    return;
+  }
+  auto delta = event->angleDelta().y();
+  if (delta != 0) {
+    // factor > 1 zooms in (shows less range), factor < 1 zooms out.
+    chart()->zoom(delta > 0 ? 1.25 : 0.8);
+  }
+  event->accept();
+}
+
+void ChartPreviewWidget::emitViewChanged() {
+  if (!zoom_enabled_) {
+    return;
+  }
+  emit viewChanged(x_axis_->min(), x_axis_->max(), y_axis_->min(), y_axis_->max());
 }
 
 }  // namespace PJ

--- a/pj_plugins/dialog_protocol/src/widget_binding.cpp
+++ b/pj_plugins/dialog_protocol/src/widget_binding.cpp
@@ -271,9 +271,11 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
     return;
   }
 
-  // --- QFrame with chart_series → ChartPreviewWidget ---
+  // --- QFrame with chart_series or chart_zoom_enabled → ChartPreviewWidget ---
   if (auto* frame = qobject_cast<QFrame*>(w)) {
-    if (auto series_data = view.chartSeries(name)) {
+    auto series_data = view.chartSeries(name);
+    auto zoom_enabled = view.chartZoomEnabled(name);
+    if (series_data || zoom_enabled) {
       // Find or create the ChartPreviewWidget inside this frame.
       auto* chart = frame->findChild<PJ::ChartPreviewWidget*>();
       if (!chart) {
@@ -285,13 +287,18 @@ static void apply_to_widget(QWidget* w, std::string_view name, const PJ::WidgetD
         chart = new PJ::ChartPreviewWidget(frame);
         layout->addWidget(chart);
       }
-      // Convert WidgetDataView series to ChartPreviewWidget series.
-      std::vector<PJ::ChartPreviewWidget::Series> chart_series;
-      chart_series.reserve(series_data->size());
-      for (const auto& s : *series_data) {
-        chart_series.push_back({s.label, s.points, s.color});
+      if (series_data) {
+        // Convert WidgetDataView series to ChartPreviewWidget series.
+        std::vector<PJ::ChartPreviewWidget::Series> chart_series;
+        chart_series.reserve(series_data->size());
+        for (const auto& s : *series_data) {
+          chart_series.push_back({s.label, s.points, s.color});
+        }
+        chart->setSeries(chart_series);
       }
-      chart->setSeries(chart_series);
+      if (zoom_enabled) {
+        chart->setZoomEnabled(*zoom_enabled);
+      }
     }
     return;
   }
@@ -327,6 +334,21 @@ static bool is_internal_widget_name(const QString& name) {
 
 void connectWidgetSignals(QWidget* root, WidgetEventCallback callback) {
   using PJ::WidgetEventBuilder;
+
+  // ChartPreviewWidget instances are unnamed children of their parent QFrame.
+  // Wire their viewChanged signals using the parent frame's objectName as the event widget name.
+  // Must run after applyWidgetData() so charts that were created on first apply are found here.
+  for (auto* chart : root->findChildren<PJ::ChartPreviewWidget*>()) {
+    auto* parent_frame = qobject_cast<QFrame*>(chart->parent());
+    if (!parent_frame || parent_frame->objectName().isEmpty()) {
+      continue;
+    }
+    std::string chart_name = parent_frame->objectName().toStdString();
+    QObject::connect(chart, &PJ::ChartPreviewWidget::viewChanged, chart,
+                     [callback, chart_name](double x_min, double x_max, double y_min, double y_max) {
+                       callback(chart_name, WidgetEventBuilder::chartViewChanged(x_min, x_max, y_min, y_max));
+                     });
+  }
 
   for (auto* w : root->findChildren<QWidget*>()) {
     QString qname = w->objectName();


### PR DESCRIPTION
## Motivation

In PJ 3.x, the FFT toolbox has a "Only data in zoomed area" mode where the user zooms in the embedded input chart and the FFT recalculates using only the visible range. The current Dialog SDK has `ChartPreviewWidget` for embedded charts, but it is static — no zoom, no pan, no events.

This PR adds interactive zoom to `ChartPreviewWidget` so plugins can replicate this behavior: the user zooms in the embedded chart, the plugin receives `onChartViewChanged()`, and reacts accordingly.

## Summary

- `WidgetData::setChartZoomEnabled(name)` — plugin declares which charts should be interactive
- `ChartPreviewWidget::setZoomEnabled()` — enables rubber band zoom + mouse wheel zoom
- `viewChanged()` signal emitted on zoom/pan with the new axis range
- `WidgetEventBuilder::chartViewChanged(x_min, x_max, y_min, y_max)` — event JSON
- `WidgetEvent::chartViewChanged()` — parser with `ChartViewState` struct
- `DialogPluginTyped::onChartViewChanged()` — virtual for the plugin to override
- `widget_binding` wires `viewChanged` to the event callback in `connectWidgetSignals()`

## Test plan
- [x] Build `pj_plugins` — no compile errors
- [x] Set `setChartZoomEnabled("my_chart")` — chart becomes zoomable (rubber band + wheel)
- [x] Zoom the chart — `onChartViewChanged` fires with correct axis range
- [x] Chart without `setChartZoomEnabled` — remains static (unchanged behavior)
