### PR TITLE
chore(license): dual-license — Apache-2.0 SDK, MPL-2.0 engine; add CL…

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,60 @@
+name: CLA Assistant
+
+# CLA Assistant Lite (contributor-assistant/github-action).
+#
+# On every pull request, the bot checks whether each contributor has signed the
+# CLA in CLA.md. Unsigned contributors are asked to sign by posting a comment on
+# their PR with the exact phrase:
+#
+#     I have read the CLA Document and I hereby sign the CLA
+#
+# Signatures are appended to a JSON file (path-to-signatures) committed to the
+# `branch` configured below. Posting `recheck` re-runs the check.
+#
+# ── One-time setup ────────────────────────────────────────────────────────────
+#   1. The `branch` used to store signatures MUST exist and MUST NOT be branch-
+#      protected (the bot pushes directly to it). Create it once:
+#         git branch cla-signatures && git push -u origin cla-signatures
+#   2. If you store signatures in the same repo on an UNPROTECTED branch, the
+#      built-in GITHUB_TOKEN is enough. PERSONAL_ACCESS_TOKEN is only required
+#      when storing signatures in a *remote* repo, or when the storage branch is
+#      protected. If needed, add a repo-scoped PAT as the secret
+#      PERSONAL_ACCESS_TOKEN in Settings → Secrets and variables → Actions.
+#   3. Edit `allowlist` below to include maintainers and bots (they skip the CLA).
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event.comment.body == 'recheck'
+            || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # only for remote/protected storage
+        with:
+          path-to-document: 'https://github.com/PlotJuggler/plotjuggler_core/blob/development/CLA.md'
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'cla-signatures'
+          allowlist: facontidavide,bot*,*[bot]
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution. Before we can merge it, please sign the
+            [Contributor License Agreement](https://github.com/PlotJuggler/plotjuggler_core/blob/development/CLA.md)
+            by posting a comment on this pull request with exactly the text below:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,95 @@
+<!--
+  TEMPLATE — REVIEW BEFORE ENABLING THE CLA WORKFLOW.
+  This Contributor License Agreement was drafted as a starting point and is not
+  legal advice. Have it reviewed by a lawyer before relying on it, especially the
+  relicensing grant in Section 2, which is what preserves the option to offer
+  pj_datastore under commercial terms. Once contributors begin signing, changing
+  the terms requires re-collecting signatures, so settle the wording first.
+-->
+
+# PlotJuggler Core — Individual Contributor License Agreement
+
+Thank you for contributing to PlotJuggler Core (the "Project"). This Contributor
+License Agreement ("Agreement") sets out the terms under which You provide
+Contributions to the Project. It protects You, the Project, and downstream users
+by making the intellectual-property terms of Your Contributions explicit.
+
+By signing this Agreement (see "How to sign" below) You accept and agree to these
+terms for Your past, present, and future Contributions to the Project.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual who submits a Contribution, or
+  the legal entity on whose behalf the Contribution is submitted.
+- **"Project Owner"** means Davide Faconti, the maintainer and copyright holder
+  of PlotJuggler Core, and any successor maintainer or assignee.
+- **"Contribution"** means any original work of authorship, including any
+  modification of or addition to existing work, that You intentionally submit to
+  the Project (e.g. via pull request, patch, or issue attachment) for inclusion
+  in or documentation of the Project.
+
+## 2. Copyright License
+
+You grant the Project Owner and recipients of software distributed by the Project
+a **perpetual, worldwide, non-exclusive, royalty-free, irrevocable** copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, **sublicense, relicense, and distribute** Your Contributions and such
+derivative works.
+
+You expressly agree that the Project Owner may **license and distribute Your
+Contributions under any license terms, including open-source, proprietary, and
+commercial terms** (for example, dual-licensing the storage engine). This right
+to relicense survives even if the Project's default license changes. You retain
+all right, title, and interest in Your Contributions not expressly granted here,
+including the right to use them for any other purpose.
+
+## 3. Patent License
+
+You grant the Project Owner and recipients of software distributed by the Project
+a perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as
+stated below) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer Your Contributions, where such license applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contribution alone or by combination of Your Contribution with the Project.
+
+If any entity institutes patent litigation alleging that Your Contribution, or
+the Project to which You contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution terminate as of the date such litigation is
+filed.
+
+## 4. Moral Rights
+
+To the fullest extent permitted by applicable law, You waive, and agree not to
+assert, any moral rights in Your Contributions against the Project Owner or
+downstream recipients.
+
+## 5. Your Representations
+
+You represent that:
+
+1. Each Contribution is either Your original creation, or You have sufficient
+   rights to submit it under the terms of this Agreement.
+2. The grants above do not violate any agreement You have with a third party. If
+   Your employer has rights to intellectual property You create, You represent
+   that You have received permission to make the Contributions on behalf of that
+   employer, or that the employer has waived such rights for Your Contributions.
+3. You are not aware of any third-party rights that would make the grants in this
+   Agreement inaccurate, and You will notify the Project Owner if You later become
+   aware of any such rights.
+
+## 6. No Warranty / No Obligation
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions "AS IS", without warranties or conditions of any kind. The Project
+Owner is under no obligation to accept, use, or distribute any Contribution.
+
+## How to sign
+
+To sign this Agreement, post a comment on your pull request containing exactly:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+The automated CLA Assistant records your signature against your GitHub username.
+If you are contributing on behalf of a company, ensure you are authorized to do
+so before signing.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,26 @@
-MIT License
+PlotJuggler Core is licensed per-module. Every source file carries an
+SPDX-License-Identifier header that is authoritative for that file.
+
+  Module          License        Full text
+  ------------    -----------    ---------------
+  pj_base         Apache-2.0     LICENSE-APACHE
+  pj_plugins      Apache-2.0     LICENSE-APACHE
+  examples        Apache-2.0     LICENSE-APACHE
+  pj_datastore    MPL-2.0        LICENSE-MPL
+
+Rationale:
+
+  - The plugin-facing surface (pj_base, pj_plugins) is Apache-2.0 so that
+    third parties may build proprietary plugins and applications on top of
+    the SDK without restriction. Apache-2.0 also grants an explicit patent
+    license to downstream users.
+
+  - The storage engine (pj_datastore) is MPL-2.0. MPL-2.0 is file-level
+    (weak) copyleft: modifications to the engine's own source files must be
+    published, but the engine may be combined with proprietary code and
+    linked into proprietary applications.
+
+Plugins load through a stable C ABI and never statically link pj_datastore,
+so the MPL-2.0 engine imposes no obligations on plugin authors.
 
 Copyright (c) 2026 Davide Faconti
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MPL
+++ b/LICENSE-MPL
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ C++20 foundation libraries for [PlotJuggler](https://github.com/facontidavide/Pl
 
 ## Modules
 
-| Module | Description | Dependencies |
-|--------|-------------|--------------|
-| **pj_base** | Vocabulary types: `Timestamp`, `DatasetId`, `TopicId`, type trees, `Expected<T>`, `Span<T>` | None |
-| **pj_datastore** | Columnar in-memory storage engine + `ObjectStore` (for media blobs) + `DerivedEngine`; typed schemas, chunk-based encoding, range/latest-at queries, derived transform DAG, Arrow IPC import | pj_base, fmt, tsl::robin_map, nanoarrow |
-| **pj_plugins** | C-ABI plugin protocol (DataSource, MessageParser, Dialog, Toolbox families), C++ SDK base classes, plugin discovery, host-side loaders, and config helpers | pj_base, nlohmann/json |
+| Module | Description | Dependencies | License |
+|--------|-------------|--------------|---------|
+| **pj_base** | Vocabulary types: `Timestamp`, `DatasetId`, `TopicId`, type trees, `Expected<T>`, `Span<T>` | None | Apache-2.0 |
+| **pj_datastore** | Columnar in-memory storage engine + `ObjectStore` (for media blobs) + `DerivedEngine`; typed schemas, chunk-based encoding, range/latest-at queries, derived transform DAG, Arrow IPC import | pj_base, fmt, tsl::robin_map, nanoarrow | MPL-2.0 |
+| **pj_plugins** | C-ABI plugin protocol (DataSource, MessageParser, Dialog, Toolbox families), C++ SDK base classes, plugin discovery, host-side loaders, and config helpers | pj_base, nlohmann/json | Apache-2.0 |
 
 ## Getting Started
 
@@ -49,4 +49,18 @@ docs/                      Project-wide design guides
 
 ## License
 
-See LICENSE file.
+PlotJuggler Core is licensed per-module; each source file carries an
+authoritative `SPDX-License-Identifier` header.
+
+- **pj_base** and **pj_plugins** — the plugin-facing SDK — are **Apache-2.0**
+  ([LICENSE-APACHE](LICENSE-APACHE)). You may build **proprietary plugins and
+  applications** on the SDK without restriction; Apache-2.0 also grants an
+  explicit patent license.
+- **pj_datastore** — the storage engine — is **MPL-2.0**
+  ([LICENSE-MPL](LICENSE-MPL)). MPL-2.0 is file-level (weak) copyleft:
+  modifications to the engine's own files must be published, but it may be
+  linked into proprietary software.
+
+Plugins load through a stable C ABI and never statically link `pj_datastore`,
+so the MPL-2.0 engine imposes no obligations on plugin authors. See
+[LICENSE](LICENSE) for the full mapping.

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,9 @@ import os
 class PlotjugglerCoreConan(ConanFile):
     name = "plotjuggler_core"
     version = "0.3.1"
-    license = "MIT"
+    # Apache-2.0 covers pj_base + pj_plugins (the plugin-facing SDK);
+    # MPL-2.0 covers pj_datastore (the storage engine). See LICENSE.
+    license = "Apache-2.0 AND MPL-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_core"
     description = "C++20 foundation libraries for PlotJuggler: storage engine, plugin SDK, plugin host loaders."
     topics = ("plotjuggler", "plugin-sdk", "telemetry", "data-visualization")
@@ -65,6 +67,8 @@ class PlotjugglerCoreConan(ConanFile):
     exports_sources = (
         "CMakeLists.txt",
         "LICENSE",
+        "LICENSE-APACHE",
+        "LICENSE-MPL",
         "cmake/*",
         "pj_base/*",
         "pj_datastore/*",
@@ -119,9 +123,11 @@ class PlotjugglerCoreConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
+        # Ships LICENSE (the per-module map) plus the full Apache-2.0 and
+        # MPL-2.0 texts (LICENSE-APACHE, LICENSE-MPL).
         copy(
             self,
-            "LICENSE",
+            "LICENSE*",
             src=self.source_folder,
             dst=os.path.join(self.package_folder, "licenses"),
         )

--- a/examples/sdk_consumer/minimal_data_source.cpp
+++ b/examples/sdk_consumer/minimal_data_source.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pj_base/sdk/data_source_patterns.hpp>
 
 namespace {

--- a/pj_base/include/pj_base/assert.hpp
+++ b/pj_base/include/pj_base/assert.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #ifdef PJ_ASSERT_THROWS
 #include <stdexcept>

--- a/pj_base/include/pj_base/buffer_anchor.hpp
+++ b/pj_base/include/pj_base/buffer_anchor.hpp
@@ -9,7 +9,7 @@
  * and keeps the allocation alive while at least one anchor copy survives.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/asset_video.hpp
+++ b/pj_base/include/pj_base/builtin/asset_video.hpp
@@ -14,7 +14,7 @@
  * forcing the consumer to open the file just to size a playback window.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/asset_video_codec.hpp
+++ b/pj_base/include/pj_base/builtin/asset_video_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/builtin_object.hpp
+++ b/pj_base/include/pj_base/builtin/builtin_object.hpp
@@ -17,7 +17,7 @@
  * builtin type is appended to BuiltinObjectType.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/compressed_point_cloud.hpp
+++ b/pj_base/include/pj_base/builtin/compressed_point_cloud.hpp
@@ -3,7 +3,7 @@
  * @brief Point cloud delivered in a compressed binary format (Draco, ...).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/compressed_point_cloud_codec.hpp
+++ b/pj_base/include/pj_base/builtin/compressed_point_cloud_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/depth_image.hpp
+++ b/pj_base/include/pj_base/builtin/depth_image.hpp
@@ -3,7 +3,7 @@
  * @brief Depth image with camera intrinsics.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/depth_image_codec.hpp
+++ b/pj_base/include/pj_base/builtin/depth_image_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/depth_image_utils.hpp
+++ b/pj_base/include/pj_base/builtin/depth_image_utils.hpp
@@ -10,7 +10,7 @@
  * ignore this header.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/frame_transforms.hpp
+++ b/pj_base/include/pj_base/builtin/frame_transforms.hpp
@@ -6,7 +6,7 @@
  * It stores strings and scalar geometry directly; no BufferAnchor is needed.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/frame_transforms_codec.hpp
+++ b/pj_base/include/pj_base/builtin/frame_transforms_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/image.hpp
+++ b/pj_base/include/pj_base/builtin/image.hpp
@@ -4,7 +4,7 @@
  *        encoding string.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/image_annotations.hpp
+++ b/pj_base/include/pj_base/builtin/image_annotations.hpp
@@ -11,7 +11,7 @@
  * concerns to worry about.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/image_annotations_codec.hpp
+++ b/pj_base/include/pj_base/builtin/image_annotations_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/image_codec.hpp
+++ b/pj_base/include/pj_base/builtin/image_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/mesh3d.hpp
+++ b/pj_base/include/pj_base/builtin/mesh3d.hpp
@@ -3,7 +3,7 @@
  * @brief 3D mesh asset in its native binary format (GLTF/STL/PLY/OBJ/USD/DAE).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/mesh3d_codec.hpp
+++ b/pj_base/include/pj_base/builtin/mesh3d_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/occupancy_grid.hpp
+++ b/pj_base/include/pj_base/builtin/occupancy_grid.hpp
@@ -3,7 +3,7 @@
  * @brief 2D metric occupancy grid placed in world coordinates.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/occupancy_grid_codec.hpp
+++ b/pj_base/include/pj_base/builtin/occupancy_grid_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/point_cloud.hpp
+++ b/pj_base/include/pj_base/builtin/point_cloud.hpp
@@ -3,7 +3,7 @@
  * @brief Packed point cloud with per-channel field layout.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/point_cloud_codec.hpp
+++ b/pj_base/include/pj_base/builtin/point_cloud_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/robot_description.hpp
+++ b/pj_base/include/pj_base/builtin/robot_description.hpp
@@ -18,7 +18,7 @@
  *     negligible vs. structured re-encoding.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/scene_entities.hpp
+++ b/pj_base/include/pj_base/builtin/scene_entities.hpp
@@ -8,7 +8,7 @@
  * is the batch container shipped on a topic.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/scene_entities_codec.hpp
+++ b/pj_base/include/pj_base/builtin/scene_entities_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin/video_frame.hpp
+++ b/pj_base/include/pj_base/builtin/video_frame.hpp
@@ -3,7 +3,7 @@
  * @brief Single frame of a compressed video stream (h264 / h265 / vp9 / av1).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/builtin/video_frame_codec.hpp
+++ b/pj_base/include/pj_base/builtin/video_frame_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/builtin_object_abi.h
+++ b/pj_base/include/pj_base/builtin_object_abi.h
@@ -17,7 +17,7 @@
  * emit scalars via the parse() slot (writing to writeHost).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef PJ_BUILTIN_OBJECT_ABI_H
 #define PJ_BUILTIN_OBJECT_ABI_H

--- a/pj_base/include/pj_base/data_source_protocol.h
+++ b/pj_base/include/pj_base/data_source_protocol.h
@@ -19,7 +19,7 @@
  * same function on the same context. Hosts copy if they need to retain.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef PJ_DATA_SOURCE_PROTOCOL_H
 #define PJ_DATA_SOURCE_PROTOCOL_H

--- a/pj_base/include/pj_base/dataset.hpp
+++ b/pj_base/include/pj_base/dataset.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <string>
 #include <vector>

--- a/pj_base/include/pj_base/diagnostic_sink.hpp
+++ b/pj_base/include/pj_base/diagnostic_sink.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 // Vocabulary types for cross-module diagnostic propagation.
 //

--- a/pj_base/include/pj_base/expected.hpp
+++ b/pj_base/include/pj_base/expected.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <string>
 #include <type_traits>

--- a/pj_base/include/pj_base/message_parser_protocol.h
+++ b/pj_base/include/pj_base/message_parser_protocol.h
@@ -21,7 +21,7 @@
  * (bind_schema) -> (classify_schema) -> parse -> destroy.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef PJ_MESSAGE_PARSER_PROTOCOL_H
 #define PJ_MESSAGE_PARSER_PROTOCOL_H

--- a/pj_base/include/pj_base/plugin_abi_export.hpp
+++ b/pj_base/include/pj_base/plugin_abi_export.hpp
@@ -2,7 +2,7 @@
 #define PJ_PLUGIN_ABI_EXPORT_HPP
 
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/plugin_data_api.h"
 

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -1,7 +1,7 @@
 #ifndef PJ_PLUGIN_DATA_API_H
 #define PJ_PLUGIN_DATA_API_H
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/pj_base/include/pj_base/sdk/arrow.hpp
+++ b/pj_base/include/pj_base/sdk/arrow.hpp
@@ -26,7 +26,7 @@
  * nanoarrow themselves and use nanoarrow::UniqueSchema etc.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/data_source_host_views.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_host_views.hpp
@@ -13,7 +13,7 @@
  * in plugin code.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/data_source_patterns.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_patterns.hpp
@@ -34,7 +34,7 @@
  * @see pj_plugins/examples/mock_source_with_dialog.cpp for StreamSourceBase + Dialog.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -24,7 +24,7 @@
  * See `pj_plugins/examples/mock_data_source.cpp` for a complete example.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/detail/data_source_trampolines.hpp
+++ b/pj_base/include/pj_base/sdk/detail/data_source_trampolines.hpp
@@ -9,7 +9,7 @@
  * — the v4 vtable requires it.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
+++ b/pj_base/include/pj_base/sdk/detail/toolbox_trampolines.hpp
@@ -5,7 +5,7 @@
  * Every trampoline is `noexcept` — the v4 vtable requires it.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/media_metadata.hpp
+++ b/pj_base/include/pj_base/sdk/media_metadata.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <string>
 #include <string_view>

--- a/pj_base/include/pj_base/sdk/object_bytes.hpp
+++ b/pj_base/include/pj_base/sdk/object_bytes.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <utility>

--- a/pj_base/include/pj_base/sdk/platform.hpp
+++ b/pj_base/include/pj_base/sdk/platform.hpp
@@ -12,7 +12,7 @@
  * pulling additional translation units or Qt dependencies.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstring>
 #include <functional>
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "pj_base/builtin/builtin_object.hpp"
-
 #include "pj_base/expected.hpp"
 #include "pj_base/plugin_data_api.h"
 #include "pj_base/sdk/arrow.hpp"

--- a/pj_base/include/pj_base/sdk/service_registry.hpp
+++ b/pj_base/include/pj_base/sdk/service_registry.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstring>
 #include <optional>

--- a/pj_base/include/pj_base/sdk/service_traits.hpp
+++ b/pj_base/include/pj_base/sdk/service_traits.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <string_view>

--- a/pj_base/include/pj_base/sdk/testing/parser_write_recorder.hpp
+++ b/pj_base/include/pj_base/sdk/testing/parser_write_recorder.hpp
@@ -23,7 +23,7 @@
  *   EXPECT_DOUBLE_EQ(recorder.rows()[0].fields[0].numeric, 23.5);
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -5,7 +5,7 @@
  * All trampolines are noexcept at the ABI boundary.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_base/include/pj_base/span.hpp
+++ b/pj_base/include/pj_base/span.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <array>
 #include <cstddef>

--- a/pj_base/include/pj_base/toolbox_protocol.h
+++ b/pj_base/include/pj_base/toolbox_protocol.h
@@ -10,7 +10,7 @@
  *   - Every vtable slot is PJ_NOEXCEPT and carries a thread-class tag.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef PJ_TOOLBOX_PROTOCOL_H
 #define PJ_TOOLBOX_PROTOCOL_H

--- a/pj_base/include/pj_base/type_tree.hpp
+++ b/pj_base/include/pj_base/type_tree.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/include/pj_base/types.hpp
+++ b/pj_base/include/pj_base/types.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
 #include <cstddef>

--- a/pj_base/proto/pj/AssetVideo.proto
+++ b/pj_base/proto/pj/AssetVideo.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical asset video protobuf schema.
 // File-backed video reference + playback metadata.
 

--- a/pj_base/proto/pj/CircleAnnotation.proto
+++ b/pj_base/proto/pj/CircleAnnotation.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical image annotation protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/Color.proto
+++ b/pj_base/proto/pj/Color.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical color protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/CompressedPointCloud.proto
+++ b/pj_base/proto/pj/CompressedPointCloud.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical compressed point cloud protobuf schema.
 // Follows the opaque-asset pattern shared with VideoFrame and Mesh3D.
 

--- a/pj_base/proto/pj/DepthImage.proto
+++ b/pj_base/proto/pj/DepthImage.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical depth image protobuf schema.
 // Wire-level contract for PJ::sdk::DepthImage in
 // pj_base/include/pj_base/builtin/DepthImage.hpp.

--- a/pj_base/proto/pj/FrameTransforms.proto
+++ b/pj_base/proto/pj/FrameTransforms.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical frame transform protobuf schemas.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/Geometry.proto
+++ b/pj_base/proto/pj/Geometry.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical geometry protobuf schemas.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/Image.proto
+++ b/pj_base/proto/pj/Image.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical image protobuf schema.
 // Wire-level contract for PJ::sdk::Image in
 // pj_base/include/pj_base/builtin/Image.hpp.

--- a/pj_base/proto/pj/ImageAnnotations.proto
+++ b/pj_base/proto/pj/ImageAnnotations.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical image annotations protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/KeyValuePair.proto
+++ b/pj_base/proto/pj/KeyValuePair.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical metadata protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/Mesh3D.proto
+++ b/pj_base/proto/pj/Mesh3D.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical 3D mesh asset protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/OccupancyGrid.proto
+++ b/pj_base/proto/pj/OccupancyGrid.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical occupancy grid protobuf schema.
 // Wire-level contract for the byte-backed `OccupancyGrid` builtin
 // (SDK struct lives in pj_base/include/pj_base/builtin/OccupancyGrid.hpp

--- a/pj_base/proto/pj/PointCloud.proto
+++ b/pj_base/proto/pj/PointCloud.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical point cloud protobuf schemas.
 // Wire-level contract for PJ::sdk::PointCloud and PJ::sdk::PointField in
 // pj_base/include/pj_base/builtin/PointCloud.hpp.

--- a/pj_base/proto/pj/PointsAnnotation.proto
+++ b/pj_base/proto/pj/PointsAnnotation.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical image annotation protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/SceneEntities.proto
+++ b/pj_base/proto/pj/SceneEntities.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical scene primitive and scene entity protobuf schemas.
 // Field layout adapted from Foxglove SDK schemas (MIT License, Copyright (c) Foxglove Technologies Inc).
 

--- a/pj_base/proto/pj/TextAnnotation.proto
+++ b/pj_base/proto/pj/TextAnnotation.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical image annotation protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/proto/pj/VideoFrame.proto
+++ b/pj_base/proto/pj/VideoFrame.proto
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 // PlotJuggler canonical video frame protobuf schema.
 // Field layout adapted from Foxglove SDK schemas (MIT License,
 // Copyright (c) Foxglove Technologies Inc).

--- a/pj_base/src/builtin/asset_video_codec.cpp
+++ b/pj_base/src/builtin/asset_video_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/asset_video_codec.hpp"
 

--- a/pj_base/src/builtin/compressed_point_cloud_codec.cpp
+++ b/pj_base/src/builtin/compressed_point_cloud_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/compressed_point_cloud_codec.hpp"
 

--- a/pj_base/src/builtin/depth_image_codec.cpp
+++ b/pj_base/src/builtin/depth_image_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/depth_image_codec.hpp"
 

--- a/pj_base/src/builtin/frame_transforms_codec.cpp
+++ b/pj_base/src/builtin/frame_transforms_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/frame_transforms_codec.hpp"
 

--- a/pj_base/src/builtin/geometry_codec.hpp
+++ b/pj_base/src/builtin/geometry_codec.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 //
 // Internal helpers shared across builtin-object codecs. Provides write /
 // decode functions for the geometric primitives reused by multiple types

--- a/pj_base/src/builtin/image_annotations_codec.cpp
+++ b/pj_base/src/builtin/image_annotations_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/image_annotations_codec.hpp"
 

--- a/pj_base/src/builtin/image_codec.cpp
+++ b/pj_base/src/builtin/image_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/image_codec.hpp"
 

--- a/pj_base/src/builtin/mesh3d_codec.cpp
+++ b/pj_base/src/builtin/mesh3d_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/mesh3d_codec.hpp"
 

--- a/pj_base/src/builtin/occupancy_grid_codec.cpp
+++ b/pj_base/src/builtin/occupancy_grid_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/occupancy_grid_codec.hpp"
 

--- a/pj_base/src/builtin/point_cloud_codec.cpp
+++ b/pj_base/src/builtin/point_cloud_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/point_cloud_codec.hpp"
 

--- a/pj_base/src/builtin/protobuf_wire.hpp
+++ b/pj_base/src/builtin/protobuf_wire.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <array>
 #include <cstddef>

--- a/pj_base/src/builtin/scene_entities_codec.cpp
+++ b/pj_base/src/builtin/scene_entities_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/scene_entities_codec.hpp"
 

--- a/pj_base/src/builtin/video_frame_codec.cpp
+++ b/pj_base/src/builtin/video_frame_codec.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/video_frame_codec.hpp"
 

--- a/pj_base/src/type_tree.cpp
+++ b/pj_base/src/type_tree.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/type_tree.hpp"
 

--- a/pj_base/tests/abi_layout_sentinels_test.cpp
+++ b/pj_base/tests/abi_layout_sentinels_test.cpp
@@ -24,7 +24,7 @@
  * port or add target-specific guards here.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_base/tests/arrow_holders_test.cpp
+++ b/pj_base/tests/arrow_holders_test.cpp
@@ -6,7 +6,7 @@
  * release-callback semantics with a simple instrumented struct.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_base/tests/asset_video_codec_test.cpp
+++ b/pj_base/tests/asset_video_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/asset_video_codec.hpp"
 

--- a/pj_base/tests/builtin_object_test.cpp
+++ b/pj_base/tests/builtin_object_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/builtin_object.hpp"
 

--- a/pj_base/tests/compressed_point_cloud_codec_test.cpp
+++ b/pj_base/tests/compressed_point_cloud_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/compressed_point_cloud_codec.hpp"
 

--- a/pj_base/tests/data_source_plugin_base_test.cpp
+++ b/pj_base/tests/data_source_plugin_base_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/sdk/data_source_plugin_base.hpp"
 

--- a/pj_base/tests/data_source_protocol_test.cpp
+++ b/pj_base/tests/data_source_protocol_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/data_source_protocol.h"
 

--- a/pj_base/tests/depth_image_codec_test.cpp
+++ b/pj_base/tests/depth_image_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/depth_image_codec.hpp"
 

--- a/pj_base/tests/expected_test.cpp
+++ b/pj_base/tests/expected_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/expected.hpp"
 

--- a/pj_base/tests/frame_transforms_codec_test.cpp
+++ b/pj_base/tests/frame_transforms_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/frame_transforms_codec.hpp"
 

--- a/pj_base/tests/image_annotations_codec_test.cpp
+++ b/pj_base/tests/image_annotations_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/image_annotations_codec.hpp"
 

--- a/pj_base/tests/image_annotations_decoder_test.cpp
+++ b/pj_base/tests/image_annotations_decoder_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_base/tests/image_codec_test.cpp
+++ b/pj_base/tests/image_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/image_codec.hpp"
 

--- a/pj_base/tests/media_metadata_test.cpp
+++ b/pj_base/tests/media_metadata_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/sdk/media_metadata.hpp"
 

--- a/pj_base/tests/mesh3d_codec_test.cpp
+++ b/pj_base/tests/mesh3d_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/mesh3d_codec.hpp"
 

--- a/pj_base/tests/message_parser_plugin_base_test.cpp
+++ b/pj_base/tests/message_parser_plugin_base_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/sdk/message_parser_plugin_base.hpp"
 

--- a/pj_base/tests/occupancy_grid_codec_test.cpp
+++ b/pj_base/tests/occupancy_grid_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/occupancy_grid_codec.hpp"
 

--- a/pj_base/tests/platform_test.cpp
+++ b/pj_base/tests/platform_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/sdk/platform.hpp"
 

--- a/pj_base/tests/plugin_data_api_test.cpp
+++ b/pj_base/tests/plugin_data_api_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/plugin_data_api.h"
 

--- a/pj_base/tests/point_cloud_codec_test.cpp
+++ b/pj_base/tests/point_cloud_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/point_cloud_codec.hpp"
 

--- a/pj_base/tests/protobuf_wire_test_helpers.hpp
+++ b/pj_base/tests/protobuf_wire_test_helpers.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <cstring>

--- a/pj_base/tests/push_message_v2_test.cpp
+++ b/pj_base/tests/push_message_v2_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests for the SDK template `DataSourceRuntimeHostView::pushMessage` and
 // its delegation to the C ABI slot `push_message_v2`. We exercise:

--- a/pj_base/tests/scene_entities_codec_test.cpp
+++ b/pj_base/tests/scene_entities_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/scene_entities_codec.hpp"
 

--- a/pj_base/tests/span_test.cpp
+++ b/pj_base/tests/span_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/span.hpp"
 

--- a/pj_base/tests/type_tree_test.cpp
+++ b/pj_base/tests/type_tree_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/type_tree.hpp"
 

--- a/pj_base/tests/types_test.cpp
+++ b/pj_base/tests/types_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/types.hpp"
 

--- a/pj_base/tests/video_frame_codec_test.cpp
+++ b/pj_base/tests/video_frame_codec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/builtin/video_frame_codec.hpp"
 

--- a/pj_datastore/benchmarks/ingest_benchmark.cpp
+++ b/pj_datastore/benchmarks/ingest_benchmark.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/benchmarks/read_benchmark.cpp
+++ b/pj_datastore/benchmarks/read_benchmark.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/examples/parquet_import.cpp
+++ b/pj_datastore/examples/parquet_import.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 // parquet_import — load a Parquet file into DataEngine, report memory stats.
 //

--- a/pj_datastore/include/pj_datastore/arrow_import.hpp
+++ b/pj_datastore/include/pj_datastore/arrow_import.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/include/pj_datastore/buffer.hpp
+++ b/pj_datastore/include/pj_datastore/buffer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/include/pj_datastore/builtin_transforms.hpp
+++ b/pj_datastore/include/pj_datastore/builtin_transforms.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_base/types.hpp"
 #include "pj_datastore/derived_engine.hpp"

--- a/pj_datastore/include/pj_datastore/chunk.hpp
+++ b/pj_datastore/include/pj_datastore/chunk.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <atomic>
 #include <cstddef>

--- a/pj_datastore/include/pj_datastore/colormap_registry.hpp
+++ b/pj_datastore/include/pj_datastore/colormap_registry.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <string>
 #include <string_view>

--- a/pj_datastore/include/pj_datastore/colormap_registry_host.hpp
+++ b/pj_datastore/include/pj_datastore/colormap_registry_host.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_base/plugin_data_api.h"
 

--- a/pj_datastore/include/pj_datastore/column_buffer.hpp
+++ b/pj_datastore/include/pj_datastore/column_buffer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/include/pj_datastore/derived_engine.hpp
+++ b/pj_datastore/include/pj_datastore/derived_engine.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <memory>
 #include <string>

--- a/pj_datastore/include/pj_datastore/encoding.hpp
+++ b/pj_datastore/include/pj_datastore/encoding.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <array>
 #include <cstddef>

--- a/pj_datastore/include/pj_datastore/engine.hpp
+++ b/pj_datastore/include/pj_datastore/engine.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <memory>
 #include <string>

--- a/pj_datastore/include/pj_datastore/object_store.hpp
+++ b/pj_datastore/include/pj_datastore/object_store.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/include/pj_datastore/plugin_data_host.hpp
+++ b/pj_datastore/include/pj_datastore/plugin_data_host.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <memory>
 

--- a/pj_datastore/include/pj_datastore/query.hpp
+++ b/pj_datastore/include/pj_datastore/query.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <deque>

--- a/pj_datastore/include/pj_datastore/reader.hpp
+++ b/pj_datastore/include/pj_datastore/reader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <optional>

--- a/pj_datastore/include/pj_datastore/topic_storage.hpp
+++ b/pj_datastore/include/pj_datastore/topic_storage.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstdint>
 #include <deque>

--- a/pj_datastore/include/pj_datastore/type_registry.hpp
+++ b/pj_datastore/include/pj_datastore/type_registry.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <memory>
 #include <optional>

--- a/pj_datastore/include/pj_datastore/writer.hpp
+++ b/pj_datastore/include/pj_datastore/writer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstddef>
 #include <cstdint>

--- a/pj_datastore/src/arrow_import.cpp
+++ b/pj_datastore/src/arrow_import.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/arrow_import.hpp"
 

--- a/pj_datastore/src/buffer.cpp
+++ b/pj_datastore/src/buffer.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/buffer.hpp"
 

--- a/pj_datastore/src/builtin_transforms.cpp
+++ b/pj_datastore/src/builtin_transforms.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/builtin_transforms.hpp"
 

--- a/pj_datastore/src/chunk.cpp
+++ b/pj_datastore/src/chunk.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/chunk.hpp"
 

--- a/pj_datastore/src/colormap_registry.cpp
+++ b/pj_datastore/src/colormap_registry.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/colormap_registry.hpp"
 

--- a/pj_datastore/src/colormap_registry_host.cpp
+++ b/pj_datastore/src/colormap_registry_host.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/colormap_registry_host.hpp"
 

--- a/pj_datastore/src/column_buffer.cpp
+++ b/pj_datastore/src/column_buffer.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/column_buffer.hpp"
 

--- a/pj_datastore/src/derived_engine.cpp
+++ b/pj_datastore/src/derived_engine.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/derived_engine.hpp"
 

--- a/pj_datastore/src/encoding.cpp
+++ b/pj_datastore/src/encoding.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/encoding.hpp"
 

--- a/pj_datastore/src/engine.cpp
+++ b/pj_datastore/src/engine.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/engine.hpp"
 

--- a/pj_datastore/src/object_store.cpp
+++ b/pj_datastore/src/object_store.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/object_store.hpp"
 

--- a/pj_datastore/src/plugin_data_host.cpp
+++ b/pj_datastore/src/plugin_data_host.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/plugin_data_host.hpp"
 

--- a/pj_datastore/src/query.cpp
+++ b/pj_datastore/src/query.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/query.hpp"
 

--- a/pj_datastore/src/reader.cpp
+++ b/pj_datastore/src/reader.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/reader.hpp"
 

--- a/pj_datastore/src/topic_storage.cpp
+++ b/pj_datastore/src/topic_storage.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/topic_storage.hpp"
 

--- a/pj_datastore/src/type_registry.cpp
+++ b/pj_datastore/src/type_registry.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/type_registry.hpp"
 

--- a/pj_datastore/src/writer.cpp
+++ b/pj_datastore/src/writer.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/writer.hpp"
 

--- a/pj_datastore/tests/array_expansion_test.cpp
+++ b/pj_datastore/tests/array_expansion_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/arrow_import_test.cpp
+++ b/pj_datastore/tests/arrow_import_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/arrow_import.hpp"
 

--- a/pj_datastore/tests/arrow_stream_round_trip_test.cpp
+++ b/pj_datastore/tests/arrow_stream_round_trip_test.cpp
@@ -11,7 +11,7 @@
  * a dlopen'd plugin — all ABI calls are made directly on the C vtable.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/buffer_test.cpp
+++ b/pj_datastore/tests/buffer_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/buffer.hpp"
 

--- a/pj_datastore/tests/chunk_test.cpp
+++ b/pj_datastore/tests/chunk_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/chunk.hpp"
 

--- a/pj_datastore/tests/column_buffer_test.cpp
+++ b/pj_datastore/tests/column_buffer_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/column_buffer.hpp"
 

--- a/pj_datastore/tests/derived_engine_test.cpp
+++ b/pj_datastore/tests/derived_engine_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/derived_engine.hpp"
 

--- a/pj_datastore/tests/encoding_test.cpp
+++ b/pj_datastore/tests/encoding_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/encoding.hpp"
 

--- a/pj_datastore/tests/engine_integration_test.cpp
+++ b/pj_datastore/tests/engine_integration_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/object_store_test.cpp
+++ b/pj_datastore/tests/object_store_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/object_store.hpp"
 

--- a/pj_datastore/tests/plugin_data_host_object_read_test.cpp
+++ b/pj_datastore/tests/plugin_data_host_object_read_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/plugin_data_host_object_test.cpp
+++ b/pj_datastore/tests/plugin_data_host_object_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/plugin_host_read_test.cpp
+++ b/pj_datastore/tests/plugin_host_read_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/plugin_host_write_test.cpp
+++ b/pj_datastore/tests/plugin_host_write_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/plugin_parser_object_write_test.cpp
+++ b/pj_datastore/tests/plugin_parser_object_write_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 // Phase 3 — verify that a parser can resolve both the scalar and
 // object write hosts from the service registry and write to each from

--- a/pj_datastore/tests/query_test.cpp
+++ b/pj_datastore/tests/query_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/query.hpp"
 

--- a/pj_datastore/tests/regression_test.cpp
+++ b/pj_datastore/tests/regression_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 // Regression tests for bugs found during code review.
 //

--- a/pj_datastore/tests/series_reader_test.cpp
+++ b/pj_datastore/tests/series_reader_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_datastore/tests/topic_storage_test.cpp
+++ b/pj_datastore/tests/topic_storage_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/topic_storage.hpp"
 

--- a/pj_datastore/tests/type_registry_test.cpp
+++ b/pj_datastore/tests/type_registry_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pj_datastore/type_registry.hpp"
 

--- a/pj_plugins/dialog_protocol/examples/mock_dialog.cpp
+++ b/pj_plugins/dialog_protocol/examples/mock_dialog.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_plugins/sdk/dialog_plugin_typed.hpp>
 #include <pj_plugins/sdk/widget_data.hpp>

--- a/pj_plugins/dialog_protocol/include/pj_plugins/dialog_protocol.h
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/dialog_protocol.h
@@ -1,7 +1,7 @@
 #ifndef PJ_DIALOG_PROTOCOL_H
 #define PJ_DIALOG_PROTOCOL_H
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/dialog_handle.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/dialog_handle.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_plugins/dialog_protocol.h>
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/dialog_library.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/dialog_library.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_plugins/dialog_protocol.h>
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <map>

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <nlohmann/json.hpp>
 #include <string>
@@ -122,8 +122,8 @@ struct WidgetEventBuilder {
 
   /// SequencePicker: date/time range filter changed. from/to are ISO-8601
   /// datetime strings (empty = unbounded on that side).
-  [[nodiscard]] static std::string dateRangeChanged(std::string_view from_iso, std::string_view to_iso,
-                                                    bool every_day) {
+  [[nodiscard]] static std::string dateRangeChanged(
+      std::string_view from_iso, std::string_view to_iso, bool every_day) {
     nlohmann::json j;
     j["date_from_iso"] = from_iso;
     j["date_to_iso"] = to_iso;

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_plugins/dialog_protocol.h>
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_plugins/sdk/dialog_plugin_base.hpp>
 #include <pj_plugins/sdk/widget_event.hpp>
@@ -90,15 +90,16 @@ class DialogPluginTyped : public DialogPluginBase {
 
   /// SequencePicker: the date/time range filter changed. from_iso/to_iso are
   /// ISO-8601 datetime strings (empty = unbounded on that side).
-  virtual bool onDateRangeChanged(std::string_view /*widget_name*/, std::string_view /*from_iso*/,
-                                  std::string_view /*to_iso*/, bool /*every_day*/) {
+  virtual bool onDateRangeChanged(
+      std::string_view /*widget_name*/, std::string_view /*from_iso*/, std::string_view /*to_iso*/,
+      bool /*every_day*/) {
     return false;
   }
 
   /// MetadataQueryBar: a key/op/value selector combo was activated.
   /// role is "key" | "op" | "value".
-  virtual bool onQuerySelector(std::string_view /*widget_name*/, std::string_view /*role*/,
-                               std::string_view /*value*/) {
+  virtual bool onQuerySelector(
+      std::string_view /*widget_name*/, std::string_view /*role*/, std::string_view /*value*/) {
     return false;
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/encoding_utils.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/encoding_utils.hpp
@@ -6,7 +6,7 @@
  * runtimeHost().listAvailableEncodings() into a std::vector<std::string>.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <map>

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <nlohmann/json.hpp>
 #include <optional>

--- a/pj_plugins/dialog_protocol/src/dialog_library.cpp
+++ b/pj_plugins/dialog_protocol/src/dialog_library.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/dialog_library.hpp"
 

--- a/pj_plugins/dialog_protocol/tests/dialog_handle_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/dialog_handle_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/dialog_protocol/tests/dialog_library_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/dialog_library_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/dialog_library.hpp"
 

--- a/pj_plugins/dialog_protocol/tests/dialog_plugin_typed_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/dialog_plugin_typed_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/dialog_protocol/tests/missing_dialog_abi_plugin.cpp
+++ b/pj_plugins/dialog_protocol/tests/missing_dialog_abi_plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include "pj_plugins/dialog_protocol.h"
 
 namespace {

--- a/pj_plugins/dialog_protocol/tests/missing_dialog_required_slots_plugin.cpp
+++ b/pj_plugins/dialog_protocol/tests/missing_dialog_required_slots_plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include "pj_plugins/dialog_protocol.h"
 
 extern "C" PJ_DIALOG_EXPORT const uint32_t pj_plugin_abi_version = PJ_ABI_VERSION;

--- a/pj_plugins/dialog_protocol/tests/plugin_lifecycle_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/plugin_lifecycle_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 #include <pj_plugins/dialog_protocol.h>

--- a/pj_plugins/dialog_protocol/tests/widget_data_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_data_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/dialog_protocol/tests/widget_data_view_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_data_view_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/dialog_protocol/tests/widget_event_builder_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_event_builder_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/dialog_protocol/tests/widget_event_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_event_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/examples/mock_data_source.cpp
+++ b/pj_plugins/examples/mock_data_source.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_base/sdk/data_source_plugin_base.hpp>
 #include <string>

--- a/pj_plugins/examples/mock_file_source.cpp
+++ b/pj_plugins/examples/mock_file_source.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_base/sdk/data_source_patterns.hpp>
 #include <string>

--- a/pj_plugins/examples/mock_json_parser.cpp
+++ b/pj_plugins/examples/mock_json_parser.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdlib>
 #include <string>

--- a/pj_plugins/examples/mock_schema_parser.cpp
+++ b/pj_plugins/examples/mock_schema_parser.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdlib>
 #include <cstring>

--- a/pj_plugins/examples/mock_source_with_dialog.cpp
+++ b/pj_plugins/examples/mock_source_with_dialog.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_base/sdk/data_source_patterns.hpp>
 #include <pj_plugins/sdk/dialog_plugin_typed.hpp>

--- a/pj_plugins/examples/mock_toolbox.cpp
+++ b/pj_plugins/examples/mock_toolbox.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <pj_base/sdk/toolbox_plugin_base.hpp>
 #include <string>

--- a/pj_plugins/include/pj_plugins/host/config_envelope.hpp
+++ b/pj_plugins/include/pj_plugins/host/config_envelope.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <nlohmann/json.hpp>
 #include <string>

--- a/pj_plugins/include/pj_plugins/host/data_source_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/data_source_handle.hpp
@@ -18,7 +18,7 @@
  * @endcode
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/host/data_source_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/data_source_library.hpp
@@ -14,7 +14,7 @@
  * @endcode
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/host/message_parser_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/message_parser_handle.hpp
@@ -3,7 +3,7 @@
  * @brief RAII wrapper around a single MessageParser plugin instance (v4).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
@@ -14,7 +14,7 @@
  * @endcode
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 /**
  * @file plugin_catalog.hpp

--- a/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <filesystem>

--- a/pj_plugins/include/pj_plugins/host/service_registry_builder.hpp
+++ b/pj_plugins/include/pj_plugins/host/service_registry_builder.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <cstring>

--- a/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_handle.hpp
@@ -3,7 +3,7 @@
  * @brief RAII wrapper around a single Toolbox plugin instance (protocol v4).
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
@@ -14,7 +14,7 @@
  * @endcode
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/sdk/detail/message_parser_trampolines.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/detail/message_parser_trampolines.hpp
@@ -6,7 +6,7 @@
  * Every trampoline is `noexcept` — the v4 vtable requires it.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
@@ -10,7 +10,7 @@
  * All trampolines are noexcept at the ABI boundary.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
@@ -164,8 +164,7 @@ class MessageParserPluginBase {
     // Use the parser-provided timestamp if set, otherwise fall back to the
     // host-provided one (the message receive time).
     const Timestamp ts = record->ts.value_or(timestamp_ns);
-    return writeHost().appendRecord(
-        ts, Span<const sdk::NamedFieldValue>(record->fields.data(), record->fields.size()));
+    return writeHost().appendRecord(ts, Span<const sdk::NamedFieldValue>(record->fields.data(), record->fields.size()));
   }
 
   // ---------------------------------------------------------------------------
@@ -237,8 +236,7 @@ class MessageParserPluginBase {
   /// Returns unexpected if no handler is registered, or if the registered
   /// handler did not provide a parse_scalars callable. Marked `final` — see
   /// classifySchema above for the rationale.
-  virtual Expected<sdk::ScalarRecord> parseScalars(
-      Timestamp timestamp_ns, Span<const uint8_t> payload) final {
+  virtual Expected<sdk::ScalarRecord> parseScalars(Timestamp timestamp_ns, Span<const uint8_t> payload) final {
     const auto* h = findSchemaHandler(bound_type_name_);
     if (h == nullptr) {
       return unexpected(std::string("parser does not register schema: ") + bound_type_name_);

--- a/pj_plugins/include/pj_plugins/sdk/object_ingest_policy.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/object_ingest_policy.hpp
@@ -12,7 +12,7 @@
  * consumer pulls.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/include/pj_plugins/testing/toolbox_test_store.hpp
+++ b/pj_plugins/include/pj_plugins/testing/toolbox_test_store.hpp
@@ -39,7 +39,7 @@
  * double-free.
  */
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/pj_plugins/src/data_source_library.cpp
+++ b/pj_plugins/src/data_source_library.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/data_source_library.hpp"
 

--- a/pj_plugins/src/detail/library_loader.hpp
+++ b/pj_plugins/src/detail/library_loader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include <memory>

--- a/pj_plugins/src/detail/vtable_validation.cpp
+++ b/pj_plugins/src/detail/vtable_validation.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include "vtable_validation.hpp"
 
 #include <initializer_list>

--- a/pj_plugins/src/detail/vtable_validation.hpp
+++ b/pj_plugins/src/detail/vtable_validation.hpp
@@ -1,4 +1,6 @@
 #pragma once
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/data_source_protocol.h"
 #include "pj_base/expected.hpp"

--- a/pj_plugins/src/message_parser_library.cpp
+++ b/pj_plugins/src/message_parser_library.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/message_parser_library.hpp"
 

--- a/pj_plugins/src/plugin_catalog.cpp
+++ b/pj_plugins/src/plugin_catalog.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/plugin_catalog.hpp"
 

--- a/pj_plugins/src/plugin_runtime_catalog.cpp
+++ b/pj_plugins/src/plugin_runtime_catalog.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/plugin_runtime_catalog.hpp"
 

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/toolbox_library.hpp"
 

--- a/pj_plugins/tests/data_source_library_test.cpp
+++ b/pj_plugins/tests/data_source_library_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/data_source_library.hpp"
 

--- a/pj_plugins/tests/delegated_ingest_integration_test.cpp
+++ b/pj_plugins/tests/delegated_ingest_integration_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/tests/file_source_integration_test.cpp
+++ b/pj_plugins/tests/file_source_integration_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/tests/invalid_optional_manifest_data_source_plugin.cpp
+++ b/pj_plugins/tests/invalid_optional_manifest_data_source_plugin.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/data_source_protocol.h"
 

--- a/pj_plugins/tests/legacy_macro_dialog_plugin.cpp
+++ b/pj_plugins/tests/legacy_macro_dialog_plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include <pj_plugins/sdk/dialog_plugin_base.hpp>
 #include <string>
 #include <string_view>

--- a/pj_plugins/tests/message_parser_library_test.cpp
+++ b/pj_plugins/tests/message_parser_library_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/message_parser_library.hpp"
 

--- a/pj_plugins/tests/missing_id_data_source_plugin.cpp
+++ b/pj_plugins/tests/missing_id_data_source_plugin.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/data_source_protocol.h"
 

--- a/pj_plugins/tests/missing_required_slots_plugin.cpp
+++ b/pj_plugins/tests/missing_required_slots_plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include "pj_base/data_source_protocol.h"
 #include "pj_base/message_parser_protocol.h"
 #include "pj_base/toolbox_protocol.h"

--- a/pj_plugins/tests/mock_data_source_v2_plugin.cpp
+++ b/pj_plugins/tests/mock_data_source_v2_plugin.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_base/data_source_protocol.h"
 

--- a/pj_plugins/tests/object_ingest_policy_test.cpp
+++ b/pj_plugins/tests/object_ingest_policy_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/sdk/object_ingest_policy.hpp"
 

--- a/pj_plugins/tests/plugin_catalog_test.cpp
+++ b/pj_plugins/tests/plugin_catalog_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include "pj_plugins/host/plugin_catalog.hpp"
 

--- a/pj_plugins/tests/source_dialog_integration_test.cpp
+++ b/pj_plugins/tests/source_dialog_integration_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/pj_plugins/tests/static_manifest_dialog_plugin.cpp
+++ b/pj_plugins/tests/static_manifest_dialog_plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
 #include "pj_plugins/dialog_protocol.h"
 
 extern "C" PJ_DIALOG_EXPORT const uint32_t pj_plugin_abi_version = PJ_ABI_VERSION;

--- a/pj_plugins/tests/toolbox_plugin_test.cpp
+++ b/pj_plugins/tests/toolbox_plugin_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 Davide Faconti
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
…A scaffold

Split licensing so third parties can build proprietary plugins (Apache-2.0 on pj_base + pj_plugins) while the storage engine stays weak copyleft (MPL-2.0 on pj_datastore). Adds per-file SPDX headers, the full Apache-2.0 and MPL-2.0 texts, a per-module LICENSE map, and updates conanfile.py (license = "Apache-2.0 AND MPL-2.0") and the README.

Also scaffolds a CLA Assistant Lite workflow (.github/workflows/cla.yml) and CLA.md, whose relicensing grant preserves a future commercial-license option for the engine. The workflow is inert until enabled (see CLA.md setup notes).