### PR TITLE
feat(pj_plugins): expose DataSourceHandle::libraryOwner() for lazy-payload DSO lifetime

### DIFF
--- a/pj_plugins/CLAUDE.md
+++ b/pj_plugins/CLAUDE.md
@@ -35,9 +35,11 @@ submodule-internal modules; `pj_base` carries none).
   only `MessageParserPluginBase` + `object_ingest_policy.hpp` live here under
   `pj_plugins/sdk/`. (The `docs/ARCHITECTURE.md` §2 diagram is stale on this.)
 - **Handles keep the DSO mapped.** Every handle holds a `shared_ptr<void>`
-  library token, so destroying/hot-reloading the loader cannot `dlclose` a live
-  plugin. Dialog handles add a non-owning `borrowed()` form for source/toolbox
-  embedded dialogs — those must not outlive the owning handle.
+  library token (exposed via `libraryOwner()`), so destroying/hot-reloading the
+  loader cannot `dlclose` a live plugin — and a lazy ObjectStore payload anchor,
+  whose `release` fn is plugin code, can capture that token to stay safe past the
+  handle's own lifetime. Dialog handles add a non-owning `borrowed()` form for
+  source/toolbox embedded dialogs — those must not outlive the owning handle.
 
 ## Read deeper
 | For | Read |

--- a/pj_plugins/docs/ARCHITECTURE.md
+++ b/pj_plugins/docs/ARCHITECTURE.md
@@ -359,7 +359,10 @@ Each family has a move-only RAII handle:
 - Destructor calls `vt->destroy(ctx)`.
 - Handles created by a loader retain a shared DSO owner; destroying or
   hot-reloading the loader/catalog entry cannot `dlclose` the plugin while
-  live handles still call its vtable.
+  live handles still call its vtable. `DataSourceHandle` exposes this token via
+  `libraryOwner()` so it can be captured anywhere plugin code may outlive the
+  handle — e.g. a lazy `ObjectStore` payload anchor whose `release` fn lives in
+  the plugin `.so` — keeping the DSO mapped until that captor is gone too.
 - No copy, move-only semantics.
 - Methods delegate to vtable functions with the stored context pointer.
 

--- a/pj_plugins/include/pj_plugins/host/data_source_handle.hpp
+++ b/pj_plugins/include/pj_plugins/host/data_source_handle.hpp
@@ -73,6 +73,14 @@ class DataSourceHandle {
     return vt_ != nullptr && ctx_ != nullptr;
   }
 
+  // The shared library token that keeps this plugin's DSO mapped. Capture a copy
+  // anywhere a callback or payload anchor PRODUCED BY the plugin may outlive this
+  // handle (e.g. lazy ObjectStore payloads): the .so must not be dlclosed while
+  // plugin code (a payload anchor's release fn) can still run.
+  [[nodiscard]] std::shared_ptr<void> libraryOwner() const {
+    return library_owner_;
+  }
+
   [[nodiscard]] std::string manifest() const {
     return vt_->manifest_json != nullptr ? std::string(vt_->manifest_json) : std::string();
   }


### PR DESCRIPTION
## What

Adds a `libraryOwner()` accessor to `DataSourceHandle` returning the handle's existing `shared_ptr<void>` DSO keepalive token, plus doc updates.

## Why

A lazy `ObjectStore` payload anchor carries the producing plugin's `release` fn (code compiled into the plugin `.so`) and can **outlive** the `DataSourceHandle` that loaded the plugin — e.g. a cached entry surviving a mid-session catalog reload (marketplace install/uninstall) or app close. The host needs to capture the handle's DSO token into each such anchor so the `.so` is not `dlclose`d while plugin code can still run. This is the SDK side of an app-close use-after-free fix observed with lazy `PJ.VideoFrame` payloads.

The token already existed on the handle (`library_owner_`); this only exposes it.

## Scope / compatibility

- **Host-side header only** (`pj_plugins/include/pj_plugins/host/`) — never included by plugins.
- No plugin ABI change; no `pj_base` abidiff baseline change → **no version bump** (invisible to the plugin-compatibility contract).

## Docs

- `pj_plugins/CLAUDE.md` — the "handles keep the DSO mapped" gotcha now names `libraryOwner()` + the lazy-anchor case.
- `pj_plugins/docs/ARCHITECTURE.md` §6 — the RAII-handle DSO-retention contract now covers the lazy-anchor extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
