### PR TITLE
feat(sdk): add registerColorMap/unregisterColorMap to toolbox host ABI

### DIFF
--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -206,6 +206,18 @@ typedef struct PJ_toolbox_host_vtable_t {
       void* ctx, PJ_topic_handle_t topic, PJ_bytes_view_t ipc_stream, PJ_string_view_t timestamp_column);
   bool (*acquire_catalog_snapshot)(void* ctx, PJ_catalog_snapshot_t* out_snapshot);
   bool (*read_series)(void* ctx, PJ_field_handle_t field, PJ_materialized_series_t* out_series);
+
+  /** Register a named colormap backed by a plugin-side callback.
+   *  eval_fn receives a scalar value and returns a color string (CSS name or "#rrggbb").
+   *  The returned pointer is plugin-owned and must remain valid until the next call.
+   *  The host stores the callback; the chart renderer calls it per data point.
+   *  Returns false if a colormap with the same name already exists. */
+  bool (*register_colormap)(void* ctx, PJ_string_view_t name,
+                            const char* (*eval_fn)(double value, void* user_ctx),
+                            void* user_ctx);
+
+  /** Unregister a previously registered colormap by name. */
+  bool (*unregister_colormap)(void* ctx, PJ_string_view_t name);
 } PJ_toolbox_host_vtable_t;
 
 typedef struct {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -563,6 +563,34 @@ class ToolboxHostView {
     return MaterializedSeries(raw);
   }
 
+  /// Register a named colormap backed by a plugin-side callback.
+  /// The callback receives a scalar value and returns a color string ("#rrggbb" or CSS name).
+  /// The host stores the callback and invokes it from the chart renderer per data point.
+  using ColorMapEvalFn = const char* (*)(double value, void* user_ctx);
+
+  [[nodiscard]] Status registerColorMap(std::string_view name,
+                                        ColorMapEvalFn eval_fn,
+                                        void* user_ctx) const {
+    if (host_.vtable->register_colormap == nullptr) {
+      return unexpected(std::string("register_colormap not supported by this host"));
+    }
+    if (!host_.vtable->register_colormap(host_.ctx, toAbiString(name), eval_fn, user_ctx)) {
+      return unexpected(std::string(lastError()));
+    }
+    return okStatus();
+  }
+
+  /// Unregister a previously registered colormap by name.
+  [[nodiscard]] Status unregisterColorMap(std::string_view name) const {
+    if (host_.vtable->unregister_colormap == nullptr) {
+      return unexpected(std::string("unregister_colormap not supported by this host"));
+    }
+    if (!host_.vtable->unregister_colormap(host_.ctx, toAbiString(name))) {
+      return unexpected(std::string(lastError()));
+    }
+    return okStatus();
+  }
+
   [[nodiscard]] std::string_view lastError() const {
     const char* err = host_.vtable->get_last_error(host_.ctx);
     return err == nullptr ? std::string_view{} : std::string_view(err);

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -955,9 +956,15 @@ struct DatastoreParserWriteHostState {
   TopicHandle topic;
 };
 
+struct ColorMapEntry {
+  const char* (*eval_fn)(double value, void* user_ctx);
+  void* user_ctx;
+};
+
 struct DatastoreToolboxHostState {
   explicit DatastoreToolboxHostState(DataEngine& engine) : core(engine) {}
   ToolboxCore core;
+  std::unordered_map<std::string, ColorMapEntry> colormaps;
 };
 
 bool sourceEnsureTopic(void* ctx, PJ_string_view_t topic_name, TopicHandle* out_topic) {
@@ -1054,6 +1061,24 @@ bool toolboxReadSeries(void* ctx, FieldHandle field, PJ_materialized_series_t* o
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.readSeries(field, out_series);
 }
 
+bool toolboxRegisterColorMap(void* ctx, PJ_string_view_t name,
+                             const char* (*eval_fn)(double, void*), void* user_ctx) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  std::string key(toStringView(name));
+  if (state->colormaps.count(key) > 0) {
+    state->core.write.last_error_ = "colormap '" + key + "' already registered";
+    return false;
+  }
+  state->colormaps[key] = {eval_fn, user_ctx};
+  return true;
+}
+
+bool toolboxUnregisterColorMap(void* ctx, PJ_string_view_t name) {
+  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
+  std::string key(toStringView(name));
+  return state->colormaps.erase(key) > 0;
+}
+
 const char* toolboxLastError(void* ctx) {
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.write.lastError();
 }
@@ -1085,7 +1110,8 @@ const PJ_toolbox_host_vtable_t kToolboxVTable = {
     toolboxEnsureTopic,         toolboxEnsureField,
     toolboxAppendRecord,        toolboxAppendRecordFast,
     toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
-    toolboxReadSeries,
+    toolboxReadSeries,          nullptr,
+    toolboxRegisterColorMap,    toolboxUnregisterColorMap,
 };
 
 DatastoreSourceWriteHost::DatastoreSourceWriteHost(DataEngine& engine, DataSourceHandle source)

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -1110,7 +1110,7 @@ const PJ_toolbox_host_vtable_t kToolboxVTable = {
     toolboxEnsureTopic,         toolboxEnsureField,
     toolboxAppendRecord,        toolboxAppendRecordFast,
     toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
-    toolboxReadSeries,          nullptr,
+    toolboxReadSeries,
     toolboxRegisterColorMap,    toolboxUnregisterColorMap,
 };
 

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -89,6 +89,8 @@ PJ_toolbox_host_t makeToolboxHost(MinimalToolboxHost* recorder) {
       .append_arrow_ipc = MinimalToolboxHost::appendArrowIpc,
       .acquire_catalog_snapshot = MinimalToolboxHost::acquireCatalogSnapshot,
       .read_series = MinimalToolboxHost::readSeries,
+      .register_colormap = nullptr,
+      .unregister_colormap = nullptr,
   };
   return PJ_toolbox_host_t{.ctx = recorder, .vtable = &vtable};
 }


### PR DESCRIPTION
## Motivation

The ColorMap Editor plugin needs to evaluate a Lua function `ColorMap(v)` per data point to determine the chart background color. In PJ 3.x this lived in the app directly. In the new plugin architecture, putting Lua in the core would be wrong — the scripting runtime should stay in the plugin.

This PR adds a service provider pattern: the plugin registers named colormaps as callbacks, and the chart renderer invokes them without knowing what runs inside (Lua, Python, lookup table, etc.).

## Summary

- `register_colormap(name, eval_fn, user_ctx)` in `PJ_toolbox_host_vtable_t` — plugin registers a named callback
- `unregister_colormap(name)` — plugin removes it when closing
- `eval_fn` signature: `const char*(double value, void* user_ctx)` — returns CSS color string
- C++ wrapper: `ToolboxHostView::registerColorMap` / `unregisterColorMap` with nullptr guards
- `ColorMapEntry` registry in `DatastoreToolboxHostState`

## Test plan
- [x] Build `pj_datastore` — no compile errors
- [x] Register a colormap from a toolbox plugin — host stores the callback
- [x] Unregister — callback removed
- [x] Existing toolbox host tests still pass
