### PR TITLE
fix(marketplace): hide registry entries with no artifact for current platform

### DIFF
--- a/pj_marketplace/include/pj_marketplace/registry_manager.hpp
+++ b/pj_marketplace/include/pj_marketplace/registry_manager.hpp
@@ -34,6 +34,13 @@ class RegistryManager : public QObject {
   // Returns the parsed extensions after a successful fetch; empty list otherwise.
   QList<Extension> extensions() const;
 
+  // Same as extensions(), but drops entries whose `platforms` map has no
+  // artifact for `platform` (e.g. "linux-x86_64"). Use this for catalog
+  // views — installation would fail anyway for the dropped entries (see
+  // ExtensionManager::doInstall). The platform key is injected by the
+  // caller so RegistryManager stays independent of host detection.
+  QList<Extension> compatibleExtensions(const QString& platform) const;
+
   // Returns the first extension whose id matches, or a default-constructed Extension
   // (id is empty) when not found.
   Extension findById(const QString& id) const;

--- a/pj_marketplace/src/core/RegistryManager.cpp
+++ b/pj_marketplace/src/core/RegistryManager.cpp
@@ -48,6 +48,17 @@ QList<Extension> RegistryManager::extensions() const {
   return extensions_;
 }
 
+QList<Extension> RegistryManager::compatibleExtensions(const QString& platform) const {
+  QList<Extension> result;
+  result.reserve(extensions_.size());
+  for (const Extension& ext : extensions_) {
+    if (ext.platforms.contains(platform)) {
+      result.append(ext);
+    }
+  }
+  return result;
+}
+
 Extension RegistryManager::findById(const QString& id) const {
   for (const Extension& ext : extensions_) {
     if (ext.id == id) {

--- a/pj_marketplace/src/ui/marketplace_window.cpp
+++ b/pj_marketplace/src/ui/marketplace_window.cpp
@@ -148,7 +148,7 @@ void MarketplaceWindow::setupSignals() {
     // A successful refresh is a strong "things are working" signal; let it
     // override any old sticky error so progress messages aren't suppressed.
     clearStickyStatus();
-    extensions_ = registry_mgr_->extensions();
+    extensions_ = registry_mgr_->compatibleExtensions(PlatformUtils::currentPlatform());
     applyFilters();
     setStatus("Ready — " + QString::number(extensions_.size()) + " extensions loaded");
   });

--- a/pj_marketplace/tests/registry_manager_test.cpp
+++ b/pj_marketplace/tests/registry_manager_test.cpp
@@ -263,6 +263,48 @@ TEST_F(RegistryManagerTest, ParsesPlatformArtifacts) {
   EXPECT_EQ(platforms["windows-x86_64"].url, "https://example.com/csv-loader-win.dll");
 }
 
+// compatibleExtensions(platform) returns only entries whose `platforms` map
+// contains the requested key, while extensions() stays untouched.
+TEST_F(RegistryManagerTest, CompatibleExtensionsFiltersByRequestedPlatform) {
+  static const QByteArray kMixedPlatformsJson = R"({
+    "extensions": [
+      { "id": "linux-only", "name": "Linux Only", "version": "1.0.0",
+        "platforms": { "linux-x86_64": { "url": "u1", "checksum": "sha256:1" } } },
+      { "id": "windows-only", "name": "Windows Only", "version": "1.0.0",
+        "platforms": { "windows-x86_64": { "url": "u2", "checksum": "sha256:2" } } },
+      { "id": "cross", "name": "Cross", "version": "1.0.0",
+        "platforms": {
+          "linux-x86_64":   { "url": "u3", "checksum": "sha256:3" },
+          "windows-x86_64": { "url": "u4", "checksum": "sha256:4" }
+        }
+      }
+    ]
+  })";
+
+  RegistryManager mgr;
+  QSignalSpy spy_finished(&mgr, &RegistryManager::fetchFinished);
+
+  server_->setResponseBody(kMixedPlatformsJson);
+  mgr.fetchRegistry(server_->url());
+  ASSERT_TRUE(spy_finished.wait(3000));
+
+  // extensions() returns the parsed list verbatim, regardless of platform.
+  EXPECT_EQ(mgr.extensions().size(), 3);
+
+  const QList<Extension> linux_compat = mgr.compatibleExtensions("linux-x86_64");
+  ASSERT_EQ(linux_compat.size(), 2);
+  EXPECT_EQ(linux_compat.at(0).id, "linux-only");
+  EXPECT_EQ(linux_compat.at(1).id, "cross");
+
+  const QList<Extension> win_compat = mgr.compatibleExtensions("windows-x86_64");
+  ASSERT_EQ(win_compat.size(), 2);
+  EXPECT_EQ(win_compat.at(0).id, "windows-only");
+  EXPECT_EQ(win_compat.at(1).id, "cross");
+
+  // Unknown platform key drops everything.
+  EXPECT_TRUE(mgr.compatibleExtensions("imaginary-os-arch").isEmpty());
+}
+
 // [2] Changelog map (version -> description)
 TEST_F(RegistryManagerTest, ParsesChangelog) {
   RegistryManager mgr;


### PR DESCRIPTION
## Summary

- Hide registry entries that declare no artifact for the host OS/arch from the marketplace catalog view, since `ExtensionManager::doInstall` would reject them anyway with "No artifact available for platform …".
- New `RegistryManager::compatibleExtensions(platform)` encapsulates the filter; `MarketplaceWindow` calls it with `PlatformUtils::currentPlatform()`. The platform key is injected by the caller so `RegistryManager` stays independent of host detection.
- `extensions()` keeps returning the parsed list verbatim — only the catalog view consumes the filtered variant.

## Why

Before this change, the marketplace listed every entry from the registry. Users on Linux/x86_64 saw Windows-only and macOS-only extensions, clicked Install, and got a confusing "No artifact available for platform …" error. The catalog now only shows extensions the host can actually install.

## Test plan

- [x] New `CompatibleExtensionsFiltersByRequestedPlatform` test exercises the filter with a synthetic platform key, no host detection involved.
- [x] Existing registry/marketplace tests still pass (the `extensions()` accessor is unchanged).