### PR TITLE
feat(sdk): add on_data_changed hook to toolbox vtable

### DIFF
--- a/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
+++ b/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
@@ -136,4 +136,15 @@ inline const char* ToolboxPluginBase::trampoline_get_last_error(void* ctx) {
   return self->last_error_.empty() ? nullptr : self->last_error_.c_str();
 }
 
+inline void ToolboxPluginBase::trampoline_on_data_changed(void* ctx) {
+  auto* self = static_cast<ToolboxPluginBase*>(ctx);
+  try {
+    self->onDataChanged();
+  } catch (const std::exception& e) {
+    self->last_error_ = e.what();
+  } catch (...) {
+    self->last_error_ = "Unknown exception in on_data_changed";
+  }
+}
+
 }  // namespace PJ

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -151,6 +151,10 @@ class ToolboxPluginBase {
     return nullptr;
   }
 
+  /// Override to react to new records being appended to the datastore.
+  /// Default is a no-op.
+  virtual void onDataChanged() {}
+
   template <typename CreateFn>
   static const PJ_toolbox_vtable_t* vtableWithCreate(CreateFn create_fn, const char* manifest) {
     PJ_ASSERT(manifest != nullptr && manifest[0] == '{', "manifest must be a JSON object");
@@ -170,6 +174,7 @@ class ToolboxPluginBase {
         trampoline_load_config,
         trampoline_get_dialog_context,
         trampoline_get_last_error,
+        trampoline_on_data_changed,
     };
     return &vt;
   }
@@ -221,6 +226,7 @@ class ToolboxPluginBase {
   static bool trampoline_load_config(void* ctx, const char* config_json);
   static void* trampoline_get_dialog_context(void* ctx);
   static const char* trampoline_get_last_error(void* ctx);
+  static void trampoline_on_data_changed(void* ctx);
 };
 
 }  // namespace PJ

--- a/pj_base/include/pj_base/toolbox_protocol.h
+++ b/pj_base/include/pj_base/toolbox_protocol.h
@@ -137,6 +137,9 @@ typedef struct PJ_toolbox_vtable_t {
 
   /** Return the last error message, or NULL if none. Plugin-owned string. */
   const char* (*get_last_error)(void* ctx);
+
+  /** Notify the plugin that new records have been appended to the datastore. */
+  void (*on_data_changed)(void* ctx);
 } PJ_toolbox_vtable_t;
 
 /** Signature of the exported entry point: `PJ_get_toolbox_vtable`. */

--- a/pj_plugins/examples/mock_toolbox.cpp
+++ b/pj_plugins/examples/mock_toolbox.cpp
@@ -27,6 +27,13 @@ class MockToolbox : public PJ::ToolboxPluginBase {
     return this;
   }
 
+  void onDataChanged() override {
+    ++data_changed_count_;
+    if (runtimeHostBound()) {
+      runtimeHost().notifyDataChanged();
+    }
+  }
+
  private:
   void applyTransform() {
     auto host = toolboxHost();
@@ -49,6 +56,7 @@ class MockToolbox : public PJ::ToolboxPluginBase {
   }
 
   std::string config_ = "{}";
+  int data_changed_count_ = 0;
 };
 
 }  // namespace

