### PR TITLE
ci(release): publish Conan binaries for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,10 @@ name: Release
 # first attempt failed (e.g. flaky upload on one platform). Set `tag` input to
 # e.g. v0.1.0. NOTE: do not *move* an already-released tag to a new commit —
 # cut a new patch version instead. Moving a tag changes the recipe revision on
-# the remote and orphans any consumer mid-resolve.
+# the remote and orphans any consumer mid-resolve. The `prepare` job enforces
+# this: it refuses to publish a version that already exists on Cloudsmith under
+# a different recipe revision (override with the `allow_republish` input only to
+# repair a botched release).
 
 on:
   push:
@@ -34,6 +37,11 @@ on:
       tag:
         description: 'Tag to (re-)release (e.g. v0.1.0). Must already exist.'
         required: true
+      allow_republish:
+        description: 'Bypass the re-publish guard (only to repair a botched release of an existing version)'
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -73,6 +81,8 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
+      - uses: conan-io/setup-conan@v1
+
       - name: Verify recipe version matches tag
         # Prevents the common footgun of tagging vX.Y.Z but forgetting to bump
         # `version` in conanfile.py. Fails fast before we publish.
@@ -83,6 +93,61 @@ jobs:
             exit 1
           fi
           echo "Version match: ${recipe_version}"
+
+      - name: Guard against re-publishing an existing version with different sources
+        # The incident this matrix fixes was triggered by *moving* a released tag:
+        # v0.5.0 was published twice from two different commits, so the second run
+        # produced a new recipe revision that replaced the first and orphaned any
+        # consumer that had resolved the original mid-build. This guard computes
+        # the recipe revision THIS release would publish and compares it to what is
+        # already on Cloudsmith for this version:
+        #   * version not published yet     -> proceed (first release)
+        #   * same recipe revision present  -> proceed (idempotent re-run after a
+        #                                      flaky/partial upload)
+        #   * a different revision present  -> FAIL (sources changed under an
+        #                                      already-released version)
+        # prepare runs on Linux (LF); the build matrix forces an LF checkout, so
+        # both compute the same canonical recipe revision.
+        env:
+          CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          if [[ "${{ inputs.allow_republish }}" == "true" ]]; then
+            echo "allow_republish=true -> skipping the re-publish guard"
+            exit 0
+          fi
+          version="${{ steps.ref.outputs.version }}"
+
+          # Recipe revision this release would publish (deterministic from the
+          # checked-out sources, independent of build settings).
+          conan profile detect --force >/dev/null 2>&1 || true
+          local_rrev=$(conan export . --format=json \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['reference'].split('#',1)[1])")
+          echo "This release would publish recipe revision: ${local_rrev}"
+
+          conan remote add plotjuggler-cloudsmith https://conan.cloudsmith.io/plotjuggler/plotjuggler --force
+          if [[ -n "$CLOUDSMITH_USER" && -n "$CLOUDSMITH_API_KEY" ]]; then
+            conan remote login plotjuggler-cloudsmith "$CLOUDSMITH_USER" -p "$CLOUDSMITH_API_KEY"
+          fi
+
+          conan list "plotjuggler_core/${version}#*" -r plotjuggler-cloudsmith --format=json \
+            > /tmp/remote_revs.json 2>/dev/null || true
+
+          if grep -q "RECIPEUNKNOWN" /tmp/remote_revs.json; then
+            echo "Version ${version} is not yet published — first release, proceeding."
+          elif grep -q '"error"' /tmp/remote_revs.json; then
+            echo "::warning::Unexpected error reading published revisions for ${version} (transient?). Proceeding without the guard."
+            cat /tmp/remote_revs.json
+          elif grep -q "${local_rrev}" /tmp/remote_revs.json; then
+            echo "Recipe revision ${local_rrev} is already published for ${version} — idempotent re-run, proceeding."
+          else
+            echo "::error::plotjuggler_core/${version} is already published with a different recipe revision."
+            echo "::error::This build would publish ${local_rrev}, which is not on the remote. Refusing to overwrite a released version."
+            echo "::error::Cut a new version, or re-run via workflow_dispatch with allow_republish=true to repair a botched release."
+            echo "Currently published for ${version}:"
+            conan list "plotjuggler_core/${version}#*" -r plotjuggler-cloudsmith 2>/dev/null || true
+            exit 1
+          fi
 
   # ---------------------------------------------------------------------------
   # Build + upload one Conan binary per consumer platform. fail-fast: false so
