### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.8.0")
+  set(PJ_PACKAGE_VERSION "0.8.1")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.8.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.8.1` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -30,7 +30,7 @@ import os
 
 class PlotjugglerSdkConan(ConanFile):
     name = "plotjuggler_sdk"
-    version = "0.8.0"
+    version = "0.8.1"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.8.0"
+  version: "0.8.1"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## Summary

Bumps `plotjuggler_sdk` **0.8.0 → 0.8.1** — the first **conda-packaged** release (the recipe/workflow from #126 landed on `main`).

Updates all three version sources the `conda-release.yml` guard cross-checks against the tag, plus the `conanfile.py` docstring example:

- `conanfile.py` — `version = "0.8.1"` (+ docstring `plotjuggler_sdk/0.8.1`)
- `recipe.yaml` — `context.version: "0.8.1"`
- `CMakeLists.txt` — `set(PJ_PACKAGE_VERSION "0.8.1")`

## Semver

**PATCH.** No consumer-facing API/ABI change since 0.8.0 — the only code delta is the GCC-14 `-Wstringop-overflow` workaround in `src/builtin/protobuf_wire.hpp`, which is **not an installed header**. `abi/baseline.abi` is unchanged (additions-only rule satisfied; here, zero changes). This release exists to publish the conda package and exercise the tag-gated pipeline.

## After merge — tagging `v0.8.1`

A `v0.8.1` tag fires **both** publish workflows (all secrets are configured):
- `conda-release.yml` → publishes the `.conda` to **prefix.dev** (`plotjuggler` channel)
- `release.yml` → publishes Conan to **Cloudsmith** (linux/macOS/win) + creates a **GitHub Release**

I verified the `conda-release.yml` version guard passes for tag `v0.8.1` against all three bumped sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)