### PR TITLE
feat(colormap): add ColorMapRegistry service and wire to chart panel

### DIFF
--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -206,24 +206,43 @@ typedef struct PJ_toolbox_host_vtable_t {
       void* ctx, PJ_topic_handle_t topic, PJ_bytes_view_t ipc_stream, PJ_string_view_t timestamp_column);
   bool (*acquire_catalog_snapshot)(void* ctx, PJ_catalog_snapshot_t* out_snapshot);
   bool (*read_series)(void* ctx, PJ_field_handle_t field, PJ_materialized_series_t* out_series);
-
-  /** Register a named colormap backed by a plugin-side callback.
-   *  eval_fn receives a scalar value and returns a color string (CSS name or "#rrggbb").
-   *  The returned pointer is plugin-owned and must remain valid until the next call.
-   *  The host stores the callback; the chart renderer calls it per data point.
-   *  Returns false if a colormap with the same name already exists. */
-  bool (*register_colormap)(void* ctx, PJ_string_view_t name,
-                            const char* (*eval_fn)(double value, void* user_ctx),
-                            void* user_ctx);
-
-  /** Unregister a previously registered colormap by name. */
-  bool (*unregister_colormap)(void* ctx, PJ_string_view_t name);
 } PJ_toolbox_host_vtable_t;
 
 typedef struct {
   void* ctx;
   const PJ_toolbox_host_vtable_t* vtable;
 } PJ_toolbox_host_t;
+
+/**
+ * Colormap registry service — an independent host-provided service for
+ * toolbox plugins that want to publish named colormap callbacks.
+ *
+ * The registry is NOT part of the toolbox-host vtable: it has its own
+ * `ctx` and lives alongside the data/engine host, so plugins that never
+ * deal with colormaps never touch it.
+ *
+ * eval_fn receives a scalar value plus the plugin-provided `user_ctx` and
+ * returns a CSS color name or "#rrggbb" hex string. The returned pointer
+ * is plugin-owned and must remain valid until the next call to the same
+ * callback.
+ */
+typedef struct PJ_colormap_registry_vtable_t {
+  uint32_t protocol_version;
+  uint32_t struct_size;
+
+  /** Register or replace a named colormap. Newly registered map becomes active. */
+  bool (*register_map)(void* ctx, PJ_string_view_t name,
+                       const char* (*eval_fn)(double value, void* user_ctx),
+                       void* user_ctx);
+
+  /** Unregister a colormap by name. Clears the active selection if it matched. */
+  bool (*unregister_map)(void* ctx, PJ_string_view_t name);
+} PJ_colormap_registry_vtable_t;
+
+typedef struct {
+  void* ctx;
+  const PJ_colormap_registry_vtable_t* vtable;
+} PJ_colormap_registry_t;
 
 #ifdef __cplusplus
 }

--- a/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
+++ b/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
@@ -65,6 +65,24 @@ inline bool ToolboxPluginBase::trampoline_bind_runtime_host(void* ctx, PJ_toolbo
   }
 }
 
