### PR TITLE
docs(pj_scene_protocol): point at sibling ARCHITECTURE.md, not pj_media

### DIFF
--- a/pj_scene_protocol/include/pj_scene_protocol/image_annotation.h
+++ b/pj_scene_protocol/include/pj_scene_protocol/image_annotation.h
@@ -8,8 +8,8 @@
 
 namespace PJ {
 
-/// Vertex topology for vector annotations. Mirrors the canonical primitive set
-/// from `pj_media/docs/datatypes_2D.md` §8.
+/// Vertex topology for vector annotations. See `docs/ARCHITECTURE.md`
+/// for the full type catalog and wire format spec.
 enum class AnnotationTopology : uint8_t {
   kPoints,     ///< Each point is independent.
   kLineList,   ///< Consecutive pairs form segments (0-1, 2-3, ...).

--- a/pj_scene_protocol/include/pj_scene_protocol/scene_decoder.h
+++ b/pj_scene_protocol/include/pj_scene_protocol/scene_decoder.h
@@ -10,14 +10,14 @@
 
 namespace PJ {
 
-/// Decodes canonical wire-format bytes (foxglove.ImageAnnotations Protobuf —
-/// the schema documented in `pj_media/docs/datatypes_2D.md §8` and serialized
-/// by `pj_scene_protocol::serializeImageAnnotation`) into a `SceneFrame` of
-/// vector primitives. Stateless — one instance per scene/annotation layer.
+/// Decodes canonical wire-format bytes (foxglove.ImageAnnotations Protobuf,
+/// serialized by `pj_scene_protocol::serializeImageAnnotation`) into a
+/// `SceneFrame` of vector primitives. Stateless — one instance per
+/// scene/annotation layer. See `docs/ARCHITECTURE.md` for the wire format spec.
 ///
 /// There is exactly ONE decoder kind. Per-source-format conversion (e.g. CDR
 /// `vision_msgs/msg/Detection2DArray` → canonical bytes) lives loader-side and
-/// is invisible to pj_media.
+/// is invisible to consumers of this module.
 class ISceneDecoder {
  public:
   virtual ~ISceneDecoder() = default;


### PR DESCRIPTION
## Summary

The schema-spec headers were left pointing at `pj_media/docs/datatypes_2D.md §8` for the canonical type catalog — a holdover from when this module lived inside PJ4's `pj_media/` tree. After the relocation in #81, that PJ4 doc was rewritten to point AT `pj_scene_protocol/docs/ARCHITECTURE.md`, making the header cross-reference **circular**.

This PR redirects the two header comments to the sibling `docs/ARCHITECTURE.md` (the authoritative spec) and drops some residual `pj_media`-specific phrasing in `scene_decoder.h`.

## Changes

- `include/pj_scene_protocol/image_annotation.h` — `AnnotationTopology` doc comment now points at `docs/ARCHITECTURE.md`.
- `include/pj_scene_protocol/scene_decoder.h` — `ISceneDecoder` doc comment points at `docs/ARCHITECTURE.md` and replaces *"invisible to pj_media"* with *"invisible to consumers of this module"* (this module shouldn't name a specific consumer).

No code change. 44/44 tests still pass.

## Test plan

- [x] `./build.sh` clean
- [x] `./test.sh` — 44/44 (image_annotation_codec_test, scene_decoder_test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)