### PR TITLE
fix(dialog-sdk): suppress clang -Wunused-function on dialogVtableFor specialisation

### DIFF
--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -258,7 +258,7 @@ PJ_borrowed_dialog_t borrowDialog(DialogT& dialog) noexcept {
   }                                                                                                       \
   namespace PJ {                                                                                          \
   template <>                                                                                             \
-  inline const PJ_dialog_vtable_t* dialogVtableFor<ClassName>() noexcept {                                \
+  [[maybe_unused]] inline const PJ_dialog_vtable_t* dialogVtableFor<ClassName>() noexcept {               \
     return PJ_get_dialog_vtable();                                                                        \
   }                                                                                                       \
   }


### PR DESCRIPTION
## Summary

The `PJ_DIALOG_PLUGIN` macro emits an `inline` template specialisation of `dialogVtableFor<T>`. Clang on macOS warns `-Wunused-function` because the definition and its only caller (`borrowDialog`) live in different translation units. GCC does not produce this warning.

**Fix:** add `[[maybe_unused]]` to the inline specialisation in the macro.

## Test plan

- [x] macOS CI passes (clang no longer warns)
- [x] Linux CI passes (no regression with GCC)
- [x] Windows CI passes