+inline bool ToolboxPluginBase::trampoline_bind_colormap_registry(void* ctx, PJ_colormap_registry_t registry) {
+  auto* self = static_cast<ToolboxPluginBase*>(ctx);
+  try {
+    auto status = self->bindColorMapRegistry(registry);
+    if (!status) {
+      self->last_error_ = std::move(status).error();
+      return false;
+    }
+    return true;
+  } catch (const std::exception& e) {
+    self->last_error_ = e.what();
+    return false;
+  } catch (...) {
+    self->last_error_ = "Unknown exception in bind_colormap_registry";
+    return false;
+  }
+}
+
 inline const char* ToolboxPluginBase::trampoline_save_config(void* ctx) {
   auto* self = static_cast<ToolboxPluginBase*>(ctx);
   try {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -563,34 +563,6 @@ class ToolboxHostView {
     return MaterializedSeries(raw);
   }
 
-  /// Register a named colormap backed by a plugin-side callback.
-  /// The callback receives a scalar value and returns a color string ("#rrggbb" or CSS name).
-  /// The host stores the callback and invokes it from the chart renderer per data point.
-  using ColorMapEvalFn = const char* (*)(double value, void* user_ctx);
-
-  [[nodiscard]] Status registerColorMap(std::string_view name,
-                                        ColorMapEvalFn eval_fn,
-                                        void* user_ctx) const {
-    if (host_.vtable->register_colormap == nullptr) {
-      return unexpected(std::string("register_colormap not supported by this host"));
-    }
-    if (!host_.vtable->register_colormap(host_.ctx, toAbiString(name), eval_fn, user_ctx)) {
-      return unexpected(std::string(lastError()));
-    }
-    return okStatus();
-  }
-
-  /// Unregister a previously registered colormap by name.
-  [[nodiscard]] Status unregisterColorMap(std::string_view name) const {
-    if (host_.vtable->unregister_colormap == nullptr) {
-      return unexpected(std::string("unregister_colormap not supported by this host"));
-    }
-    if (!host_.vtable->unregister_colormap(host_.ctx, toAbiString(name))) {
-      return unexpected(std::string(lastError()));
-    }
-    return okStatus();
-  }
-
   [[nodiscard]] std::string_view lastError() const {
     const char* err = host_.vtable->get_last_error(host_.ctx);
     return err == nullptr ? std::string_view{} : std::string_view(err);
@@ -598,6 +570,44 @@ class ToolboxHostView {
 
  private:
   PJ_toolbox_host_t host_;
+};
+
+// ---------------------------------------------------------------------------
+// ColorMapRegistryView — typed C++ view over PJ_colormap_registry_t
+// ---------------------------------------------------------------------------
+
+/// Signature of a color evaluation callback — mirrors the C ABI.
+using ColorMapEvalFn = const char* (*)(double value, void* user_ctx);
+
+/// C++ wrapper around PJ_colormap_registry_t for plugins that publish
+/// colormaps. Constructed from the fat pointer delivered via
+/// `bind_colormap_registry`. Empty-constructible; `valid()` tells whether
+/// the host exposed a registry.
+class ColorMapRegistryView {
+ public:
+  ColorMapRegistryView() = default;
+  explicit ColorMapRegistryView(PJ_colormap_registry_t registry) : registry_(registry) {}
+
+  [[nodiscard]] bool valid() const noexcept {
+    return registry_.vtable != nullptr && registry_.ctx != nullptr;
+  }
+
+  /// Register (or replace) a named colormap. The new entry becomes active.
+  [[nodiscard]] bool registerMap(std::string_view name,
+                                 ColorMapEvalFn eval_fn,
+                                 void* user_ctx) const {
+    if (!valid() || registry_.vtable->register_map == nullptr) return false;
+    return registry_.vtable->register_map(registry_.ctx, toAbiString(name), eval_fn, user_ctx);
+  }
+
+  /// Unregister a colormap by name. Clears the active selection if it matched.
+  [[nodiscard]] bool unregisterMap(std::string_view name) const {
+    if (!valid() || registry_.vtable->unregister_map == nullptr) return false;
+    return registry_.vtable->unregister_map(registry_.ctx, toAbiString(name));
+  }
+
+ private:
+  PJ_colormap_registry_t registry_{};
 };
 
 }  // namespace PJ::sdk

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -122,6 +122,13 @@ class ToolboxPluginBase {
     return okStatus();
   }
 
+  /// Bind the optional colormap registry service. Override for plugins that
+  /// publish colormaps. Default accepts the registry (valid or not) as a no-op.
+  virtual Status bindColorMapRegistry(PJ_colormap_registry_t registry) {
+    colormap_registry_ = registry;
+    return okStatus();
+  }
+
   /// Serialize plugin configuration to JSON. Default returns "{}".
   virtual std::string saveConfig() const {
     return "{}";
@@ -158,6 +165,7 @@ class ToolboxPluginBase {
         trampoline_capabilities,
         trampoline_bind_toolbox_host,
         trampoline_bind_runtime_host,
+        trampoline_bind_colormap_registry,
         trampoline_save_config,
         trampoline_load_config,
         trampoline_get_dialog_context,
@@ -183,6 +191,14 @@ class ToolboxPluginBase {
     return ToolboxRuntimeHostView(runtime_host_);
   }
 
+  [[nodiscard]] sdk::ColorMapRegistryView colorMapRegistry() const {
+    return sdk::ColorMapRegistryView(colormap_registry_);
+  }
+
+  [[nodiscard]] bool colorMapRegistryBound() const {
+    return colormap_registry_.ctx != nullptr && colormap_registry_.vtable != nullptr;
+  }
+
   void setLastError(std::string error) {
     last_error_ = std::move(error);
   }
@@ -190,6 +206,7 @@ class ToolboxPluginBase {
  private:
   PJ_toolbox_host_t toolbox_host_{};
   PJ_toolbox_runtime_host_t runtime_host_{};
+  PJ_colormap_registry_t colormap_registry_{};
   std::string config_buf_;
   mutable std::string last_error_;
 
@@ -199,6 +216,7 @@ class ToolboxPluginBase {
   static uint64_t trampoline_capabilities(void* ctx);
   static bool trampoline_bind_toolbox_host(void* ctx, PJ_toolbox_host_t toolbox_host);
   static bool trampoline_bind_runtime_host(void* ctx, PJ_toolbox_runtime_host_t runtime_host);
+  static bool trampoline_bind_colormap_registry(void* ctx, PJ_colormap_registry_t registry);
   static const char* trampoline_save_config(void* ctx);
   static bool trampoline_load_config(void* ctx, const char* config_json);
   static void* trampoline_get_dialog_context(void* ctx);

--- a/pj_base/include/pj_base/toolbox_protocol.h
+++ b/pj_base/include/pj_base/toolbox_protocol.h
@@ -114,6 +114,14 @@ typedef struct PJ_toolbox_vtable_t {
   bool (*bind_toolbox_host)(void* ctx, PJ_toolbox_host_t toolbox_host);
   /** Bind the control-plane runtime host. Must be called before interaction. */
   bool (*bind_runtime_host)(void* ctx, PJ_toolbox_runtime_host_t runtime_host);
+  /**
+   * Bind the optional colormap registry service.
+   *
+   * Called by the host after bind_toolbox_host when a registry is available.
+   * Plugins that don't publish colormaps can leave this NULL; the host checks
+   * for NULL before calling. Returns true on success.
+   */
+  bool (*bind_colormap_registry)(void* ctx, PJ_colormap_registry_t registry);
 
   /** Serialize plugin configuration to JSON. Plugin-owned string. */
   const char* (*save_config)(void* ctx);

--- a/pj_datastore/CMakeLists.txt
+++ b/pj_datastore/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(pj_datastore STATIC
   src/derived_engine.cpp
   src/builtin_transforms.cpp
   src/plugin_data_host.cpp
+  src/colormap_registry.cpp
+  src/colormap_registry_host.cpp
 )
 target_include_directories(pj_datastore PUBLIC include)
 target_compile_features(pj_datastore PUBLIC cxx_std_20)

--- a/pj_datastore/include/pj_datastore/colormap_registry.hpp
+++ b/pj_datastore/include/pj_datastore/colormap_registry.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace PJ {
+
+/// Signature of a color evaluation callback. Receives a scalar value and a
+/// user-provided context pointer; returns a CSS color name or "#rrggbb" hex
+/// string. The returned pointer must remain valid until the next call to the
+/// same callback.
+using ColorMapEvalFn = const char* (*)(double value, void* user_ctx);
+
+/// Registry of named colormap callbacks.
+///
+/// Plugins register one or more named maps during the lifetime of their
+/// dialog, pick one as active, and consumers (chart renderers, exporters)
+/// evaluate the active map per data point.
+///
+/// The `DatastoreToolboxHost` owns one instance and forwards
+/// `register_colormap`/`unregister_colormap` calls received through the C ABI
+/// vtable. Consumers read through `DatastoreToolboxHost::colorMaps()`.
+class ColorMapRegistry {
+ public:
+  ColorMapRegistry() = default;
+  ~ColorMapRegistry() = default;
+
+  ColorMapRegistry(const ColorMapRegistry&) = delete;
+  ColorMapRegistry& operator=(const ColorMapRegistry&) = delete;
+
+  /// Register or replace a named colormap. The newly registered map becomes
+  /// active; call `setActive()` afterwards to switch to a different one.
+  void registerMap(std::string_view name, ColorMapEvalFn eval_fn, void* user_ctx);
+
+  /// Unregister a colormap by name. If it was active, clears the active
+  /// selection — subsequent `evaluate()` calls return an empty string.
+  void unregisterMap(std::string_view name);
+
+  /// Set the active colormap by name. No-op if `name` is not registered.
+  void setActive(std::string_view name);
+
+  /// Evaluate the active colormap for a scalar value. Returns empty when no
+  /// colormap is active.
+  [[nodiscard]] std::string evaluate(double value) const;
+
+  /// True when a colormap is active and its callback is available.
+  [[nodiscard]] bool hasActive() const;
+
+  /// Name of the currently active colormap, or empty string when none.
+  [[nodiscard]] const std::string& activeName() const { return active_; }
+
+ private:
+  struct Entry {
+    ColorMapEvalFn eval_fn;
+    void* user_ctx;
+  };
+  std::unordered_map<std::string, Entry> maps_;
+  std::string active_;
+};
+
+}  // namespace PJ

--- a/pj_datastore/include/pj_datastore/colormap_registry_host.hpp
+++ b/pj_datastore/include/pj_datastore/colormap_registry_host.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "pj_base/plugin_data_api.h"
+
+namespace PJ {
+
+class ColorMapRegistry;
+
+/// Wrap a `ColorMapRegistry` as a C ABI `PJ_colormap_registry_t` so it can be
+/// bound into a toolbox plugin via `bind_colormap_registry`.
+///
+/// The returned fat pointer references `registry` by address; the registry
+/// must outlive every plugin instance it is bound to. The vtable itself is a
+/// static singleton — safe to share across plugins and threads.
+[[nodiscard]] PJ_colormap_registry_t makeColorMapRegistryHost(ColorMapRegistry& registry);
+
+}  // namespace PJ

--- a/pj_datastore/src/colormap_registry.cpp
+++ b/pj_datastore/src/colormap_registry.cpp
@@ -1,0 +1,42 @@
+#include "pj_datastore/colormap_registry.hpp"
+
+namespace PJ {
+
+void ColorMapRegistry::registerMap(std::string_view name, ColorMapEvalFn eval_fn, void* user_ctx) {
+  std::string key(name);
+  maps_[key] = Entry{eval_fn, user_ctx};
+  active_ = std::move(key);
+}
+
+void ColorMapRegistry::unregisterMap(std::string_view name) {
+  std::string key(name);
+  maps_.erase(key);
+  if (active_ == key) {
+    active_.clear();
+  }
+}
+
+void ColorMapRegistry::setActive(std::string_view name) {
+  std::string key(name);
+  if (maps_.find(key) != maps_.end()) {
+    active_ = std::move(key);
+  }
+}
+
+std::string ColorMapRegistry::evaluate(double value) const {
+  if (active_.empty()) {
+    return {};
+  }
+  auto it = maps_.find(active_);
+  if (it == maps_.end()) {
+    return {};
+  }
+  const char* result = it->second.eval_fn(value, it->second.user_ctx);
+  return result ? std::string{result} : std::string{};
+}
+
+bool ColorMapRegistry::hasActive() const {
+  return !active_.empty() && maps_.find(active_) != maps_.end();
+}
+
+}  // namespace PJ

--- a/pj_datastore/src/colormap_registry_host.cpp
+++ b/pj_datastore/src/colormap_registry_host.cpp
@@ -1,0 +1,44 @@
+#include "pj_datastore/colormap_registry_host.hpp"
+
+#include <string_view>
+
+#include "pj_datastore/colormap_registry.hpp"
+
+namespace PJ {
+
+namespace {
+
+std::string_view toStringView(PJ_string_view_t s) {
+  return std::string_view(s.data, s.size);
+}
+
+bool registryRegisterMap(void* ctx, PJ_string_view_t name,
+                         const char* (*eval_fn)(double, void*), void* user_ctx) {
+  auto* reg = static_cast<ColorMapRegistry*>(ctx);
+  reg->registerMap(toStringView(name), eval_fn, user_ctx);
+  return true;
+}
+
+bool registryUnregisterMap(void* ctx, PJ_string_view_t name) {
+  auto* reg = static_cast<ColorMapRegistry*>(ctx);
+  reg->unregisterMap(toStringView(name));
+  return true;
+}
+
+constexpr PJ_colormap_registry_vtable_t kRegistryVTable = {
+    PJ_PLUGIN_DATA_API_VERSION,
+    sizeof(PJ_colormap_registry_vtable_t),
+    registryRegisterMap,
+    registryUnregisterMap,
+};
+
+}  // namespace
+
+PJ_colormap_registry_t makeColorMapRegistryHost(ColorMapRegistry& registry) {
+  return PJ_colormap_registry_t{
+      .ctx = &registry,
+      .vtable = &kRegistryVTable,
+  };
+}
+
+}  // namespace PJ

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -956,15 +956,9 @@ struct DatastoreParserWriteHostState {
   TopicHandle topic;
 };
 
-struct ColorMapEntry {
-  const char* (*eval_fn)(double value, void* user_ctx);
-  void* user_ctx;
-};
-
 struct DatastoreToolboxHostState {
   explicit DatastoreToolboxHostState(DataEngine& engine) : core(engine) {}
   ToolboxCore core;
-  std::unordered_map<std::string, ColorMapEntry> colormaps;
 };
 
 bool sourceEnsureTopic(void* ctx, PJ_string_view_t topic_name, TopicHandle* out_topic) {
@@ -1061,24 +1055,6 @@ bool toolboxReadSeries(void* ctx, FieldHandle field, PJ_materialized_series_t* o
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.readSeries(field, out_series);
 }
 
-bool toolboxRegisterColorMap(void* ctx, PJ_string_view_t name,
-                             const char* (*eval_fn)(double, void*), void* user_ctx) {
-  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
-  std::string key(toStringView(name));
-  if (state->colormaps.count(key) > 0) {
-    state->core.write.last_error_ = "colormap '" + key + "' already registered";
-    return false;
-  }
-  state->colormaps[key] = {eval_fn, user_ctx};
-  return true;
-}
-
-bool toolboxUnregisterColorMap(void* ctx, PJ_string_view_t name) {
-  auto* state = static_cast<DatastoreToolboxHostState*>(ctx);
-  std::string key(toStringView(name));
-  return state->colormaps.erase(key) > 0;
-}
-
 const char* toolboxLastError(void* ctx) {
   return static_cast<DatastoreToolboxHostState*>(ctx)->core.write.lastError();
 }
@@ -1111,7 +1087,6 @@ const PJ_toolbox_host_vtable_t kToolboxVTable = {
     toolboxAppendRecord,        toolboxAppendRecordFast,
     toolboxAppendArrowIpc,      toolboxAcquireCatalogSnapshot,
     toolboxReadSeries,
-    toolboxRegisterColorMap,    toolboxUnregisterColorMap,
 };
 
 DatastoreSourceWriteHost::DatastoreSourceWriteHost(DataEngine& engine, DataSourceHandle source)

--- a/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
@@ -83,6 +83,14 @@ class ToolboxHandle {
     return vt_->bind_runtime_host(ctx_, runtime_host);
   }
 
+  /// Bind the optional colormap registry service. Returns true when the plugin
+  /// accepts the registry (plugins that don't use it still return true as a
+  /// no-op) or when the plugin does not implement the binding at all.
+  [[nodiscard]] bool bindColorMapRegistry(PJ_colormap_registry_t registry) {
+    if (vt_->bind_colormap_registry == nullptr) return true;
+    return vt_->bind_colormap_registry(ctx_, registry);
+  }
+
   [[nodiscard]] std::string saveConfig() const {
     return safeString(vt_->save_config(ctx_));
   }

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -89,8 +89,6 @@ PJ_toolbox_host_t makeToolboxHost(MinimalToolboxHost* recorder) {
       .append_arrow_ipc = MinimalToolboxHost::appendArrowIpc,
       .acquire_catalog_snapshot = MinimalToolboxHost::acquireCatalogSnapshot,
       .read_series = MinimalToolboxHost::readSeries,
-      .register_colormap = nullptr,
-      .unregister_colormap = nullptr,
   };
   return PJ_toolbox_host_t{.ctx = recorder, .vtable = &vtable};
 }

--- a/pj_proto_app/src/chart_panel.cpp
+++ b/pj_proto_app/src/chart_panel.cpp
@@ -3,6 +3,7 @@
 #include <QContextMenuEvent>
 #include <QDataStream>
 #include <QMimeData>
+#include <QPen>
 #include <cmath>
 #include <limits>
 
@@ -53,6 +54,10 @@ void ChartPanel::clearAllSeries() {
   }
   series_.clear();
   first_timestamp_ = 0;
+}
+
+void ChartPanel::setColorMap(std::function<QColor(double)> fn) {
+  colormap_fn_ = std::move(fn);
 }
 
 void ChartPanel::updateData(PJ::Timestamp t_min, PJ::Timestamp t_max) {
@@ -108,6 +113,20 @@ void ChartPanel::updateData(PJ::Timestamp t_min, PJ::Timestamp t_max) {
     });
 
     s.line->replace(points);
+    if (!points.empty()) {
+      s.last_value = points.last().y();
+    }
+  }
+
+  if (colormap_fn_) {
+    for (auto& s : series_) {
+      QColor color = colormap_fn_(s.last_value);
+      if (color.isValid()) {
+        QPen pen = s.line->pen();
+        pen.setColor(color);
+        s.line->setPen(pen);
+      }
+    }
   }
 
   // Auto-scale x-axis (skipped when user has manually zoomed or panned)

--- a/pj_proto_app/src/chart_panel.hpp
+++ b/pj_proto_app/src/chart_panel.hpp
@@ -9,6 +9,7 @@
 #include <QtCharts/QChartView>
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,7 @@ struct PlottedSeries {
   PJ::TopicId topic_id = 0;
   size_t col_index = 0;
   std::string label;
+  double last_value = 0.0;
 };
 
 class ChartPanel : public QChartView {
@@ -34,6 +36,12 @@ class ChartPanel : public QChartView {
   void removeSeries(int index);
   void clearAllSeries();
   void updateData(PJ::Timestamp t_min, PJ::Timestamp t_max);
+
+  /// Install a color function keyed on each series' last value. Pass `{}` to
+  /// restore default per-series colors. The function may query shared state
+  /// (e.g. a `ColorMapRegistry`) and is consulted on every `updateData()`
+  /// call, so registry changes take effect on the next refresh.
+  void setColorMap(std::function<QColor(double)> fn);
 
  signals:
   void seriesDropped();
@@ -54,6 +62,7 @@ class ChartPanel : public QChartView {
   QValueAxis* x_axis_;
   QValueAxis* y_axis_;
   std::vector<PlottedSeries> series_;
+  std::function<QColor(double)> colormap_fn_;
   PJ::Timestamp first_timestamp_ = 0;
   bool user_zoom_ = false;
   bool is_panning_ = false;

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -167,6 +167,13 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
   connect(tree_view_, &QTreeView::customContextMenuRequested, this, &MainWindow::onTreeContextMenu);
 
   chart_panel_ = new ChartPanel(engine_);
+  // Feed the chart a live view of the colormap registry: the lambda captures
+  // the registry by reference, so any plugin that later activates a colormap
+  // takes effect on the next refresh without re-wiring the chart.
+  chart_panel_->setColorMap([this](double v) -> QColor {
+    std::string color_str = colormap_registry_.evaluate(v);
+    return color_str.empty() ? QColor() : QColor(QString::fromStdString(color_str));
+  });
 
   auto* splitter = new QSplitter(Qt::Horizontal);
   splitter->addWidget(tree_view_);
@@ -698,8 +705,8 @@ void MainWindow::onOpenMarketplace() {
 
 void MainWindow::setupToolboxPanels(QMenu* tools_menu) {
   for (const auto& tb : registry_.allToolboxes()) {
-    auto session =
-        std::make_unique<ToolboxSession>(engine_, const_cast<PJ::ToolboxLibrary&>(tb.library), tb.name, this);
+    auto session = std::make_unique<ToolboxSession>(
+        engine_, const_cast<PJ::ToolboxLibrary&>(tb.library), colormap_registry_, tb.name, this);
     if (!session->init()) {
       continue;
     }

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -12,6 +12,7 @@
 
 #include "chart_panel.hpp"
 #include "data_source_session.hpp"
+#include "pj_datastore/colormap_registry.hpp"
 #include "pj_datastore/engine.hpp"
 #include "plugin_registry.hpp"
 #include "series_tree_model.hpp"
@@ -58,6 +59,7 @@ class MainWindow : public QMainWindow {
   void restartSession(DataSourceSession* session);
 
   PJ::DataEngine engine_;
+  PJ::ColorMapRegistry colormap_registry_;
   PJ::TimeDomainId default_td_id_ = 0;
   PluginRegistry registry_;
   std::vector<std::unique_ptr<DataSourceSession>> sessions_;

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+#include "pj_datastore/colormap_registry_host.hpp"
 #include "pj_plugins/host_qt/dialog_engine.hpp"
 
 namespace proto {
@@ -41,10 +42,12 @@ static const PJ_toolbox_runtime_host_vtable_t kRuntimeVtable = {
 // ---------------------------------------------------------------------------
 
 ToolboxSession::ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
-                               std::string name, QObject* parent)
+                               PJ::ColorMapRegistry& colormap_registry, std::string name,
+                               QObject* parent)
     : QObject(parent),
       engine_(engine),
       library_(library),
+      colormap_registry_(colormap_registry),
       name_(std::move(name)),
       handle_(library_.createHandle()) {}
 
@@ -62,6 +65,11 @@ bool ToolboxSession::init(const std::string& config_json) {
   auto runtime_host = makeRuntimeHost(this);
   if (!handle_.bindRuntimeHost(runtime_host)) {
     std::cerr << "Toolbox '" << name_ << "': bindRuntimeHost failed: " << handle_.lastError() << "\n";
+    return false;
+  }
+
+  if (!handle_.bindColorMapRegistry(PJ::makeColorMapRegistryHost(colormap_registry_))) {
+    std::cerr << "Toolbox '" << name_ << "': bindColorMapRegistry failed: " << handle_.lastError() << "\n";
     return false;
   }
 

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -11,13 +11,18 @@
 #include "pj_plugins/host/toolbox_library.hpp"
 #include "plugin_registry.hpp"
 
+namespace PJ {
+class ColorMapRegistry;
+}  // namespace PJ
+
 namespace proto {
 
 class ToolboxSession : public QObject {
   Q_OBJECT
 
  public:
-  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library, std::string name,
+  ToolboxSession(PJ::DataEngine& engine, PJ::ToolboxLibrary& library,
+                 PJ::ColorMapRegistry& colormap_registry, std::string name,
                  QObject* parent = nullptr);
 
   /// Bind hosts and load persisted config. Returns false on error.
@@ -50,6 +55,7 @@ class ToolboxSession : public QObject {
 
   PJ::DataEngine& engine_;
   PJ::ToolboxLibrary& library_;
+  PJ::ColorMapRegistry& colormap_registry_;
   std::string name_;
   PJ::ToolboxHandle handle_;
   std::unique_ptr<PJ::DatastoreToolboxHost> toolbox_host_;


### PR DESCRIPTION
## Summary

Introduce a dedicated `ColorMapRegistry` as a session-wide service — peer to `DataEngine` — that stores plugin-registered color evaluation callbacks and exposes an active selection to rendering consumers.

Plugins that publish colormaps receive the registry through a new optional `bind_colormap_registry` entry on the toolbox plugin vtable. The data-plane toolbox host no longer carries colormap-specific callbacks.

## Why

The previous shape placed `register_colormap` / `unregister_colormap` on the toolbox host vtable. That coupled the generic data/writing host to a presentation concern and left no first-class home for the registry state. Lifting the registry to its own service — independent class, its own ABI fat pointer, owned by `MainWindow` alongside `DataEngine` — keeps each side cohesive: the host handles data, the registry handles named colormaps, and the chart reads from the registry directly.

## Key pieces

- `pj_datastore/colormap_registry.{hpp,cpp}` — new class with `registerMap` / `unregisterMap` / `setActive` / `evaluate` / `hasActive`. Qt-free, header + cpp.
- `pj_datastore/colormap_registry_host.{hpp,cpp}` — `makeColorMapRegistryHost(ColorMapRegistry&)` adapter that exposes a registry reference as a `PJ_colormap_registry_t` ABI fat pointer.
- `pj_base/plugin_data_api.h` — drop `register_colormap` / `unregister_colormap` from `PJ_toolbox_host_vtable_t`; add the new ABI types.
- `pj_base/toolbox_protocol.h` — add optional `bind_colormap_registry` to the toolbox plugin vtable.
- `pj_base/sdk/plugin_data_api.hpp` — drop `registerColorMap` / `unregisterColorMap` from `ToolboxHostView`; add `ColorMapRegistryView` C++ wrapper.
- `pj_base/sdk/toolbox_plugin_base.hpp` — `bindColorMapRegistry` virtual, trampoline, `colorMapRegistry()` accessor.
- `pj_plugins/toolbox_handle.hpp` — `bindColorMapRegistry` pass-through.
- `pj_proto_app` — owns the single `ColorMapRegistry`, threads it into each `ToolboxSession`, and feeds a live view to `ChartPanel` via `setColorMap`. Chart now tracks the last value per series.
- Tests — mock vtables in `pj_plugins` updated.

## Breaking change

This changes the toolbox host ABI. The matching plugin-side migration is in [pj-official-plugins#NN](https://github.com/PlotJuggler/pj-official-plugins) (`feat/colormap-registry-migration`) — they must be merged together for CPM-pulled builds to stay green.

## Test plan

- [x] `pj_base` + `pj_datastore` + `pj_plugins` tests green (`ctest -R "toolbox_plugin_test|quaternion"` passes)
- [x] Full build including proto_app + 12 plugins compiles with `-Wall -Wextra -Werror`
- [x] Runtime: open proto_app, load data, open ColorMap Editor, define a map, apply, see chart colors update