### PR TITLE
fix(library_loader): allow plugins to ship sibling DLLs on Windows

### DIFF
--- a/pj_plugins/src/detail/library_loader.hpp
+++ b/pj_plugins/src/detail/library_loader.hpp
@@ -15,9 +15,15 @@ namespace PJ::detail {
 
 inline Expected<void*> loadLibraryHandle(std::string_view path) {
 #if defined(_WIN32)
-  HMODULE module = LoadLibraryA(std::string(path).c_str());
+  // LOAD_WITH_ALTERED_SEARCH_PATH adds the directory of the loaded DLL to the
+  // search path for resolving its dependencies — matches dlopen's default on
+  // Linux. Without it, deps are only searched in the .exe directory, System32
+  // and PATH, so plugins cannot ship their own sibling DLLs 
+  HMODULE module = LoadLibraryExA(std::string(path).c_str(), nullptr,
+                                  LOAD_WITH_ALTERED_SEARCH_PATH);
   if (module == nullptr) {
-    return unexpected(std::string("LoadLibraryA failed"));
+    return unexpected("LoadLibraryExA failed (error " +
+                      std::to_string(GetLastError()) + ")");
   }
   return reinterpret_cast<void*>(module);
 #else


### PR DESCRIPTION
## Summary

- Switch `LoadLibraryA` to `LoadLibraryExA` with `LOAD_WITH_ALTERED_SEARCH_PATH` on Windows.
- Include `GetLastError()` code in the failure message to make future DLL-resolution issues diagnosable.

## Why

Without `LOAD_WITH_ALTERED_SEARCH_PATH`, Windows only searches the `.exe` directory, `System32`, and `PATH` when resolving a loaded plugin's DLL dependencies. That prevents a plugin from shipping sibling runtime DLLs next to its binary — on Linux, `dlopen` already behaves this way by default.

The `reactive_script_editor` plugin hits this specifically: when `cpython` is built as a shared Conan package (required on Windows/MSVC to support `.pyd` extensions), `python3XX.dll` is copied next to the plugin `.dll` at install-time, but the host loader cannot find it without this flag, and the plugin fails to load.

## Scope

The flag only affects DLLs loaded via an absolute path (which is how `PluginRegistry::scanDirectory` loads them), so there is no behavior change for any other code path.

## Test plan

- [x] Plugin loader on Linux still loads any plugin unchanged
- [x] Plugin loader on Windows resolves sibling DLLs shipped inside the plugin folder (verified with `reactive_script_editor` + bundled `python3XX.dll`)
- [x] Error message on Windows now includes `GetLastError()` for future debugging