### PR TITLE
chore: detach pj_ported_plugins from build, document main as PR target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,17 @@ CLAUDE.md -> relevant docs -> code
 
 Dependencies: Conan (`conanfile.txt`).
 
+## Branch Convention
+
+- PRs target **`main`** (`gh repo view --json defaultBranchRef`). There is no
+  `development` branch — earlier docs/state hints may say otherwise; they are
+  stale.
+- The official PlotJuggler plugin collection lives in a separate repo,
+  `pj-official-plugins` (not bundled here). If you see a local
+  `pj_ported_plugins/` directory inside this checkout, it's an external repo
+  you cloned for staging; this build system does not depend on or descend
+  into it.
+
 ## Pre-commit Validation
 
 Before committing, first check whether the code changes require documentation updates. If documentation is stale

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ option(
   ON
 )
 option(PJ_BUILD_DATASTORE "Build pj_datastore module (requires nanoarrow)" ON)
-option(PJ_BUILD_PORTED_PLUGINS "Build pj_ported_plugins (ported plugins collection)" ON)
 option(PJ_BUILD_TESTS "Build tests, benchmarks, and examples" ON)
 option(PJ_ENABLE_ABI_CHECK "Enable abidiff-based ABI drift gate (requires libabigail)" OFF)
 
@@ -175,11 +174,6 @@ if(PJ_BUILD_DATASTORE)
   add_subdirectory(pj_datastore)
 endif()
 add_subdirectory(pj_plugins)
-
-if(PJ_BUILD_PORTED_PLUGINS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/pj_ported_plugins/CMakeLists.txt")
-  set(PJ_HAS_PORTED_PLUGINS TRUE)
-  add_subdirectory(pj_ported_plugins)
-endif()
 
 # ---------------------------------------------------------------------------
 # plotjuggler_core package install

--- a/build.sh
+++ b/build.sh
@@ -73,15 +73,6 @@ build_config() {
     -o "plotjuggler_core/*:with_parquet_example=True" \
     "${conan_extra[@]+"${conan_extra[@]}"}"
 
-  # Install dependencies from subdirectory conanfiles (e.g. pj_ported_plugins)
-  for sub_conan in "$SCRIPT_DIR"/pj_ported_plugins/conanfile.txt; do
-    if [[ -f "$sub_conan" ]]; then
-      echo "--- Installing deps from $(dirname "$sub_conan") ---"
-      conan install "$(dirname "$sub_conan")" --output-folder="$build_dir" --build=missing \
-        -s build_type="$build_type" -s compiler.cppstd=20 \
-        "${conan_extra[@]+"${conan_extra[@]}"}"
-    fi
-  done
   cmake -S "$SCRIPT_DIR" -B "$build_dir" \
     -DCMAKE_TOOLCHAIN_FILE="$build_dir/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE="$build_type" \

--- a/conanfile.py
+++ b/conanfile.py
@@ -121,7 +121,6 @@ class PlotjugglerCoreConan(ConanFile):
         tc.cache_variables["PJ_INSTALL_SDK"] = True
         tc.cache_variables["PJ_BUILD_DATASTORE"] = bool(self.options.with_datastore)
         tc.cache_variables["PJ_BUILD_TESTS"] = bool(self.options.with_tests)
-        tc.cache_variables["PJ_BUILD_PORTED_PLUGINS"] = False
         tc.cache_variables["PJ_BUILD_PARQUET_IMPORT_EXAMPLE"] = bool(
             self.options.with_parquet_example
         )


### PR DESCRIPTION
## Summary

- Remove the `add_subdirectory(pj_ported_plugins)` hook, the unused `PJ_BUILD_PORTED_PLUGINS` CMake option, and the `build.sh` loop that ran `conan install` inside `pj_ported_plugins/`. The collection is maintained upstream as `pj-official-plugins`; no in-tree subdirectory is expected.
- Drop the stale `tc.cache_variables["PJ_BUILD_PORTED_PLUGINS"] = False` line in `conanfile.py` — CMake no longer defines the option, so this assignment was a no-op that would produce an "unused variable" warning on the next reconfigure.
- Document in `CLAUDE.md`: PRs target `main` (origin/development was deleted upstream; `gh repo view --json defaultBranchRef` returns `main`). Also note that `pj_ported_plugins/` is external and not part of this build.

## Test plan

- [x] `cmake -B build` reconfigures cleanly with no `PJ_BUILD_PORTED_PLUGINS` warning
- [x] Full build (`cmake --build build`) passes with `-Wall -Wextra -Werror`
- [x] All 62 ctest cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)