@@ -103,6 +168,16 @@ jobs:
       run:
         shell: bash   # Git Bash on Windows; conan/cmake are on PATH everywhere
     steps:
+      - name: Force LF line endings (consistent recipe revision across OSes)
+        # No .gitattributes in the repo, so on Windows git would convert text
+        # files to CRLF on checkout, changing the recipe revision hash and
+        # splitting the package across two revisions. Force LF everywhere so every
+        # matrix leg computes and uploads the SAME recipe revision (matching the
+        # one prepare's guard validated on Linux).
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,29 @@
 name: Release
 
 # Triggers on tag push (e.g. `git push origin v0.2.0`). Builds the Conan
-# package, uploads it to the project's Cloudsmith remote, and publishes a
-# GitHub Release with auto-generated notes.
+# package on every consumer platform (Linux, macOS, Windows), uploads each
+# binary to the project's Cloudsmith remote, and publishes a GitHub Release
+# with auto-generated notes.
 #
-# Secrets required (set in repo Settings → Secrets and variables → Actions):
-#   CLOUDSMITH_USER     — Cloudsmith username (e.g. "davide-faconti")
-#   CLOUDSMITH_API_KEY  — Cloudsmith API key with write access to the
+# Why a matrix: Cloudsmith stores one binary package per platform/compiler
+# (package_id). A single ubuntu job only ever publishes a Linux/gcc binary, so
+# macOS and Windows consumers are forced to build plotjuggler_core from source
+# via `--build=missing`. That is slow and, on macOS specifically, fragile: a
+# from-source build depends on the recipe's exported sources being intact in
+# the cache, which breaks (e.g. after a version is re-published with a new
+# recipe revision) with "exports_sources but sources not found in local cache".
+# Publishing a binary per platform means consumers download instead of compile.
+#
+# Secrets required (set in repo Settings -> Secrets and variables -> Actions):
+#   CLOUDSMITH_USER     - Cloudsmith username (e.g. "davide-faconti")
+#   CLOUDSMITH_API_KEY  - Cloudsmith API key with write access to the
 #                         plotjuggler/plotjuggler repository
 #
-# Manual trigger: workflow_dispatch lets you re-run for an existing tag if
-# the first attempt failed (e.g. flaky upload). Set `tag` input to e.g. v0.1.0.
+# Manual trigger: workflow_dispatch lets you re-run for an existing tag if the
+# first attempt failed (e.g. flaky upload on one platform). Set `tag` input to
+# e.g. v0.1.0. NOTE: do not *move* an already-released tag to a new commit —
+# cut a new patch version instead. Moving a tag changes the recipe revision on
+# the remote and orphans any consumer mid-resolve.
 
 on:
   push:
@@ -27,10 +40,18 @@ concurrency:
   cancel-in-progress: false  # never cancel an in-flight release
 
 jobs:
-  release:
+  # ---------------------------------------------------------------------------
+  # Resolve the version/tag once and verify it matches conanfile.py, so the
+  # build matrix and the GitHub Release all agree on a single source of truth.
+  # ---------------------------------------------------------------------------
+  prepare:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write   # required to create the GitHub Release
+      contents: read
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+      tag: ${{ steps.ref.outputs.tag }}
+      version: ${{ steps.ref.outputs.version }}
     steps:
       - name: Resolve ref
         id: ref
@@ -52,13 +73,6 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: conan-io/setup-conan@v1
-
-      - name: Detect Conan profile
-        run: |
-          conan profile detect --force
-          conan profile show
-
       - name: Verify recipe version matches tag
         # Prevents the common footgun of tagging vX.Y.Z but forgetting to bump
         # `version` in conanfile.py. Fails fast before we publish.
@@ -70,7 +84,40 @@ jobs:
           fi
           echo "Version match: ${recipe_version}"
 
+  # ---------------------------------------------------------------------------
+  # Build + upload one Conan binary per consumer platform. fail-fast: false so
+  # a transient failure on one OS still publishes the others (re-run the
+  # workflow_dispatch for the failed leg); the GitHub Release is gated on ALL
+  # legs succeeding so we never advertise an incomplete release.
+  # ---------------------------------------------------------------------------
+  build:
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15-intel, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash   # Git Bash on Windows; conan/cmake are on PATH everywhere
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - uses: conan-io/setup-conan@v1
+
+      - name: Detect Conan profile
+        run: |
+          conan profile detect --force
+          conan profile show
+
       - name: Build Conan package
