### PR TITLE
chore: apply clang-format to object_store.cpp

### DIFF
--- a/pj_datastore/src/object_store.cpp
+++ b/pj_datastore/src/object_store.cpp
@@ -21,8 +21,7 @@ Expected<ObjectTopicId> ObjectStore::registerTopic(const ObjectTopicDescriptor& 
   return id;
 }
 
-std::optional<ObjectTopicId> ObjectStore::findTopic(
-    DatasetId dataset_id, std::string_view topic_name) const {
+std::optional<ObjectTopicId> ObjectStore::findTopic(DatasetId dataset_id, std::string_view topic_name) const {
   std::shared_lock lock(store_mutex_);
   for (const auto& [tid, series] : topics_) {
     if (series->descriptor.dataset_id == dataset_id && series->descriptor.topic_name == topic_name) {


### PR DESCRIPTION
## Summary

`pj_datastore/src/object_store.cpp` had drifted 3 lines from `.clang-format` (Google style, 120-col, `InsertBraces: true`). Re-applying clang-format restores compliance.

No behavior change.
