### PR TITLE
feat(pj_base): add platform helpers for env and user data dir

### DIFF
--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -47,6 +47,7 @@ if(PJ_BUILD_TESTS)
     tests/data_source_protocol_test.cpp
     tests/data_source_plugin_base_test.cpp
     tests/message_parser_plugin_base_test.cpp
+    tests/platform_test.cpp
   )
 
   foreach(test_src ${PJ_BASE_TESTS})

--- a/pj_base/include/pj_base/sdk/platform.hpp
+++ b/pj_base/include/pj_base/sdk/platform.hpp
@@ -1,0 +1,79 @@
+/**
+ * @file platform.hpp
+ * @brief Qt-free, header-only platform helpers for plugins and core.
+ *
+ * Provides small cross-platform utilities that plugins would otherwise need
+ * to reimplement (and sometimes do incorrectly): reading environment
+ * variables without tripping MSVC's C4996 deprecation warning, and locating
+ * the per-user data directory that mirrors Qt's
+ * QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).
+ *
+ * Header-only so plugins linked against pj_base pick it up via CPM without
+ * pulling additional translation units or Qt dependencies.
+ */
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace PJ::sdk {
+
+/// Read an environment variable.
+///
+/// Returns std::nullopt if the variable is unset or empty. Wraps std::getenv
+/// with a local MSVC C4996 suppression so the call compiles under /W4 /WX
+/// without forcing _CRT_SECURE_NO_WARNINGS project-wide.
+inline std::optional<std::string> getEnv(const char* name) {
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#endif
+  const char* value = std::getenv(name);
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+  if (value == nullptr || *value == '\0') {
+    return std::nullopt;
+  }
+  return std::string{value};
+}
+
+/// Return the per-user data directory used by PlotJuggler and its plugins.
+///
+/// Mirrors Qt's `QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/plotjuggler"`,
+/// so plugins that need on-disk state (script libraries, cached downloads,
+/// etc.) share the same root as the Qt-linked host. Falls back to the
+/// system temp directory when no suitable environment variable is set, so
+/// the returned path is never empty.
+///
+/// Platform resolution:
+/// - Windows: `%LOCALAPPDATA%/plotjuggler`, then `%USERPROFILE%/AppData/Local/plotjuggler`
+/// - macOS:   `$HOME/Library/Application Support/plotjuggler`
+/// - Linux:   `$XDG_DATA_HOME/plotjuggler`, then `$HOME/.local/share/plotjuggler`
+inline std::filesystem::path userDataDir() {
+  namespace fs = std::filesystem;
+#if defined(_WIN32)
+  if (auto v = getEnv("LOCALAPPDATA")) {
+    return fs::path(*v) / "plotjuggler";
+  }
+  if (auto v = getEnv("USERPROFILE")) {
+    return fs::path(*v) / "AppData" / "Local" / "plotjuggler";
+  }
+#elif defined(__APPLE__)
+  if (auto v = getEnv("HOME")) {
+    return fs::path(*v) / "Library" / "Application Support" / "plotjuggler";
+  }
+#else
+  if (auto v = getEnv("XDG_DATA_HOME")) {
+    return fs::path(*v) / "plotjuggler";
+  }
+  if (auto v = getEnv("HOME")) {
+    return fs::path(*v) / ".local" / "share" / "plotjuggler";
+  }
+#endif
+  return fs::temp_directory_path() / "plotjuggler";
+}
+
+}  // namespace PJ::sdk

