### PR TITLE
feat(sdk): static plugin registry + static dialog for no-dlopen (WASM) builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.10.0")
+  set(PJ_PACKAGE_VERSION "0.11.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ else()
     -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wold-style-cast
     -Wcast-qual -Wconversion -Woverloaded-virtual -Wpedantic
   )
+  # On wasm32 size_t is 32-bit, so many uint64_t->size_t conversions trip
+  # -Wshorten-64-to-32 / -Wsign-conversion that never fire on 64-bit desktop
+  # (see SUSTAINABILITY.md T0-3). Keep the warnings visible but don't fail the
+  # build for the WASM prototype. TODO: make the ABI/size types 32-bit-clean.
+  if(EMSCRIPTEN)
+    list(APPEND PJ_WARNING_FLAGS -Wno-error)
+  endif()
 endif()
 
 # ---------------------------------------------------------------------------

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.10.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.11.0` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -30,7 +30,7 @@ import os
 
 class PlotjugglerSdkConan(ConanFile):
     name = "plotjuggler_sdk"
-    version = "0.10.0"
+    version = "0.11.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/data_source_plugin_base.hpp
@@ -250,3 +250,26 @@ class DataSourcePluginBase {
         manifest);                                                                                       \
     return vt;                                                                                           \
   }
+
+// --- Static-link variant (WASM / no dlopen) ----------------------------------
+// With PJ_STATIC_PLUGINS the plugin is linked into the host binary. The fixed
+// `extern "C" PJ_get_data_source_vtable` symbol would collide across plugins in
+// one binary, so emit a uniquely-named (class-keyed) C++ function instead. The
+// host's static registry declares these extern and passes them to
+// PluginRuntimeCatalog::registerStaticDataSource().
+#ifdef PJ_STATIC_PLUGINS
+#undef PJ_DATA_SOURCE_PLUGIN
+#define PJ_DATA_SOURCE_PLUGIN(ClassName, manifest)                                         \
+  const PJ_data_source_vtable_t* pj_static_get_data_source_vtable_##ClassName() noexcept { \
+    static const PJ_data_source_vtable_t* vt = PJ::DataSourcePluginBase::vtableWithCreate( \
+        []() noexcept -> void* {                                                           \
+          try {                                                                            \
+            return new ClassName();                                                        \
+          } catch (...) {                                                                  \
+            return nullptr;                                                                \
+          }                                                                                \
+        },                                                                                 \
+        manifest);                                                                         \
+    return vt;                                                                             \
+  }
+#endif

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -254,17 +254,17 @@ class ToolboxPluginBase {
 // --- Static-link variant (WASM / no dlopen) ---  see data_source_plugin_base.hpp
 #ifdef PJ_STATIC_PLUGINS
 #undef PJ_TOOLBOX_PLUGIN
-#define PJ_TOOLBOX_PLUGIN(ClassName, manifest)                                       \
-  const PJ_toolbox_vtable_t* pj_static_get_toolbox_vtable_##ClassName() noexcept {    \
-    static const PJ_toolbox_vtable_t* vt = PJ::ToolboxPluginBase::vtableWithCreate(   \
-        []() noexcept -> void* {                                                     \
-          try {                                                                      \
-            return new ClassName();                                                  \
-          } catch (...) {                                                            \
-            return nullptr;                                                          \
-          }                                                                          \
-        },                                                                           \
-        manifest);                                                                   \
-    return vt;                                                                       \
+#define PJ_TOOLBOX_PLUGIN(ClassName, manifest)                                      \
+  const PJ_toolbox_vtable_t* pj_static_get_toolbox_vtable_##ClassName() noexcept {  \
+    static const PJ_toolbox_vtable_t* vt = PJ::ToolboxPluginBase::vtableWithCreate( \
+        []() noexcept -> void* {                                                    \
+          try {                                                                     \
+            return new ClassName();                                                 \
+          } catch (...) {                                                           \
+            return nullptr;                                                         \
+          }                                                                         \
+        },                                                                          \
+        manifest);                                                                  \
+    return vt;                                                                      \
   }
 #endif

--- a/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
+++ b/pj_base/include/pj_base/sdk/toolbox_plugin_base.hpp
@@ -250,3 +250,21 @@ class ToolboxPluginBase {
         manifest);                                                                           \
     return vt;                                                                               \
   }
+
+// --- Static-link variant (WASM / no dlopen) ---  see data_source_plugin_base.hpp
+#ifdef PJ_STATIC_PLUGINS
+#undef PJ_TOOLBOX_PLUGIN
+#define PJ_TOOLBOX_PLUGIN(ClassName, manifest)                                       \
+  const PJ_toolbox_vtable_t* pj_static_get_toolbox_vtable_##ClassName() noexcept {    \
+    static const PJ_toolbox_vtable_t* vt = PJ::ToolboxPluginBase::vtableWithCreate(   \
+        []() noexcept -> void* {                                                     \
+          try {                                                                      \
+            return new ClassName();                                                  \
+          } catch (...) {                                                            \
+            return nullptr;                                                          \
+          }                                                                          \
+        },                                                                           \
+        manifest);                                                                   \
+    return vt;                                                                       \
+  }
+#endif

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -303,3 +303,33 @@ PJ_borrowed_dialog_t borrowDialog(DialogT& dialog) noexcept {
     return PJ_get_dialog_vtable();                                                          \
   }                                                                                         \
   }
+
+// --- Static-link variant (WASM / no dlopen) ---  see data_source_plugin_base.hpp.
+// Many statically-linked plugins each carry a PJ_DIALOG_PLUGIN, so the fixed
+// `extern "C" PJ_get_dialog_vtable` symbol (and the ABI-version export) would
+// collide at link. The static registry never resolves a dialog via dlsym (the
+// host short-circuits the dialog path on WASM), so emit only a uniquely
+// class-keyed getter — kept so dialogVtableFor<ClassName>() still resolves for
+// any in-binary caller.
+#ifdef PJ_STATIC_PLUGINS
+#undef PJ_DIALOG_PLUGIN_WITH_MANIFEST
+#define PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, ManifestJson)                              \
+  inline const PJ_dialog_vtable_t* pj_static_get_dialog_vtable_##ClassName() noexcept {      \
+    static const PJ_dialog_vtable_t* vt = PJ::DialogPluginBase::vtableWithCreate(            \
+        []() noexcept -> void* {                                                             \
+          try {                                                                              \
+            return static_cast<PJ::DialogPluginBase*>(new ClassName());                      \
+          } catch (...) {                                                                    \
+            return nullptr;                                                                  \
+          }                                                                                  \
+        },                                                                                   \
+        ManifestJson);                                                                       \
+    return vt;                                                                               \
+  }                                                                                          \
+  namespace PJ {                                                                             \
+  template <>                                                                                \
+  [[maybe_unused]] inline const PJ_dialog_vtable_t* dialogVtableFor<ClassName>() noexcept {  \
+    return pj_static_get_dialog_vtable_##ClassName();                                        \
+  }                                                                                          \
+  }
+#endif  // PJ_STATIC_PLUGINS

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -313,23 +313,23 @@ PJ_borrowed_dialog_t borrowDialog(DialogT& dialog) noexcept {
 // any in-binary caller.
 #ifdef PJ_STATIC_PLUGINS
 #undef PJ_DIALOG_PLUGIN_WITH_MANIFEST
-#define PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, ManifestJson)                              \
-  inline const PJ_dialog_vtable_t* pj_static_get_dialog_vtable_##ClassName() noexcept {      \
-    static const PJ_dialog_vtable_t* vt = PJ::DialogPluginBase::vtableWithCreate(            \
-        []() noexcept -> void* {                                                             \
-          try {                                                                              \
-            return static_cast<PJ::DialogPluginBase*>(new ClassName());                      \
-          } catch (...) {                                                                    \
-            return nullptr;                                                                  \
-          }                                                                                  \
-        },                                                                                   \
-        ManifestJson);                                                                       \
-    return vt;                                                                               \
-  }                                                                                          \
-  namespace PJ {                                                                             \
-  template <>                                                                                \
-  [[maybe_unused]] inline const PJ_dialog_vtable_t* dialogVtableFor<ClassName>() noexcept {  \
-    return pj_static_get_dialog_vtable_##ClassName();                                        \
-  }                                                                                          \
+#define PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, ManifestJson)                             \
+  inline const PJ_dialog_vtable_t* pj_static_get_dialog_vtable_##ClassName() noexcept {     \
+    static const PJ_dialog_vtable_t* vt = PJ::DialogPluginBase::vtableWithCreate(           \
+        []() noexcept -> void* {                                                            \
+          try {                                                                             \
+            return static_cast<PJ::DialogPluginBase*>(new ClassName());                     \
+          } catch (...) {                                                                   \
+            return nullptr;                                                                 \
+          }                                                                                 \
+        },                                                                                  \
+        ManifestJson);                                                                      \
+    return vt;                                                                              \
+  }                                                                                         \
+  namespace PJ {                                                                            \
+  template <>                                                                               \
+  [[maybe_unused]] inline const PJ_dialog_vtable_t* dialogVtableFor<ClassName>() noexcept { \
+    return pj_static_get_dialog_vtable_##ClassName();                                       \
+  }                                                                                         \
   }
 #endif  // PJ_STATIC_PLUGINS

--- a/pj_plugins/include/pj_plugins/host/data_source_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/data_source_library.hpp
@@ -51,6 +51,10 @@ class DataSourceLibrary {
   /// Load a plugin from @p path. Returns an error string on failure.
   [[nodiscard]] static Expected<DataSourceLibrary> load(std::string_view path);
 
+  /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
+  /// @p vtable must have static storage duration (valid for the program lifetime).
+  [[nodiscard]] static Expected<DataSourceLibrary> loadStatic(const PJ_data_source_vtable_t* vtable);
+
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
     return handle_ != nullptr && vtable_ != nullptr;

--- a/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
@@ -51,6 +51,10 @@ class MessageParserLibrary {
   /// Load a plugin from @p path. Returns an error string on failure.
   [[nodiscard]] static Expected<MessageParserLibrary> load(std::string_view path);
 
+  /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
+  /// @p vtable must have static storage duration (valid for the program lifetime).
+  [[nodiscard]] static Expected<MessageParserLibrary> loadStatic(const PJ_message_parser_vtable_t* vtable);
+
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
     return handle_ != nullptr && vtable_ != nullptr;

--- a/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
@@ -81,6 +81,14 @@ class PluginRuntimeCatalog {
   // Reconciles loaded state with disk and returns true if it changed.
   [[nodiscard]] bool reload();
 
+  // --- Static plugin registration (WASM/static builds; no dlopen) -------------
+  // Register a statically-linked plugin by its vtable. The vtable must outlive
+  // this catalog (static storage duration); the manifest is read from
+  // vtable->manifest_json. Returns false (and reports a diagnostic) on failure.
+  bool registerStaticDataSource(const PJ_data_source_vtable_t* vtable);
+  bool registerStaticMessageParser(const PJ_message_parser_vtable_t* vtable);
+  bool registerStaticToolbox(const PJ_toolbox_vtable_t* vtable);
+
   // Returns loaded DataSource plugins.
   [[nodiscard]] const std::vector<RuntimeDataSourcePlugin>& dataSources() const {
     return data_sources_;

--- a/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
@@ -51,6 +51,10 @@ class ToolboxLibrary {
   /// Load a plugin from @p path. Returns an error string on failure.
   [[nodiscard]] static Expected<ToolboxLibrary> load(std::string_view path);
 
+  /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
+  /// @p vtable must have static storage duration (valid for the program lifetime).
+  [[nodiscard]] static Expected<ToolboxLibrary> loadStatic(const PJ_toolbox_vtable_t* vtable);
+
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
     return handle_ != nullptr && vtable_ != nullptr;

--- a/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
@@ -380,17 +380,17 @@ class MessageParserPluginBase {
 // --- Static-link variant (WASM / no dlopen) ---  see data_source_plugin_base.hpp
 #ifdef PJ_STATIC_PLUGINS
 #undef PJ_MESSAGE_PARSER_PLUGIN
-#define PJ_MESSAGE_PARSER_PLUGIN(ClassName, manifest)                                          \
-  const PJ_message_parser_vtable_t* pj_static_get_message_parser_vtable_##ClassName() noexcept {\
-    static const PJ_message_parser_vtable_t* vt = PJ::MessageParserPluginBase::vtableWithCreate(\
-        []() noexcept -> void* {                                                               \
-          try {                                                                                \
-            return new ClassName();                                                            \
-          } catch (...) {                                                                      \
-            return nullptr;                                                                    \
-          }                                                                                    \
-        },                                                                                     \
-        manifest);                                                                             \
-    return vt;                                                                                 \
+#define PJ_MESSAGE_PARSER_PLUGIN(ClassName, manifest)                                            \
+  const PJ_message_parser_vtable_t* pj_static_get_message_parser_vtable_##ClassName() noexcept { \
+    static const PJ_message_parser_vtable_t* vt = PJ::MessageParserPluginBase::vtableWithCreate( \
+        []() noexcept -> void* {                                                                 \
+          try {                                                                                  \
+            return new ClassName();                                                              \
+          } catch (...) {                                                                        \
+            return nullptr;                                                                      \
+          }                                                                                      \
+        },                                                                                       \
+        manifest);                                                                               \
+    return vt;                                                                                   \
   }
 #endif

--- a/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/message_parser_plugin_base.hpp
@@ -376,3 +376,21 @@ class MessageParserPluginBase {
         manifest);                                                                                                \
     return vt;                                                                                                    \
   }
+
+// --- Static-link variant (WASM / no dlopen) ---  see data_source_plugin_base.hpp
+#ifdef PJ_STATIC_PLUGINS
+#undef PJ_MESSAGE_PARSER_PLUGIN
+#define PJ_MESSAGE_PARSER_PLUGIN(ClassName, manifest)                                          \
+  const PJ_message_parser_vtable_t* pj_static_get_message_parser_vtable_##ClassName() noexcept {\
+    static const PJ_message_parser_vtable_t* vt = PJ::MessageParserPluginBase::vtableWithCreate(\
+        []() noexcept -> void* {                                                               \
+          try {                                                                                \
+            return new ClassName();                                                            \
+          } catch (...) {                                                                      \
+            return nullptr;                                                                    \
+          }                                                                                    \
+        },                                                                                     \
+        manifest);                                                                             \
+    return vt;                                                                                 \
+  }
+#endif

--- a/pj_plugins/src/data_source_library.cpp
+++ b/pj_plugins/src/data_source_library.cpp
@@ -70,6 +70,26 @@ Expected<DataSourceLibrary> DataSourceLibrary::load(std::string_view path) {
   return DataSourceLibrary(std::move(handle), vtable, std::string(path));
 }
 
+Expected<DataSourceLibrary> DataSourceLibrary::loadStatic(const PJ_data_source_vtable_t* vtable) {
+  if (vtable == nullptr) {
+    return unexpected("static DataSource vtable is null");
+  }
+  if (vtable->protocol_version != PJ_DATA_SOURCE_PROTOCOL_VERSION) {
+    return unexpected("DataSource protocol version mismatch");
+  }
+  if (vtable->struct_size < PJ_DATA_SOURCE_MIN_VTABLE_SIZE) {
+    return unexpected("DataSource vtable smaller than v4.0 baseline");
+  }
+  if (auto status = detail::validateRequiredSlots(vtable); !status) {
+    return unexpected(status.error());
+  }
+  // Statically linked: no DSO to keep alive, but valid()/createHandle() expect a
+  // non-null owner. Use a sentinel shared_ptr with a no-op deleter.
+  static char anchor = 0;
+  std::shared_ptr<void> handle(&anchor, [](void*) {});
+  return DataSourceLibrary(std::move(handle), vtable, "static://");
+}
+
 Expected<const PJ_dialog_vtable_t*> DataSourceLibrary::resolveDialogVtable() const {
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {

--- a/pj_plugins/src/message_parser_library.cpp
+++ b/pj_plugins/src/message_parser_library.cpp
@@ -68,6 +68,24 @@ Expected<MessageParserLibrary> MessageParserLibrary::load(std::string_view path)
   return MessageParserLibrary(std::move(handle), vtable, std::string(path));
 }
 
+Expected<MessageParserLibrary> MessageParserLibrary::loadStatic(const PJ_message_parser_vtable_t* vtable) {
+  if (vtable == nullptr) {
+    return unexpected("static MessageParser vtable is null");
+  }
+  if (vtable->protocol_version != PJ_MESSAGE_PARSER_PROTOCOL_VERSION) {
+    return unexpected("MessageParser protocol version mismatch");
+  }
+  if (vtable->struct_size < PJ_MESSAGE_PARSER_MIN_VTABLE_SIZE) {
+    return unexpected("MessageParser vtable smaller than v4.0 baseline");
+  }
+  if (auto status = detail::validateRequiredSlots(vtable); !status) {
+    return unexpected(status.error());
+  }
+  static char anchor = 0;
+  std::shared_ptr<void> handle(&anchor, [](void*) {});
+  return MessageParserLibrary(std::move(handle), vtable, "static://");
+}
+
 Expected<const PJ_dialog_vtable_t*> MessageParserLibrary::resolveDialogVtable() const {
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {

--- a/pj_plugins/src/plugin_runtime_catalog.cpp
+++ b/pj_plugins/src/plugin_runtime_catalog.cpp
@@ -150,6 +150,107 @@ bool PluginRuntimeCatalog::reload() {
   return changed;
 }
 
+namespace {
+
+// Parse a plugin's embedded manifest JSON. Returns false on invalid JSON.
+bool parseStaticManifest(const char* manifest_json, nlohmann::json& out) {
+  try {
+    out = nlohmann::json::parse(manifest_json ? manifest_json : "");
+    return out.is_object();
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+std::vector<std::string> readManifestStringArray(const nlohmann::json& j, const char* key) {
+  std::vector<std::string> values;
+  if (auto it = j.find(key); it != j.end() && it->is_array()) {
+    for (const auto& v : *it) {
+      if (v.is_string()) {
+        values.push_back(v.get<std::string>());
+      }
+    }
+  }
+  return values;
+}
+
+}  // namespace
+
+bool PluginRuntimeCatalog::registerStaticDataSource(const PJ_data_source_vtable_t* vtable) {
+  auto result = DataSourceLibrary::loadStatic(vtable);
+  if (!result) {
+    report(DiagnosticLevel::kError, {}, "static DataSource: " + result.error());
+    return false;
+  }
+  nlohmann::json j;
+  if (!parseStaticManifest(vtable->manifest_json, j)) {
+    report(DiagnosticLevel::kError, {}, "static DataSource: invalid manifest JSON");
+    return false;
+  }
+  RuntimeDataSourcePlugin loaded;
+  loaded.library = std::move(*result);
+  loaded.id = j.value("id", std::string{});
+  loaded.name = j.value("name", std::string{});
+  loaded.version = j.value("version", std::string{});
+  loaded.path = "static://" + loaded.id;
+  loaded.loaded_mtime = std::filesystem::file_time_type{};
+  loaded.capabilities = loaded.library.createHandle().capabilities();
+  for (auto& ext : readManifestStringArray(j, "file_extensions")) {
+    loaded.file_extensions.push_back(normalizeExtension(std::move(ext)));
+  }
+  report(DiagnosticLevel::kInfo, loaded.id, "Registered static DataSource " + loaded.name);
+  data_sources_.push_back(std::move(loaded));
+  return true;
+}
+
+bool PluginRuntimeCatalog::registerStaticMessageParser(const PJ_message_parser_vtable_t* vtable) {
+  auto result = MessageParserLibrary::loadStatic(vtable);
+  if (!result) {
+    report(DiagnosticLevel::kError, {}, "static MessageParser: " + result.error());
+    return false;
+  }
+  nlohmann::json j;
+  if (!parseStaticManifest(vtable->manifest_json, j)) {
+    report(DiagnosticLevel::kError, {}, "static MessageParser: invalid manifest JSON");
+    return false;
+  }
+  RuntimeMessageParserPlugin loaded;
+  loaded.library = std::move(*result);
+  loaded.id = j.value("id", std::string{});
+  loaded.name = j.value("name", std::string{});
+  loaded.version = j.value("version", std::string{});
+  loaded.path = "static://" + loaded.id;
+  loaded.loaded_mtime = std::filesystem::file_time_type{};
+  loaded.encodings = readManifestStringArray(j, "encoding");
+  report(DiagnosticLevel::kInfo, loaded.id, "Registered static MessageParser " + loaded.name);
+  message_parsers_.push_back(std::move(loaded));
+  return true;
+}
+
+bool PluginRuntimeCatalog::registerStaticToolbox(const PJ_toolbox_vtable_t* vtable) {
+  auto result = ToolboxLibrary::loadStatic(vtable);
+  if (!result) {
+    report(DiagnosticLevel::kError, {}, "static Toolbox: " + result.error());
+    return false;
+  }
+  nlohmann::json j;
+  if (!parseStaticManifest(vtable->manifest_json, j)) {
+    report(DiagnosticLevel::kError, {}, "static Toolbox: invalid manifest JSON");
+    return false;
+  }
+  RuntimeToolboxPlugin loaded;
+  loaded.library = std::move(*result);
+  loaded.id = j.value("id", std::string{});
+  loaded.name = j.value("name", std::string{});
+  loaded.version = j.value("version", std::string{});
+  loaded.path = "static://" + loaded.id;
+  loaded.loaded_mtime = std::filesystem::file_time_type{};
+  loaded.capabilities = loaded.library.createHandle().capabilities();
+  report(DiagnosticLevel::kInfo, loaded.id, "Registered static Toolbox " + loaded.name);
+  toolbox_plugins_.push_back(std::move(loaded));
+  return true;
+}
+
 bool PluginRuntimeCatalog::loadAndRegister(const PluginDescriptor& descriptor) {
   switch (descriptor.family) {
     case PluginFamily::kDataSource:

--- a/pj_plugins/src/plugin_runtime_catalog.cpp
+++ b/pj_plugins/src/plugin_runtime_catalog.cpp
@@ -174,81 +174,66 @@ std::vector<std::string> readManifestStringArray(const nlohmann::json& j, const 
   return values;
 }
 
+// Shared body for the three registerStatic* methods: load the static vtable,
+// parse the embedded manifest, fill the common Runtime*Plugin fields, and push.
+// `fill` adds the family-specific fields (capabilities / extensions / encodings);
+// `report` bridges to the catalog's private diagnostic sink.
+template <typename LibraryT, typename RuntimeT, typename ReportFn, typename FillFn>
+bool registerStaticPlugin(
+    const auto* vtable, std::vector<RuntimeT>& out, const char* family, const ReportFn& report, const FillFn& fill) {
+  auto result = LibraryT::loadStatic(vtable);
+  if (!result) {
+    report(DiagnosticLevel::kError, std::string{}, "static " + std::string(family) + ": " + result.error());
+    return false;
+  }
+  nlohmann::json j;
+  if (!parseStaticManifest(vtable->manifest_json, j)) {
+    report(DiagnosticLevel::kError, std::string{}, "static " + std::string(family) + ": invalid manifest JSON");
+    return false;
+  }
+  RuntimeT loaded;
+  loaded.library = std::move(*result);
+  loaded.id = j.value("id", std::string{});
+  loaded.name = j.value("name", std::string{});
+  loaded.version = j.value("version", std::string{});
+  loaded.path = "static://" + loaded.id;
+  loaded.loaded_mtime = std::filesystem::file_time_type{};
+  fill(loaded, j);
+  report(DiagnosticLevel::kInfo, loaded.id, "Registered static " + std::string(family) + " " + loaded.name);
+  out.push_back(std::move(loaded));
+  return true;
+}
+
 }  // namespace
 
 bool PluginRuntimeCatalog::registerStaticDataSource(const PJ_data_source_vtable_t* vtable) {
-  auto result = DataSourceLibrary::loadStatic(vtable);
-  if (!result) {
-    report(DiagnosticLevel::kError, {}, "static DataSource: " + result.error());
-    return false;
-  }
-  nlohmann::json j;
-  if (!parseStaticManifest(vtable->manifest_json, j)) {
-    report(DiagnosticLevel::kError, {}, "static DataSource: invalid manifest JSON");
-    return false;
-  }
-  RuntimeDataSourcePlugin loaded;
-  loaded.library = std::move(*result);
-  loaded.id = j.value("id", std::string{});
-  loaded.name = j.value("name", std::string{});
-  loaded.version = j.value("version", std::string{});
-  loaded.path = "static://" + loaded.id;
-  loaded.loaded_mtime = std::filesystem::file_time_type{};
-  loaded.capabilities = loaded.library.createHandle().capabilities();
-  for (auto& ext : readManifestStringArray(j, "file_extensions")) {
-    loaded.file_extensions.push_back(normalizeExtension(std::move(ext)));
-  }
-  report(DiagnosticLevel::kInfo, loaded.id, "Registered static DataSource " + loaded.name);
-  data_sources_.push_back(std::move(loaded));
-  return true;
+  return registerStaticPlugin<DataSourceLibrary>(
+      vtable, data_sources_, "DataSource",
+      [this](DiagnosticLevel level, const std::string& id, std::string msg) { report(level, id, std::move(msg)); },
+      [](RuntimeDataSourcePlugin& loaded, const nlohmann::json& j) {
+        loaded.capabilities = loaded.library.createHandle().capabilities();
+        for (auto& ext : readManifestStringArray(j, "file_extensions")) {
+          loaded.file_extensions.push_back(normalizeExtension(std::move(ext)));
+        }
+      });
 }
 
 bool PluginRuntimeCatalog::registerStaticMessageParser(const PJ_message_parser_vtable_t* vtable) {
-  auto result = MessageParserLibrary::loadStatic(vtable);
-  if (!result) {
-    report(DiagnosticLevel::kError, {}, "static MessageParser: " + result.error());
-    return false;
-  }
-  nlohmann::json j;
-  if (!parseStaticManifest(vtable->manifest_json, j)) {
-    report(DiagnosticLevel::kError, {}, "static MessageParser: invalid manifest JSON");
-    return false;
-  }
-  RuntimeMessageParserPlugin loaded;
-  loaded.library = std::move(*result);
-  loaded.id = j.value("id", std::string{});
-  loaded.name = j.value("name", std::string{});
-  loaded.version = j.value("version", std::string{});
-  loaded.path = "static://" + loaded.id;
-  loaded.loaded_mtime = std::filesystem::file_time_type{};
-  loaded.encodings = readManifestStringArray(j, "encoding");
-  report(DiagnosticLevel::kInfo, loaded.id, "Registered static MessageParser " + loaded.name);
-  message_parsers_.push_back(std::move(loaded));
-  return true;
+  return registerStaticPlugin<MessageParserLibrary>(
+      vtable, message_parsers_, "MessageParser",
+      [this](DiagnosticLevel level, const std::string& id, std::string msg) { report(level, id, std::move(msg)); },
+      [](RuntimeMessageParserPlugin& loaded, const nlohmann::json& j) {
+        loaded.encodings = readManifestStringArray(j, "encoding");
+      });
 }
 
 bool PluginRuntimeCatalog::registerStaticToolbox(const PJ_toolbox_vtable_t* vtable) {
-  auto result = ToolboxLibrary::loadStatic(vtable);
-  if (!result) {
-    report(DiagnosticLevel::kError, {}, "static Toolbox: " + result.error());
-    return false;
-  }
-  nlohmann::json j;
-  if (!parseStaticManifest(vtable->manifest_json, j)) {
-    report(DiagnosticLevel::kError, {}, "static Toolbox: invalid manifest JSON");
-    return false;
-  }
-  RuntimeToolboxPlugin loaded;
-  loaded.library = std::move(*result);
-  loaded.id = j.value("id", std::string{});
-  loaded.name = j.value("name", std::string{});
-  loaded.version = j.value("version", std::string{});
-  loaded.path = "static://" + loaded.id;
-  loaded.loaded_mtime = std::filesystem::file_time_type{};
-  loaded.capabilities = loaded.library.createHandle().capabilities();
-  report(DiagnosticLevel::kInfo, loaded.id, "Registered static Toolbox " + loaded.name);
-  toolbox_plugins_.push_back(std::move(loaded));
-  return true;
+  return registerStaticPlugin<ToolboxLibrary>(
+      vtable, toolbox_plugins_, "Toolbox",
+      [this](DiagnosticLevel level, const std::string& id, std::string msg) { report(level, id, std::move(msg)); },
+      [](RuntimeToolboxPlugin& loaded, const nlohmann::json& /*j*/) {
+        loaded.capabilities = loaded.library.createHandle().capabilities();
+      });
 }
 
 bool PluginRuntimeCatalog::loadAndRegister(const PluginDescriptor& descriptor) {

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -67,6 +67,24 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
   return ToolboxLibrary(std::move(handle), vtable, std::string(path));
 }
 
+Expected<ToolboxLibrary> ToolboxLibrary::loadStatic(const PJ_toolbox_vtable_t* vtable) {
+  if (vtable == nullptr) {
+    return unexpected("static Toolbox vtable is null");
+  }
+  if (vtable->protocol_version != PJ_TOOLBOX_PLUGIN_PROTOCOL_VERSION) {
+    return unexpected("Toolbox protocol version mismatch");
+  }
+  if (vtable->struct_size < PJ_TOOLBOX_MIN_VTABLE_SIZE) {
+    return unexpected("Toolbox vtable smaller than v4.0 baseline");
+  }
+  if (auto status = detail::validateRequiredSlots(vtable); !status) {
+    return unexpected(status.error());
+  }
+  static char anchor = 0;
+  std::shared_ptr<void> handle(&anchor, [](void*) {});
+  return ToolboxLibrary(std::move(handle), vtable, "static://");
+}
+
 Expected<const PJ_dialog_vtable_t*> ToolboxLibrary::resolveDialogVtable() const {
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.10.0"
+  version: "0.11.0"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## What

Adds the SDK infrastructure for **statically-linked plugins** — needed by builds with no `dlopen`, primarily **Qt-for-WebAssembly**. Three commits:

- `feat(sdk): static plugin registry for WASM / no-dlopen builds` — host-side registration entry points so a DataSource / MessageParser / Toolbox plugin compiled *into* the executable can register with the runtime catalog without `dlopen` (`plugin_runtime_catalog` + the four `*_library` host classes + the SDK plugin-base hooks).
- `feat(sdk): static PJ_DIALOG_PLUGIN variant (no-collision, WASM)` — a collision-free static variant of the dialog plugin macro so multiple statically-linked dialog plugins coexist in one binary.
- `chore(release): bump version to 0.11.0`.

## Why

On wasm there is no dynamic loader, so every plugin must be linked into the app and registered via a known symbol instead of being discovered on disk. These additions provide that path while leaving the existing dynamic (`dlopen`) flow untouched.

## Version / compatibility

**MINOR → 0.11.0.** All changes are **backward-compatible API additions** — new entry points only; every already-built plugin keeps working with no recompile (`abidiff` should show additions only). Three version sources bumped in lockstep (`conanfile.py`, `CMakeLists.txt`, `recipe.yaml`).

This branch was **rebased onto current `main`**, so it already includes the AssetVideo removal (#131); the diff here is purely the static-plugin additions.

**No tag / release in this PR** — tagging `v0.11.0` (which would fire the conda + GitHub release jobs) is a separate, explicitly-authorized step.

## Downstream

Unblocks the PlotJuggler wasm build: PJ4's `feat/wasm-p0-p1-refresh` statically links the ROS + foxglove message parsers and scene2D, and re-points its submodule at this branch's tip.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>