### PR TITLE
Release 0.2.1: fix Conan cmake_build_modules + namespaced subdir aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.2.0")
+  set(PJ_PACKAGE_VERSION "0.2.1")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_core)
 
   install(EXPORT plotjuggler_coreTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ import os
 
 class PlotjugglerCoreConan(ConanFile):
     name = "plotjuggler_core"
-    version = "0.2.0"
+    version = "0.2.1"
     license = "MIT"
     url = "https://github.com/PlotJuggler/plotjuggler_core"
     description = "C++20 foundation libraries for PlotJuggler: storage engine, plugin SDK, plugin host loaders."

--- a/conanfile.py
+++ b/conanfile.py
@@ -131,6 +131,16 @@ class PlotjugglerCoreConan(ConanFile):
         # No top-level umbrella target: the four components have
         # mutually-exclusive audiences. Consumers must request a component.
 
+        # Conan 2's CMakeDeps only aggregates cmake_build_modules declared at
+        # the package level (self.cpp_info), not at component level — declaring
+        # it on the `sdk` component below silently produced an empty
+        # plotjuggler_core_BUILD_MODULES_PATHS_RELEASE in the generated data
+        # file. Ship the PjPluginManifest helper from the package root so
+        # CMakeDeps actually include()s it after find_package() returns.
+        self.cpp_info.set_property("cmake_build_modules", [
+            os.path.join("lib", "cmake", "plotjuggler_core", "PjPluginManifest.cmake"),
+        ])
+
         # --- base ---
         base = self.cpp_info.components["base"]
         base.set_property("cmake_target_name", "plotjuggler_core::base")
@@ -156,11 +166,6 @@ class PlotjugglerCoreConan(ConanFile):
         sdk.libs = []  # INTERFACE only
         sdk.includedirs = ["include"]
         sdk.requires = ["base", "nlohmann_json::nlohmann_json"]
-        # Ship the cmake helper alongside the component. cmake_build_modules
-        # makes Conan auto-include() it after find_package() succeeds.
-        sdk.set_property("cmake_build_modules", [
-            os.path.join("lib", "cmake", "plotjuggler_core", "PjPluginManifest.cmake"),
-        ])
 
         # --- plugin_host (umbrella linking every host-side loader) ---
         if self.options.with_host:

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -28,6 +28,11 @@ set_target_properties(pj_base PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   EXPORT_NAME base
 )
+# Build-tree alias so subdirectory-mode consumers can use the same namespaced
+# target name that the install/export tree exposes (and that the Conan package
+# emits). Keeps add_subdirectory() and find_package(plotjuggler_core) consumers
+# writing identical link declarations.
+add_library(plotjuggler_core::base ALIAS pj_base)
 if(PJ_ASSERT_THROWS)
   target_compile_definitions(pj_base PUBLIC PJ_ASSERT_THROWS)
 endif()

--- a/pj_datastore/CMakeLists.txt
+++ b/pj_datastore/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties(pj_datastore PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   EXPORT_NAME datastore
 )
+add_library(plotjuggler_core::datastore ALIAS pj_datastore)
 if(PJ_ASSERT_THROWS)
   target_compile_definitions(pj_datastore PUBLIC PJ_ASSERT_THROWS)
 endif()

--- a/pj_plugins/CMakeLists.txt
+++ b/pj_plugins/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(pj_plugin_sdk INTERFACE
 )
 target_link_libraries(pj_plugin_sdk INTERFACE pj_base pj_dialog_sdk)
 set_target_properties(pj_plugin_sdk PROPERTIES EXPORT_NAME plugin_sdk)
+add_library(plotjuggler_core::plugin_sdk ALIAS pj_plugin_sdk)
 
 # ---------------------------------------------------------------------------
 # pj_plugin_catalog — host-side embedded-manifest discovery
@@ -257,6 +258,7 @@ target_link_libraries(pj_plugin_host INTERFACE
   pj_plugin_catalog
 )
 set_target_properties(pj_plugin_host PROPERTIES EXPORT_NAME plugin_host)
+add_library(plotjuggler_core::plugin_host ALIAS pj_plugin_host)
 
 if(PJ_BUILD_TESTS)
 


### PR DESCRIPTION
## Summary

Two additive fixes uncovered while wiring `pj-official-plugins` to consume `plotjuggler_core` 0.2.0 as a Conan package instead of a CPM source dependency. Together they let downstream consumers drop ~25 lines of workaround per project.

- **fix(conan)** — Move `cmake_build_modules` from the `sdk` component to `self.cpp_info`. Conan 2's CMakeDeps generator [only aggregates `cmake_build_modules` declared at the package level](https://docs.conan.io/2/reference/tools/cmake/cmakedeps.html), so the previous component-level declaration was silently dropped — `plotjuggler_core_BUILD_MODULES_PATHS_RELEASE` ended up empty in the generated data file, `PjPluginManifest.cmake` was never `include()`d, and consumers calling `pj_emit_plugin_manifest()` saw "Unknown CMake command".
- **feat(cmake)** — Add build-tree `plotjuggler_core::base`, `::datastore`, `::plugin_sdk`, `::plugin_host` ALIAS targets mirroring the existing `EXPORT_NAME`s. Subdirectory-mode consumers (`add_subdirectory()`) can now use the same namespaced names as `find_package(plotjuggler_core CONFIG)` consumers — canonical CMake idiom per the [importing-exporting guide](https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html).
- **chore** — Bump `0.2.0` → `0.2.1` in `conanfile.py` and `CMakeLists.txt:PJ_PACKAGE_VERSION`.

## Verified downstream

`pj-official-plugins` (`ros_3d_objects` branch) builds against `plotjuggler_core/0.2.1`:
- 17/17 plugin `.so` files built under `-Werror`
- 0 errors, 0 warnings
- 11/11 ctest pass
- consumer workaround block (6 ALIAS lines + `find_file(PjPluginManifest)`) removed; replaced by direct use of `plotjuggler_core::plugin_sdk` / `::plugin_host`.

## Test plan

- [x] Local `conan create . -s compiler.cppstd=gnu20` produces `plotjuggler_core/0.2.1` package
- [x] Linux CI passes (existing `linux-ci.yml` workflow on PR)
- [ ] After merge: tag `v0.2.1` triggers `release.yml` → uploads to cloudsmith + creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)