### PR TITLE
fix(pj_media): remove stale Qt-fallback demo from pj_media/demos

### DIFF
--- a/pj_media/demos/CMakeLists.txt
+++ b/pj_media/demos/CMakeLists.txt
@@ -60,14 +60,4 @@ if(TARGET pj_media_qt)
     target_compile_options(mp4_video_viewer PRIVATE ${PJ_WARNING_FLAGS})
     target_link_libraries(mp4_video_viewer PRIVATE pj_media_qt pj_media_core)
   endif()
-elseif(PJ_BUILD_DIALOG_ENGINE_QT)
-  find_package(Qt6 REQUIRED COMPONENTS Widgets)
-  set(CMAKE_AUTOMOC ON)
-  add_executable(mcap_image_viewer mcap_image_viewer.cpp image_widget.hpp)
-  target_compile_features(mcap_image_viewer PRIVATE cxx_std_20)
-  target_compile_options(mcap_image_viewer PRIVATE ${PJ_WARNING_FLAGS})
-  target_link_libraries(mcap_image_viewer PRIVATE
-    pj_media_core pj_datastore mcap::mcap libjpeg-turbo::libjpeg-turbo
-    Qt6::Widgets
-  )
 endif()


### PR DESCRIPTION
## Summary

- Removes the `elseif(PJ_BUILD_DIALOG_ENGINE_QT)` fallback block from `pj_media/demos/CMakeLists.txt`

This block built a basic `mcap_image_viewer` demo using plain `Qt6::Widgets` when `pj_media_qt` was not available. Now that `pj_media_qt` exists, the branch is dead code: it never executes when `pj_media_qt` is present, and building a raw-widget demo without QRhi support provides no value when it is absent.

## Test plan

- [x] Build with Qt6 available (`pj_media_qt` built) — `mcap_image_viewer` still compiles via the `if(TARGET pj_media_qt)` branch
- [x] Build without Qt6 — no demo built, no error