### PR TITLE
fix(proto-app): refresh Tools menu after marketplace install/uninstall

### DIFF
--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -195,8 +195,8 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
   connect(&refresh_timer_, &QTimer::timeout, this, &MainWindow::onRefreshTimer);
 
   // --- Tools menu ---
-  auto* tools_menu = menuBar()->addMenu("&Tools");
-  setupToolboxPanels(tools_menu);
+  tools_menu_ = menuBar()->addMenu("&Tools");
+  setupToolboxPanels(tools_menu_);
 
   setWindowTitle("PlotJuggler Proto");
 }
@@ -699,7 +699,10 @@ void MainWindow::onOpenMarketplace() {
   window.resize(700, 500);
   window.exec();
   if (window.installationsChanged()) {
+    toolbox_sessions_.clear();
     registry_.reload();
+    tools_menu_->clear();
+    setupToolboxPanels(tools_menu_);
   }
 }
 

--- a/pj_proto_app/src/main_window.cpp
+++ b/pj_proto_app/src/main_window.cpp
@@ -131,13 +131,13 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
 
   auto* btn_load = new QPushButton("Load File");
   auto* btn_stream = new QPushButton("Start Stream");
-  auto* btn_marketplace = new QPushButton("Marketplace");
+  btn_marketplace_ = new QPushButton("Marketplace");
   auto* btn_clear_data = new QPushButton("Clear Data");
   auto* btn_clear_plots = new QPushButton("Clear Plots");
 
   toolbar->addWidget(btn_load);
   toolbar->addWidget(btn_stream);
-  toolbar->addWidget(btn_marketplace);
+  toolbar->addWidget(btn_marketplace_);
   toolbar->addSeparator();
   toolbar->addWidget(btn_clear_data);
   toolbar->addWidget(btn_clear_plots);
@@ -153,7 +153,7 @@ MainWindow::MainWindow(const std::string& plugin_dir, QWidget* parent)
 
   connect(btn_load, &QPushButton::clicked, this, &MainWindow::onLoadFile);
   connect(btn_stream, &QPushButton::clicked, this, &MainWindow::onStartStream);
-  connect(btn_marketplace, &QPushButton::clicked, this, &MainWindow::onOpenMarketplace);
+  connect(btn_marketplace_, &QPushButton::clicked, this, &MainWindow::onOpenMarketplace);
   connect(btn_clear_data, &QPushButton::clicked, this, &MainWindow::onClearData);
   connect(btn_clear_plots, &QPushButton::clicked, this, &MainWindow::onClearPlots);
 
