### PR TITLE
test(examples): mock_file_source fail_start failure-injection hook

### DIFF
--- a/pj_plugins/examples/mock_file_source.cpp
+++ b/pj_plugins/examples/mock_file_source.cpp
@@ -22,6 +22,15 @@ class MockFileSource : public PJ::FileSourceBase {
   }
 
   PJ::Status importData() override {
+    // Test-only failure injection: the host creates the dataset in the live engine
+    // before importData() runs, so returning an error here lets tests exercise the
+    // host's abandoned-dataset cleanup. config_ is opaque to this example (no JSON
+    // dependency), so the marker is matched by substring — safe because only tests
+    // set this config.
+    if (config_.find("fail_start") != std::string::npos) {
+      return PJ::unexpected("mock_file_source: configured start failure");
+    }
+
     if (!runtimeHost().progressStart("Importing", 3, true)) {
       return PJ::unexpected("progress unavailable");
     }


### PR DESCRIPTION
## What
Adds a test-only `fail_start` config marker to the `mock_file_source` example. When present, `importData()` returns an error instead of writing its 3 rows, simulating a source that loads/binds successfully but then fails mid-ingest.

## Why
`mock_file_source` is the shared test fixture for PlotJuggler's `file_loader_test`. A downstream PlotJuggler fix makes dataset *removal* a real engine delete, and the loader now also erases the **abandoned dataset** when a non-replacing first load fails *after* the dataset was created in the live engine. Exercising that cleanup needs a source that:
1. loads/binds OK (so the dataset gets created), then
2. fails during ingest.

Nothing could produce that today — the mock always succeeds, and the deliberately-broken sibling plugins fail at *discovery* (before the dataset exists), so they can't reach the cleanup path. A `fail_start` hook on the existing fixture is the minimal, reusable way.

## Scope / versioning
Example/test plugin only — no installed header, no ABI, no canonical-object/wire change. Per the versioning policy this is invisible to consumers, so **no version bump** (stays `0.8.1`). `config_` is matched by substring to keep the example free of a JSON dependency; only tests set this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)