### PR TITLE
fix(dialog-sdk): disable acceptDrops on ChartPreviewWidget for DropEventFilter compatibility

### DIFF
--- a/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
+++ b/pj_plugins/dialog_protocol/src/chart_preview_widget.cpp
@@ -29,6 +29,11 @@ const std::vector<QColor>& kDefaultPalette() {
 ChartPreviewWidget::ChartPreviewWidget(QWidget* parent) : QChartView(new QChart(), parent) {
   setRenderHint(QPainter::Antialiasing);
 
+  // Let drag events pass through to the parent frame so the dialog-level
+  // DropEventFilter can handle them. QGraphicsView accepts drops by default.
+  setAcceptDrops(false);
+  viewport()->setAcceptDrops(false);
+
   x_axis_ = new QValueAxis();
   y_axis_ = new QValueAxis();
   chart()->addAxis(x_axis_, Qt::AlignBottom);


### PR DESCRIPTION
## Summary

QGraphicsView (parent of QChartView/ChartPreviewWidget) enables `acceptDrops` by default. This causes it to consume drag-drop events silently, preventing them from reaching the dialog-level DropEventFilter.

Fix: disable `acceptDrops` on both the widget and its viewport in the constructor, so drag events propagate to the parent QFrame where the DropEventFilter can handle them.

Discovered when porting the FFT toolbox — drag-drop onto the input chart area didn't work because QGraphicsView was eating the events.

## Test plan
- [x] Drag a field from the series tree onto a QFrame containing a ChartPreviewWidget — drop event reaches the plugin
- [x] ChartPreviewWidget still renders series correctly (no regression)
