### PR TITLE
feat(pj_base): add DatasetDescriptor::requested_id for streaming lockstep

### DIFF
--- a/pj_base/include/pj_base/dataset.hpp
+++ b/pj_base/include/pj_base/dataset.hpp
@@ -28,6 +28,12 @@ struct DatasetDescriptor {
   std::string source_name;
   /// Time domain used by all topics in this dataset.
   TimeDomainId time_domain_id = 0;
+  /// When non-zero, create the dataset with this exact DatasetId instead of the
+  /// next auto-assigned one (fails if already in use; advances the counter past
+  /// it). Lets the streaming lockstep mirror give the secondary engine the SAME
+  /// DatasetId as the primary even when their counters have drifted (e.g. a file
+  /// loaded between streams touched only the primary). Zero = auto-assign.
+  DatasetId requested_id = 0;
 };
 
 /// Materialized dataset record stored in the engine.


### PR DESCRIPTION
## Summary

Add an optional `requested_id` field to `DatasetDescriptor`. When non-zero, the engine creates the dataset with that exact `DatasetId` (failing if it is already in use and advancing the counter past it); zero keeps the previous auto-assign behaviour, so existing callers are unaffected.

## Why

This is the SDK half of a streaming secondary-engine id desync fix. The lockstep mirror needs to give the secondary engine the **same** `DatasetId` as the primary even when their id counters have drifted — e.g. a file loaded between two streams advances only the primary's counter, so a later `createDataset` on each engine would yield two different ids and the two engines would key the dataset differently.

The consuming side (`DataEngine::createDataset` honouring `requested_id`, plus the parallel `TopicDescriptor::requested_id` field and the streaming source manager wiring) lives in the app repo: PlotJuggler/PJ4#145. That PR does not compile against the current public SDK because the field added here doesn't exist yet — this PR unblocks it.

## Scope

- One header change in `pj_base/include/pj_base/dataset.hpp` (+6 lines).
- Field is **additive and default-zero**: no existing callsite needs to change.
- No ABI break (struct grows by one `DatasetId` at the end; layout of existing fields unchanged).

## Test plan

- [ ] CI green on all matrix jobs (header-only change; build only).
- [ ] PlotJuggler/PJ4#145 builds clean once this lands and the SDK Conan recipe is bumped.