### PR TITLE
build(conda): publish the SDK for win-64 and osx-64

### DIFF
--- a/.github/workflows/conda-release.yml
+++ b/.github/workflows/conda-release.yml
@@ -7,6 +7,12 @@ on:
   push:
     tags:
       - "v*"
+  # Build-only on PRs that touch the recipe/workflow, so the win-64/osx-64 legs
+  # are validated before a release tag (the upload step is skipped — see below).
+  pull_request:
+    paths:
+      - "recipe.yaml"
+      - ".github/workflows/conda-release.yml"
   # Manual dispatch builds the current conanfile.py/recipe.yaml version (no tag
   # guard); idempotent via `rattler-build upload --skip-existing`.
   workflow_dispatch: {}
@@ -21,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]   # extend to macos-15-intel, windows-2022 in a later task
+        # linux-64, osx-64 (macos-13 is Intel), win-64.
+        os: [ubuntu-22.04, macos-13, windows-2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,18 +62,23 @@ jobs:
           setup-only: true
           rattler-build-version: v0.66.2
 
+      # Relative output dir (not runner.temp) so the bash glob below works
+      # identically under Git Bash on the Windows runner.
       - name: Build conda package
         shell: bash
         run: |
           rattler-build build \
             --recipe recipe.yaml \
             --channel conda-forge \
-            --output-dir "${{ runner.temp }}/conda-output"
+            --output-dir conda-output
 
+      # Upload only on a release tag or manual dispatch — never on pull_request
+      # (PRs are build-only validation of the win-64/osx-64 legs).
       - name: Upload to prefix.dev (plotjuggler)
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           PREFIX_API_KEY: ${{ secrets.PREFIX_API_KEY }}
         run: |
-          find "${{ runner.temp }}/conda-output" -name '*.conda' -print0 \
+          find conda-output -name '*.conda' -print0 \
             | xargs -0 rattler-build upload prefix --channel plotjuggler --skip-existing

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -13,17 +13,19 @@ source:
 build:
   number: 0
   script:
-    - cmake -G Ninja -B build -S .
-        -DPJ_INSTALL_SDK=ON
-        -DPJ_BUILD_TESTS=OFF
-        -DPJ_BUILD_PORTED_PLUGINS=OFF
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_CXX_STANDARD=20
-        -DCMAKE_PREFIX_PATH=$PREFIX
-        -DCMAKE_INSTALL_PREFIX=$PREFIX
-        -DCMAKE_INSTALL_LIBDIR=lib
-    - cmake --build build
-    - cmake --install build --prefix $PREFIX
+    # Unix (linux-64, osx-64): install prefix is $PREFIX, libs in $PREFIX/lib.
+    - if: unix
+      then:
+        - cmake -G Ninja -B build -S . -DPJ_INSTALL_SDK=ON -DPJ_BUILD_TESTS=OFF -DPJ_BUILD_PORTED_PLUGINS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib
+        - cmake --build build
+        - cmake --install build --prefix $PREFIX
+    # Windows (win-64): conda installs under %LIBRARY_PREFIX% (the Library\ tree);
+    # MSVC needs an explicit Release config at build/install time.
+    - if: win
+      then:
+        - cmake -G Ninja -B build -S . -DPJ_INSTALL_SDK=ON -DPJ_BUILD_TESTS=OFF -DPJ_BUILD_PORTED_PLUGINS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"
+        - cmake --build build --config Release
+        - cmake --install build --config Release
 
 requirements:
   build:
@@ -49,17 +51,25 @@ requirements:
       - fast_float
 
 tests:
+  # Installed CMake package files — cross-platform (conda puts them under
+  # $PREFIX/lib on unix, %LIBRARY_PREFIX%\lib i.e. Library/lib on Windows).
+  - package_contents:
+      files:
+        - ${{ "lib" if unix else "Library/lib" }}/cmake/plotjuggler_sdk/plotjuggler_sdkConfig.cmake
+        - ${{ "lib" if unix else "Library/lib" }}/cmake/plotjuggler_sdk/plotjuggler_sdkConfigVersion.cmake
+        - ${{ "lib" if unix else "Library/lib" }}/cmake/plotjuggler_sdk/PjPluginManifest.cmake
+  # Actually exercise the package: build the repo's example consumer, which
+  # find_package(plotjuggler_sdk COMPONENTS plugin_sdk), links a plugin lib, and
+  # runs pj_emit_plugin_manifest(). Catches broken CMake config / find_dependency
+  # / manifest helper — failure modes the file checks above cannot see. Kept
+  # unix-only for now: the Windows package build itself is the win-64 gate, and
+  # the plugin-shared-lib example needs separate validation on MSVC (follow-up).
   - script:
-      - test -f $PREFIX/lib/cmake/plotjuggler_sdk/plotjuggler_sdkConfig.cmake
-      - test -f $PREFIX/lib/cmake/plotjuggler_sdk/plotjuggler_sdkConfigVersion.cmake
-      - test -f $PREFIX/lib/cmake/plotjuggler_sdk/PjPluginManifest.cmake
-      - test -f $PREFIX/lib/libpj_base.a
-      # Actually exercise the package: build the repo's example consumer, which
-      # find_package(plotjuggler_sdk COMPONENTS plugin_sdk), links a plugin .so, and
-      # runs pj_emit_plugin_manifest(). Catches broken CMake config / find_dependency
-      # / manifest helper — failure modes the test -f checks above cannot see.
-      - cmake -G Ninja -B test_build -S examples/sdk_consumer -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH=$PREFIX
-      - cmake --build test_build
+      - if: unix
+        then:
+          - test -f $PREFIX/lib/libpj_base.a
+          - cmake -G Ninja -B test_build -S examples/sdk_consumer -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH=$PREFIX
+          - cmake --build test_build
     requirements:
       run:
         - ${{ compiler('cxx') }}


### PR DESCRIPTION
## Publish the SDK conda package for win-64 and osx-64

The pixi plugin migration needs `plotjuggler_sdk` on prefix.dev for **win-64** (a win-64 plugin solve currently can't resolve the SDK — it's linux-64-only on the channel). All SDK host deps (`nlohmann_json`/`fmt`/`fast_float`) are already on win-64, so only the package build was missing. This also adds osx-64, completing the 3-platform matrix.

### Changes
- **recipe.yaml** — `if: unix` / `if: win` build branches (Windows installs under `%LIBRARY_PREFIX%`, MSVC needs an explicit `--config Release`); the `test -f` checks become a cross-platform `package_contents` test; the deeper example-consumer build stays unix-only for now (MSVC plugin-lib validation is a follow-up).
- **conda-release.yml** — matrix `ubuntu-22.04 + macos-13 + windows-2022`; a `pull_request` trigger that **builds all three platforms without uploading**, so this PR's CI is the win-64/osx-64 gate; upload remains tag/dispatch-only.

### Validation
- linux build + tests pass locally (rattler-build).
- **win-64 / osx-64 are validated by this PR's CI** (build-only). If the MSVC build surfaces issues, they'll show here.

### To publish after merge
Run the workflow via **workflow_dispatch** (or push a new `v*` tag). `--skip-existing` means the already-published linux-64 `0.8.1` is skipped and only the new win-64/osx-64 artifacts upload. No version bump required.