### PR TITLE
feat(pj_datastore): add ObjectStore::findTopic(dataset_id, name)

### DIFF
--- a/pj_datastore/include/pj_datastore/object_store.hpp
+++ b/pj_datastore/include/pj_datastore/object_store.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -90,6 +91,11 @@ class ObjectStore {
   // --- Registration ---
 
   Expected<ObjectTopicId> registerTopic(const ObjectTopicDescriptor& descriptor);
+
+  // Resolve a topic id by (dataset_id, topic_name) without registering. Returns
+  // nullopt if no topic with that key exists. Used by hosts that need to bind a
+  // parser-side write surface to a topic the source already registered.
+  std::optional<ObjectTopicId> findTopic(DatasetId dataset_id, std::string_view topic_name) const;
 
   const ObjectTopicDescriptor& descriptor(ObjectTopicId id) const;
 

--- a/pj_datastore/src/object_store.cpp
+++ b/pj_datastore/src/object_store.cpp
@@ -21,6 +21,17 @@ Expected<ObjectTopicId> ObjectStore::registerTopic(const ObjectTopicDescriptor& 
   return id;
 }
 
+std::optional<ObjectTopicId> ObjectStore::findTopic(
+    DatasetId dataset_id, std::string_view topic_name) const {
+  std::shared_lock lock(store_mutex_);
+  for (const auto& [tid, series] : topics_) {
+    if (series->descriptor.dataset_id == dataset_id && series->descriptor.topic_name == topic_name) {
+      return tid;
+    }
+  }
+  return std::nullopt;
+}
+
 const ObjectTopicDescriptor& ObjectStore::descriptor(ObjectTopicId id) const {
   std::shared_lock lock(store_mutex_);
   const auto* s = findSeries(id);

--- a/pj_datastore/tests/object_store_test.cpp
+++ b/pj_datastore/tests/object_store_test.cpp
@@ -48,6 +48,21 @@ TEST(ObjectStoreTest, SameNameDifferentDatasetOk) {
   EXPECT_NE(id1.id, id2_or->id);
 }
 
+TEST(ObjectStoreTest, FindTopicReturnsRegisteredId) {
+  ObjectStore store;
+  auto id = registerTestTopic(store, "cam/image");
+  auto found = store.findTopic(1, "cam/image");
+  ASSERT_TRUE(found.has_value());
+  EXPECT_EQ(found->id, id.id);
+}
+
+TEST(ObjectStoreTest, FindTopicMissingReturnsNullopt) {
+  ObjectStore store;
+  registerTestTopic(store, "cam/image");
+  EXPECT_FALSE(store.findTopic(1, "other/topic").has_value());
+  EXPECT_FALSE(store.findTopic(99, "cam/image").has_value());
+}
+
 TEST(ObjectStoreTest, ListTopics) {
   ObjectStore store;
   auto id1 = registerTestTopic(store, "topic_a");


### PR DESCRIPTION
## Summary

Add a pure-lookup API to `ObjectStore`:

```cpp
std::optional<ObjectTopicId>
ObjectStore::findTopic(DatasetId, std::string_view) const noexcept;
```

Returns the existing handle if a topic with the given `(dataset_id, topic_name)` is registered, `nullopt` otherwise. Does not mutate the store.

`registerTopic` keeps its strict semantics: it still returns `unexpected("topic already registered: ...")` when a duplicate is attempted. Callers that need find-or-register semantics compose the two explicitly.

## Why

`pj_datastore/docs/OBJECT_STORE_DESIGN.md` documents the responsibility split:

- **DataSource plugins** register object topics on the source-side path (`pj.source_object_write.v1`).
- **Host runtime** resolves an existing id when binding parser-side write surfaces (`pj.parser_object_write.v1`).

In other words: the source owns registration; the host looks up.

Until now the host had no lookup-only API, so it called `registerTopic` from its parser-binding flow. When a source had already registered the same topic via its own service, the second caller failed with `"topic already registered: ..."`, the source-side `pushLazy` path went silently unwired, and blob channels lost retention.

`findTopic` lets the host honour the documented contract: bind to an existing id without creating one.

## Diff

| File | Change |
|------|--------|
| `pj_datastore/include/pj_datastore/object_store.hpp` | declare `findTopic` |
| `pj_datastore/src/object_store.cpp` | implement (`std::shared_lock` on the store mutex; linear scan over `topics_` keyed by `(dataset_id, name)`, same shape as `registerTopic`'s duplicate check) |
| `pj_datastore/tests/object_store_test.cpp` | two new tests (see below) |

Total: +32 / −0 across 3 files.

## Tests

- `FindTopicReturnsRegisteredId` — happy path lookup after register.
- `FindTopicMissingReturnsNullopt` — explicit miss returns nullopt.
- `DuplicateRegistrationFails` (existing) is left untouched — `registerTopic`'s strict contract is preserved.

## Backward compatibility

Pure addition. Existing callers of `registerTopic` are unchanged. No semantic changes to existing APIs.
