### PR TITLE
fix(series_tree_model): include topic name in data labels

### DIFF
--- a/pj_proto_app/src/series_tree_model.cpp
+++ b/pj_proto_app/src/series_tree_model.cpp
@@ -348,9 +348,11 @@ QMimeData* SeriesTreeModel::mimeData(const QModelIndexList& indexes) const {
       continue;
     }
 
-    const auto& field = datasets_[ds_idx].topics[topic_idx].fields[row];
+    const auto& topic = datasets_[ds_idx].topics[topic_idx];
+    const auto& field = topic.fields[row];
+    std::string qualified_name = topic.name + "/" + field.name;
     stream << static_cast<quint32>(field.topic_id) << static_cast<quint32>(field.col_index)
-           << QString::fromStdString(field.name);
+           << QString::fromStdString(qualified_name);
     ++count;
   }
 


### PR DESCRIPTION
## Summary

Include the fully-qualified topic path in the drag-and-drop MIME label so dropped series show their complete namespace (e.g. `/imu/orientation/x`) instead of only the leaf field name (`x`). This avoids name collisions across topics and makes the dragged item unambiguous on the drop target.

## Test plan
- [x] Drag a field from the series tree onto a plugin dialog — the full path appears (e.g. `/imu/orientation/x`), not just the leaf name
- [x] Fields from different topics with the same leaf name are distinguishable