@@ -700,6 +700,7 @@ void MainWindow::onOpenMarketplace() {
   window.exec();
   if (window.installationsChanged()) {
     toolbox_sessions_.clear();
+    open_toolbox_dialogs_ = 0;
     registry_.reload();
     tools_menu_->clear();
     setupToolboxPanels(tools_menu_);
@@ -718,6 +719,18 @@ void MainWindow::setupToolboxPanels(QMenu* tools_menu) {
       auto [begin, end] = computeVisibleRange();
       chart_panel_->updateData(begin, end);
       tree_model_.rebuildIfChanged();
+    });
+
+    // Non-modal toolbox dialogs share the event loop with the rest of the UI.
+    // Block the Marketplace while any toolbox dialog is open: a reload would
+    // dlclose the plugin whose code is still live on the stack (runDialog).
+    connect(session.get(), &ToolboxSession::dialogOpened, this, [this]() {
+      ++open_toolbox_dialogs_;
+      btn_marketplace_->setEnabled(open_toolbox_dialogs_ == 0);
+    });
+    connect(session.get(), &ToolboxSession::dialogClosed, this, [this]() {
+      --open_toolbox_dialogs_;
+      btn_marketplace_->setEnabled(open_toolbox_dialogs_ == 0);
     });
 
     ToolboxSession* raw_session = session.get();

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -3,6 +3,7 @@
 #include <QMainWindow>
 #include <QMenu>
 #include <QMenuBar>
+#include <QPushButton>
 #include <QSpinBox>
 #include <QSplitter>
 #include <QTimer>
@@ -70,10 +71,12 @@ class MainWindow : public QMainWindow {
   QTreeView* tree_view_ = nullptr;
   ChartPanel* chart_panel_ = nullptr;
   QSpinBox* buffer_spinbox_ = nullptr;
+  QPushButton* btn_marketplace_ = nullptr;
   QMenu* tools_menu_ = nullptr;
   QTimer refresh_timer_;
   int refresh_tick_ = 0;
   bool streaming_active_ = false;
+  int open_toolbox_dialogs_ = 0;
 
   std::vector<std::unique_ptr<ToolboxSession>> toolbox_sessions_;
 };

--- a/pj_proto_app/src/main_window.hpp
+++ b/pj_proto_app/src/main_window.hpp
@@ -70,6 +70,7 @@ class MainWindow : public QMainWindow {
   QTreeView* tree_view_ = nullptr;
   ChartPanel* chart_panel_ = nullptr;
   QSpinBox* buffer_spinbox_ = nullptr;
+  QMenu* tools_menu_ = nullptr;
   QTimer refresh_timer_;
   int refresh_tick_ = 0;
   bool streaming_active_ = false;

--- a/pj_proto_app/src/toolbox_session.cpp
+++ b/pj_proto_app/src/toolbox_session.cpp
@@ -103,8 +103,10 @@ bool ToolboxSession::runDialog(QWidget* parent) {
   PJ::DialogEngine dialog_engine(std::move(dialog_handle), config);
 
   dialog_running_ = true;
+  emit dialogOpened();
   auto result = dialog_engine.showDialog(parent);
   dialog_running_ = false;
+  emit dialogClosed();
 
   // Always persist the plugin's config after the dialog closes, regardless of
   // whether the user clicked OK or Close/X. Toolbox dialogs (unlike file-open

--- a/pj_proto_app/src/toolbox_session.hpp
+++ b/pj_proto_app/src/toolbox_session.hpp
@@ -40,6 +40,8 @@ class ToolboxSession : public QObject {
 
  signals:
   void dataChanged();
+  void dialogOpened();
+  void dialogClosed();
 
  public:
   // Public so the file-scope static vtable lambdas can cast to it.


### PR DESCRIPTION
## Summary

Three independent improvements around the Tools menu lifecycle and marketplace interaction:

1. **`ToolboxSession` emits `dialogOpened` / `dialogClosed` signals** around `runDialog()`, so the host can react to lifecycle transitions.
2. **Rebuild the Tools menu and toolbox sessions after a marketplace install/uninstall.** Plugins added or removed via the marketplace now appear/disappear without restarting the app.
3. **Disable the Marketplace button while any toolbox dialog is open.** Prevents the user from mutating the plugin set (install/uninstall) while a toolbox is mid-interaction, which would dangle the session behind the dialog.

## Changes

- `pj_proto_app/src/toolbox_session.{cpp,hpp}`: add `dialogOpened` / `dialogClosed` Qt signals emitted around the existing `runDialog` body.
- `pj_proto_app/src/main_window.{cpp,hpp}`:
  - Track `btn_marketplace_` and `tools_menu_` as members so we can update them after first creation.
  - Count open toolbox dialogs (`open_toolbox_dialogs_`) and toggle the Marketplace button enabled state.
  - After marketplace close, re-scan the registry and rebuild the tools menu + toolbox sessions in-place.

## Test plan

- [x] Build compiles clean with `-Werror`
- [x] Runtime: install a plugin from marketplace → appears in Tools menu without restart
- [x] Runtime: uninstall from marketplace → disappears from Tools menu
- [x] Runtime: open a toolbox dialog → Marketplace button disabled; close dialog → re-enabled