### PR TITLE
feat(pj_base)!: carry frame_id through the canonical Image schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.6.0")
+  set(PJ_PACKAGE_VERSION "1.0.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.6.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/1.0.0` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -30,7 +30,7 @@ import os
 
 class PlotjugglerSdkConan(ConanFile):
     name = "plotjuggler_sdk"
-    version = "0.6.0"
+    version = "1.0.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/docs/builtin_type.md
+++ b/docs/builtin_type.md
@@ -150,6 +150,7 @@ messages.
 | `anchor` | `BufferAnchor` | Keeps `data` alive when it references shared storage. |
 | `compressed_depth_min` | `std::optional<float>` | ROS compressed-depth quantization metadata, when present. |
 | `compressed_depth_max` | `std::optional<float>` | ROS compressed-depth quantization metadata, when present. |
+| `frame_id` | `std::string` | Source coordinate frame (ROS `sensor_msgs/Image` and `foxglove.CompressedImage` both carry it). Lets a consumer match the image to the `CameraInfo` of the same `frame_id` (calibration / native resolution), e.g. to rectify lens distortion so 2D annotations align with the image. Empty when the producer has no frame information. |
 
 Common raw encodings are `rgb8`, `rgba8`, `bgr8`, `bgra8`, `mono8`, and
 `mono16`. Common compressed encodings are `jpeg`, `png`, and `qoi`.

--- a/pj_base/include/pj_base/builtin/image.hpp
+++ b/pj_base/include/pj_base/builtin/image.hpp
@@ -150,6 +150,13 @@ struct Image {
   std::optional<float> compressed_depth_max;
 
   Timestamp timestamp_ns = 0;
+
+  /// Source coordinate frame (ROS sensor_msgs/Image and foxglove.CompressedImage
+  /// both carry it). Lets a consumer match the image to the CameraInfo of the same
+  /// frame_id (calibration / native resolution), e.g. to rectify lens distortion so
+  /// 2D annotations align with the image. Empty when the producer has no frame
+  /// information.
+  std::string frame_id;
 };
 
 }  // namespace sdk

--- a/pj_base/proto/pj/Image.proto
+++ b/pj_base/proto/pj/Image.proto
@@ -57,4 +57,9 @@ message Image {
   // ROS compressedDepth quantization maximum; set together with `compressed_depth_min` when `encoding ==
   // "compressedDepth"`.
   optional float compressed_depth_max = 9;
+
+  // Source coordinate frame (ROS sensor_msgs/Image, foxglove.CompressedImage). Lets a consumer match the image to the
+  // CameraInfo of the same frame_id (calibration / native resolution), e.g. to rectify lens distortion so 2D
+  // annotations align with the image. Empty when the producer has no frame information.
+  string frame_id = 10;
 }

--- a/pj_base/src/builtin/image_codec.cpp
+++ b/pj_base/src/builtin/image_codec.cpp
@@ -53,6 +53,7 @@ std::vector<uint8_t> serializeImage(const Image& image) {
   if (image.compressed_depth_max.has_value()) {
     writer.floatField(9, *image.compressed_depth_max);
   }
+  writer.string(10, image.frame_id);
 
   return out;
 }
@@ -139,6 +140,8 @@ Expected<sdk::Image> deserializeImage(const uint8_t* data, size_t size) {
         image.compressed_depth_max = v;
         return true;
       }
+      case 10:
+        return tag.type == WireType::kLengthDelimited && r.readString(image.frame_id);
       default:
         return false;
     }

--- a/pj_base/tests/image_codec_test.cpp
+++ b/pj_base/tests/image_codec_test.cpp
@@ -33,6 +33,7 @@ TEST(ImageCodecTest, RoundTripRawRGB8) {
   in.encoding = "rgb8";
   in.row_step = 6;  // 2 px * 3 bytes
   in.is_bigendian = false;
+  in.frame_id = "camera_front";
   const std::vector<uint8_t> pixels = {255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128};
   in.data = Span<const uint8_t>(pixels.data(), pixels.size());
 
@@ -45,6 +46,7 @@ TEST(ImageCodecTest, RoundTripRawRGB8) {
   EXPECT_EQ(out->encoding, in.encoding);
   EXPECT_EQ(out->row_step, in.row_step);
   EXPECT_FALSE(out->is_bigendian);
+  EXPECT_EQ(out->frame_id, "camera_front");
   EXPECT_FALSE(out->compressed_depth_min.has_value());
   EXPECT_FALSE(out->compressed_depth_max.has_value());
   ASSERT_EQ(out->data.size(), pixels.size());
@@ -70,6 +72,7 @@ TEST(ImageCodecTest, RoundTripCompressedDepthWithRange) {
   ASSERT_TRUE(out->compressed_depth_max.has_value());
   EXPECT_FLOAT_EQ(*out->compressed_depth_min, 0.5f);
   EXPECT_FLOAT_EQ(*out->compressed_depth_max, 10.0f);
+  EXPECT_TRUE(out->frame_id.empty());  // unset frame_id round-trips as empty
 }
 
 }  // namespace


### PR DESCRIPTION
`Image` was the only canonical builtin not carrying `frame_id`: a producer could not tell a
consumer which `CameraInfo` (calibration / native resolution / rectification) an image belongs to,
nor place it in 3D via the TF tree. Every sibling codec already serializes `frame_id`; `Image`
silently dropped it on any serialized path.

## Change
- `Image.proto`: append field 10 (`string frame_id`).
- `image_codec`: serialize / deserialize `frame_id`.
- `image_codec_test`: populated round-trip + empty default.

## Compatibility / version
The wire change alone is forward/backward compatible (an old reader skips the unknown field). The
break is the **struct**: `sdk::Image` gains a member, and `Image` crosses the plugin↔host boundary
by value inside `BuiltinObject` (`std::any`), so an old-built plugin and a new host disagree on
layout. Per the SDK versioning policy that is an **ABI break → MAJOR**, and since it is the first
break leaving pre-1.0, it bumps **0.6.0 → 1.0.0**. `abi/baseline.abi` is unchanged (a header struct
field exports no ELF symbols). Consumers pin `[>=1.0.0 <2.0.0]`.

> Note for the maintainer: this declares the SDK **1.0.0** — leaving the pre-1.0 line is your call;
> flagging it explicitly.