--- a/pj_base/tests/platform_test.cpp
+++ b/pj_base/tests/platform_test.cpp
@@ -1,0 +1,116 @@
+#include "pj_base/sdk/platform.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace PJ::sdk {
+namespace {
+
+// Thin RAII wrapper so a test can set/unset an env var and restore the
+// previous value on scope exit. Uses setenv/unsetenv on POSIX and
+// _putenv_s on Windows.
+class ScopedEnv {
+ public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    if (auto prev = getEnv(name)) {
+      had_prev_ = true;
+      prev_ = *prev;
+    }
+#if defined(_WIN32)
+    _putenv_s(name_.c_str(), value);
+#else
+    ::setenv(name_.c_str(), value, 1);
+#endif
+  }
+
+  ~ScopedEnv() {
+#if defined(_WIN32)
+    _putenv_s(name_.c_str(), had_prev_ ? prev_.c_str() : "");
+#else
+    if (had_prev_) {
+      ::setenv(name_.c_str(), prev_.c_str(), 1);
+    } else {
+      ::unsetenv(name_.c_str());
+    }
+#endif
+  }
+
+  ScopedEnv(const ScopedEnv&) = delete;
+  ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+ private:
+  std::string name_;
+  bool had_prev_ = false;
+  std::string prev_;
+};
+
+TEST(GetEnvTest, ReturnsValueWhenSet) {
+  ScopedEnv guard("PJ_BASE_TEST_VAR", "hello");
+  auto value = getEnv("PJ_BASE_TEST_VAR");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, "hello");
+}
+
+TEST(GetEnvTest, ReturnsNulloptWhenUnset) {
+  auto value = getEnv("PJ_BASE_TEST_DEFINITELY_UNSET_XYZZY");
+  EXPECT_FALSE(value.has_value());
+}
+
+TEST(GetEnvTest, ReturnsNulloptForEmptyValue) {
+#if defined(_WIN32)
+  _putenv_s("PJ_BASE_TEST_EMPTY", "");
+#else
+  ::setenv("PJ_BASE_TEST_EMPTY", "", 1);
+#endif
+  auto value = getEnv("PJ_BASE_TEST_EMPTY");
+  EXPECT_FALSE(value.has_value());
+#if !defined(_WIN32)
+  ::unsetenv("PJ_BASE_TEST_EMPTY");
+#endif
+}
+
+TEST(UserDataDirTest, EndsWithPlotjuggler) {
+  auto dir = userDataDir();
+  EXPECT_EQ(dir.filename(), "plotjuggler");
+}
+
+TEST(UserDataDirTest, IsAbsolute) {
+  auto dir = userDataDir();
+  EXPECT_TRUE(dir.is_absolute());
+}
+
+#if defined(_WIN32)
+TEST(UserDataDirTest, PrefersLocalAppDataOnWindows) {
+  ScopedEnv guard("LOCALAPPDATA", "C:/tmp/pj_test_localappdata");
+  auto dir = userDataDir();
+  EXPECT_EQ(dir, std::filesystem::path("C:/tmp/pj_test_localappdata") / "plotjuggler");
+}
+#elif defined(__APPLE__)
+TEST(UserDataDirTest, UsesApplicationSupportOnMac) {
+  ScopedEnv guard("HOME", "/tmp/pj_test_home");
+  auto dir = userDataDir();
+  EXPECT_EQ(dir,
+            std::filesystem::path("/tmp/pj_test_home") / "Library" / "Application Support" / "plotjuggler");
+}
+#else
+TEST(UserDataDirTest, PrefersXdgDataHomeOnLinux) {
+  ScopedEnv guard("XDG_DATA_HOME", "/tmp/pj_test_xdg");
+  auto dir = userDataDir();
+  EXPECT_EQ(dir, std::filesystem::path("/tmp/pj_test_xdg") / "plotjuggler");
+}
+
+TEST(UserDataDirTest, FallsBackToHomeLocalShareOnLinux) {
+  // Unset XDG_DATA_HOME so the helper falls through to HOME/.local/share.
+  ::unsetenv("XDG_DATA_HOME");
+  ScopedEnv guard("HOME", "/tmp/pj_test_home");
+  auto dir = userDataDir();
+  EXPECT_EQ(dir,
+            std::filesystem::path("/tmp/pj_test_home") / ".local" / "share" / "plotjuggler");
+}
+#endif
+
+}  // namespace
+}  // namespace PJ::sdk


### PR DESCRIPTION
## Summary

Add `pj_base/sdk/platform.hpp` with two Qt-free, header-only helpers:

- `PJ::sdk::getEnv(name)` — read an env variable into `std::optional<std::string>`, with a local MSVC C4996 suppression so callers compile cleanly under `/W4 /WX`.
- `PJ::sdk::userDataDir()` — cross-platform per-user data directory matching `QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/plotjuggler"`, with a temp-dir fallback.

## Motivation

Plugins that need on-disk state (script libraries, cached downloads) currently reimplement this logic privately because they can't depend on Qt. That leads to duplicated platform `#if` ladders and stumbles like MSVC's C4996 on `std::getenv`. Centralising the helpers in `pj_base` — zero external deps, consumed by every plugin via CPM — gives us one place to fix, test, and evolve.

No existing code is migrated in this PR. Consumers will switch over in follow-ups.

## Test coverage

`pj_base/tests/platform_test.cpp` covers:
- `getEnv` roundtrip (set / unset / empty-string)
- `userDataDir` ends in `plotjuggler` and is absolute
- Per-OS branches: Windows `LOCALAPPDATA`, macOS `Library/Application Support`, Linux `XDG_DATA_HOME` and `HOME/.local/share` fallback

## Downstream

The matching consumer PR in `pj-official-plugins` will remove the local `pjUserDataDir()` implementation in `toolbox_reactive_scripts_editor` and switch to this helper. That PR depends on this one landing on `development` so CPM picks it up on the next CI run.