+        # Same settings consumers use (-s build_type=Release -s
+        # compiler.cppstd=20) so the published package_id matches what
+        # downstream `conan install` resolves on each platform.
         run: |
           conan create . \
             --build=missing \
@@ -91,19 +138,32 @@ jobs:
           conan remote login plotjuggler-cloudsmith "$CLOUDSMITH_USER" -p "$CLOUDSMITH_API_KEY"
 
       - name: Upload package to Cloudsmith
+        # Each matrix leg uploads the recipe + its own binary. The recipe
+        # revision is identical across platforms (same recipe content), so
+        # concurrent recipe uploads are idempotent — only the per-platform
+        # binary differs. `--check` verifies integrity before/after transfer.
         run: |
-          conan upload "plotjuggler_core/${{ steps.ref.outputs.version }}" \
+          conan upload "plotjuggler_core/${{ needs.prepare.outputs.version }}" \
             -r plotjuggler-cloudsmith \
             --confirm \
             --check
 
+  # ---------------------------------------------------------------------------
+  # Cut the GitHub Release once, only after every platform binary is published.
+  # ---------------------------------------------------------------------------
+  github-release:
+    needs: [prepare, build]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write   # required to create the GitHub Release
+    steps:
       - name: Create GitHub Release
         # softprops/action-gh-release: handles auto-generated notes + idempotent
         # re-runs (skips if a release for the tag already exists).
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.ref.outputs.tag }}
-          name: plotjuggler_core ${{ steps.ref.outputs.tag }}
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: plotjuggler_core ${{ needs.prepare.outputs.tag }}
           generate_release_notes: true
           body: |
             ## Install via Conan
@@ -115,7 +175,7 @@ jobs:
             Add to your `conanfile.py` / `conanfile.txt`:
 
             ```python
-            requires = ("plotjuggler_core/${{ steps.ref.outputs.version }}",)
+            requires = ("plotjuggler_core/${{ needs.prepare.outputs.version }}",)
             ```
 
             Link in CMake:


### PR DESCRIPTION
## Problem

The `Release` workflow ran on a **single `ubuntu-22.04` job**, so Cloudsmith only ever received a **Linux/gcc** binary of `plotjuggler_core`. macOS and Windows consumers were therefore forced to build core from source via `--build=missing`.

That is slow, and on **macOS** it is brittle: a from-source build depends on the recipe's exported sources being intact in the local cache. After a version is re-published under a new recipe revision (or a cache is restored from a superseded one), the build dies with:

```
ERROR: The 'plotjuggler_core/0.5.0' package has 'exports_sources' but sources not found in local cache.
Probably it was installed from a remote that is no longer available.
```

This is exactly what broke the downstream **pj-official-plugins macOS CI** on `main`. (Earlier, pre-`fast_float`, the from-source macOS build also failed to compile because libc++ lacks `std::from_chars` for floating-point — now fixed in `number_parse.hpp`, but the from-source path remains an avoidable liability.)

## Fix

Restructure the workflow into three jobs:

- **`prepare`** — resolve the version/tag once and verify it matches `conanfile.py` (unchanged logic, now exposed as job outputs).
- **`build`** — matrix over `[ubuntu-22.04, macos-15-intel, windows-latest]`, each running `conan create` + `conan upload` with the same `-s build_type=Release -s compiler.cppstd=20` settings consumers use, so the published `package_id` matches what downstream `conan install` resolves on each platform.
- **`github-release`** — cut the GitHub Release once, gated on **all** platform binaries publishing successfully.

With a binary per platform, downstream macOS/Windows CI **downloads** core instead of compiling it — eliminating the from-source fragility entirely (and speeding those jobs up).

### Notes
- `fail-fast: false` so a flaky upload on one OS still publishes the others; re-run the failed leg via `workflow_dispatch`. The GitHub Release stays gated on every leg succeeding, so an incomplete release is never advertised.
- Matrix legs each upload the recipe + their own binary; the recipe revision is identical across platforms, so concurrent recipe uploads are idempotent (only the per-platform binary differs).
- `package_id` matching assumes the release runner and the consumer runner share a compiler version (e.g. both `macos-15-intel`). If a runner image bumps Xcode/MSVC between release and consumption, consumers harmlessly fall back to today's from-source behavior.

## Follow-up (not in this PR)
The original incident's trigger was a **moved tag** (`v0.5.0` published twice from two different commits). This PR makes consumers robust to that, but does not prevent it. A guard in `prepare` that refuses to publish over an existing-but-different recipe revision could be added separately — happy to include it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)