--- a/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
@@ -20,6 +20,7 @@
 #include <pj_base/toolbox_protocol.h>
 
 #include <cassert>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -105,6 +106,21 @@ class ToolboxHandle {
 
   [[nodiscard]] std::string lastError() const {
     return safeString(vt_->get_last_error(ctx_));
+  }
+
+  /// Notify the plugin that new records have been appended to the datastore.
+  /// No-op for plugins compiled against an older SDK revision whose vtable
+  /// does not include the `on_data_changed` slot.
+  void onDataChanged() const {
+    if (vt_ == nullptr || ctx_ == nullptr) {
+      return;
+    }
+    constexpr size_t required_size =
+        offsetof(PJ_toolbox_vtable_t, on_data_changed) + sizeof(vt_->on_data_changed);
+    if (vt_->struct_size < required_size || vt_->on_data_changed == nullptr) {
+      return;
+    }
+    vt_->on_data_changed(ctx_);
   }
 
   [[nodiscard]] const PJ_toolbox_vtable_t* vtable() const {

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -173,6 +173,29 @@ TEST(ToolboxPluginTest, ReadTransformWriteFlowAndNotifyDataChanged) {
   EXPECT_EQ(runtime_recorder.notify_data_changed_calls, 1);
 }
 
+TEST(ToolboxPluginTest, OnDataChangedReachesPluginAndTriggersNotify) {
+  auto library = PJ::ToolboxLibrary::load(PJ_MOCK_TOOLBOX_PLUGIN_PATH);
+  ASSERT_TRUE(library) << library.error();
+  auto handle = library->createHandle();
+
+  MinimalRuntimeHost runtime_recorder;
+  ASSERT_TRUE(handle.bindRuntimeHost(makeRuntimeHost(&runtime_recorder)));
+
+  const auto required = offsetof(PJ_toolbox_vtable_t, on_data_changed) + sizeof(void*);
+  EXPECT_GE(library->vtable()->struct_size, required);
+  EXPECT_NE(library->vtable()->on_data_changed, nullptr);
+
+  handle.onDataChanged();
+  handle.onDataChanged();
+  EXPECT_EQ(runtime_recorder.notify_data_changed_calls, 2);
+}
+
+TEST(ToolboxPluginTest, OnDataChangedIsNoOpWhenHandleInvalid) {
+  PJ::ToolboxHandle handle{nullptr};
+  EXPECT_FALSE(handle.valid());
+  handle.onDataChanged();  // Must not crash.
+}
+
 // Exception safety: use vtableWithCreate directly to test trampoline catch paths.
 namespace {
 
@@ -229,6 +252,37 @@ TEST(ToolboxPluginTest, ExceptionsSafelyCaughtAcrossAbi) {
 
   // get_dialog_context: exception → returns nullptr
   EXPECT_EQ(drv.vt->get_dialog_context(drv.ctx), nullptr);
+}
+
+namespace {
+
+class ThrowingOnDataChanged : public PJ::ToolboxPluginBase {
+ public:
+  uint64_t capabilities() const override {
+    return 0;
+  }
+  void onDataChanged() override {
+    throw std::runtime_error("on_data_changed exploded");
+  }
+};
+
+const PJ_toolbox_vtable_t* throwingOnDataChangedVtable() {
+  static const PJ_toolbox_vtable_t* vt = PJ::ToolboxPluginBase::vtableWithCreate(
+      []() -> void* { return new ThrowingOnDataChanged(); },
+      R"({"name":"ThrowOnDataChanged","version":"0.0.1"})");
+  return vt;
+}
+
+}  // namespace
+
+TEST(ToolboxPluginTest, OnDataChangedExceptionsSafelyCaught) {
+  VtableDriver drv(throwingOnDataChangedVtable());
+  ASSERT_NE(drv.vt->on_data_changed, nullptr);
+  drv.vt->on_data_changed(drv.ctx);  // Must not propagate.
+
+  const char* err = drv.vt->get_last_error(drv.ctx);
+  ASSERT_NE(err, nullptr);
+  EXPECT_NE(std::string(err).find("on_data_changed exploded"), std::string::npos);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Add an optional `on_data_changed(void* ctx)` hook at the end of `PJ_toolbox_vtable_t`. Mirrors the existing `on_time_changed` hook pattern for data-change events.

## What

- **ABI** — `PJ_toolbox_vtable_t` gains a new slot `on_data_changed` at the end of the struct (opt-in; host NULL-checks before calling).
- **C++ SDK** — `ToolboxPluginBase` exposes a virtual `onDataChanged()` with a no-op default. Subclasses override it to react to newly appended data (e.g. recompute a transform over just the delta).
- **Trampoline** — `trampoline_on_data_changed` catches exceptions across the C ABI boundary.
- **Host** — `ToolboxHandle::onDataChanged()` forwards through the vtable; safe no-op when the plugin doesn't set the slot.

## Opt-in

Plugins that don't override the virtual pay no cost and the host never invokes the slot. Backward compatible with plugins compiled against the prior vtable.

## Test plan

- [x] `toolbox_plugin_test` covers direct invocation through the ABI, no-op path when not overridden, and correct forwarding from `ToolboxHandle`.
- [x] Exception safety case (trampoline catches).
- [x] Mock toolbox (`pj_plugins/examples/mock_toolbox.cpp`) gains a `onDataChanged` counter for testing.

## Downstream

An incoming follow-up on `pj-official-plugins` uses this hook in the Quaternion toolbox to re-apply the RPY transform only over newly appended samples (matching PJ 3.x's reactive behaviour).