### PR TITLE
fix(pj_marketplace): advance update queue after staging on Windows

### DIFF
--- a/pj_marketplace/src/ui/marketplace_window.cpp
+++ b/pj_marketplace/src/ui/marketplace_window.cpp
@@ -113,7 +113,8 @@ void MarketplaceWindow::setupSignals() {
           ui_->progress_bar_->setVisible(false);
           populateCards();
           setStatus("Extension staged — will be active after restart");
-   });   
+          processInstallQueue();
+   });
 
 
   connect(ext_mgr_, &ExtensionManager::uninstallPendingRestart, this,


### PR DESCRIPTION
## Summary

- On Windows the per-extension completion signal when staging a pending restart is \`installPendingRestart\` (not \`installFinished\`), so the handler that advances \`processInstallQueue()\` never fires.
- \"Update All\" halts after the first extension and the remaining items stay queued until the user clicks the button again.

This change calls \`processInstallQueue()\` from the \`installPendingRestart\` slot in \`MarketplaceWindow\`, matching what \`installFinished\` and \`installError\` already do, so the queue moves forward regardless of which of the three completion signals the extension manager emits.

## Test plan

- [x] On Windows, trigger \"Update All\" against a list of pending extensions and confirm the queue advances through every item even when each install lands on \`installPendingRestart\`.
- [x] On Linux/macOS, confirm normal \"Update All\" still completes (signals land on \`installFinished\` as before).