### PR TITLE
feat(plugins): prefer higher plugin version over folder priority on duplicate ids

### DIFF
--- a/pj_plugins/CMakeLists.txt
+++ b/pj_plugins/CMakeLists.txt
@@ -127,6 +127,16 @@ target_compile_features(mock_data_source_v2_plugin PRIVATE cxx_std_20)
 target_compile_options(mock_data_source_v2_plugin PRIVATE ${PJ_WARNING_FLAGS})
 target_link_libraries(mock_data_source_v2_plugin PRIVATE pj_base)
 
+add_library(mock_data_source_incompatible_plugin SHARED tests/mock_data_source_incompatible_plugin.cpp)
+target_compile_features(mock_data_source_incompatible_plugin PRIVATE cxx_std_20)
+target_compile_options(mock_data_source_incompatible_plugin PRIVATE ${PJ_WARNING_FLAGS})
+target_link_libraries(mock_data_source_incompatible_plugin PRIVATE pj_base)
+
+add_library(mock_data_source_incompatible_low_plugin SHARED tests/mock_data_source_incompatible_low_plugin.cpp)
+target_compile_features(mock_data_source_incompatible_low_plugin PRIVATE cxx_std_20)
+target_compile_options(mock_data_source_incompatible_low_plugin PRIVATE ${PJ_WARNING_FLAGS})
+target_link_libraries(mock_data_source_incompatible_low_plugin PRIVATE pj_base)
+
 add_library(invalid_optional_manifest_data_source_plugin SHARED tests/invalid_optional_manifest_data_source_plugin.cpp)
 target_compile_features(invalid_optional_manifest_data_source_plugin PRIVATE cxx_std_20)
 target_compile_options(invalid_optional_manifest_data_source_plugin PRIVATE ${PJ_WARNING_FLAGS})
@@ -374,6 +384,9 @@ add_test(NAME toolbox_plugin_test COMMAND toolbox_plugin_test)
 add_executable(plugin_catalog_test tests/plugin_catalog_test.cpp)
 target_compile_definitions(plugin_catalog_test PRIVATE
   PJ_MOCK_DATA_SOURCE_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_plugin>"
+  PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_v2_plugin>"
+  PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_incompatible_plugin>"
+  PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_LOW_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_incompatible_low_plugin>"
   PJ_MOCK_JSON_PARSER_PLUGIN_PATH="$<TARGET_FILE:mock_json_parser_plugin>"
   PJ_MOCK_TOOLBOX_PLUGIN_PATH="$<TARGET_FILE:mock_toolbox_plugin>"
   PJ_MOCK_DIALOG_PLUGIN_PATH="$<TARGET_FILE:mock_dialog_plugin>"
@@ -388,7 +401,9 @@ target_compile_options(plugin_catalog_test PRIVATE ${PJ_WARNING_FLAGS})
 target_link_libraries(plugin_catalog_test PRIVATE
   pj_plugin_catalog pj_plugin_runtime_catalog GTest::gtest_main
 )
-add_dependencies(plugin_catalog_test mock_data_source_plugin mock_json_parser_plugin
+add_dependencies(plugin_catalog_test mock_data_source_plugin mock_data_source_v2_plugin
+                 mock_data_source_incompatible_plugin mock_data_source_incompatible_low_plugin
+                 mock_json_parser_plugin
                  mock_toolbox_plugin mock_dialog_plugin missing_id_data_source_plugin
                  invalid_optional_manifest_data_source_plugin missing_required_slots_plugin
                  static_manifest_dialog_plugin legacy_macro_dialog_plugin

--- a/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
@@ -44,6 +44,7 @@ struct PluginDescriptor {
   std::string id;
   std::string name;
   std::string version;
+  std::string min_plotjuggler_version;  ///< optional; "" means no declared minimum (always compatible)
   std::string description;
   std::string category;
   std::vector<std::string> encoding;         ///< for message parsers (one or more)

--- a/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_runtime_catalog.hpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "pj_base/diagnostic_sink.hpp"
@@ -24,6 +25,15 @@
 #include "pj_plugins/host/toolbox_library.hpp"
 
 namespace PJ {
+
+namespace detail {
+// Compares two dotted numeric version strings ("4.1.0" vs "4.0.2"). Overflow-safe:
+// components are compared as decimals, never converted to an integer. Only leading
+// numeric components count; pre-release/build suffixes are ignored; a missing
+// component is 0. Exposed here so the version ordering can be unit-tested directly.
+// Returns <0, 0, or >0 like strcmp.
+int compareSemver(std::string_view lhs, std::string_view rhs);
+}  // namespace detail
 
 // Loaded DataSource plugin plus metadata used by host UIs and sessions.
 struct RuntimeDataSourcePlugin {
@@ -73,14 +83,47 @@ class PluginRuntimeCatalog {
   void setPluginDir(std::filesystem::path plugin_dir);
 
   // Replaces the ordered list of directories scanned by scanDirectory() and
-  // reload(). Directories are scanned in order and de-duplicated by manifest id:
-  // when the same plugin id appears in more than one directory, the first
-  // (highest-priority) directory wins and the later copies are skipped with an
-  // info diagnostic. Empty entries are ignored.
+  // reload(). Directories are scanned in descending priority order and
+  // de-duplicated by manifest id: when the same plugin id appears in more than
+  // one directory, the winner is chosen by compatibility first (see
+  // setHostVersion), then by higher version, then by directory priority; the
+  // losers are skipped with an info diagnostic. Empty entries are ignored.
   void setPluginDirs(std::vector<std::filesystem::path> plugin_dirs);
 
   // Replaces the optional diagnostic sink.
   void setDiagnosticSink(DiagnosticSink sink);
+
+  // Sets the host ("PlotJuggler") version used to gauge plugin compatibility
+  // against each plugin's manifest `min_plotjuggler_version`. Used only to break
+  // ties between duplicate ids: a compatible build is preferred over an
+  // incompatible one (min > host) regardless of version. It never excludes a
+  // plugin — a lone incompatible plugin still loads (with no warning), and if
+  // every candidate for an id is incompatible the highest version still wins.
+  // Empty (the default) disables the check entirely: every plugin is treated as
+  // compatible, so incompatible builds load silently — set a host version to make
+  // the compatibility tie-break take effect.
+  //
+  // Call before the first scanDirectory()/reload(): the value is read on the
+  // scan thread and this class is not thread-safe, so it must not change
+  // concurrently with a scan.
+  void setHostVersion(std::string host_version);
+
+  // Marks a subset of the scan folders (see setPluginDirs) as *authoritative* — a
+  // hard override for duplicate-id resolution. When a plugin id is present in an
+  // authoritative folder, the highest-priority authoritative copy wins outright,
+  // ignoring version and compatibility of any lower-priority folder. The host uses
+  // this for user-explicit tiers (custom folders + --plugin-dir); marketplace and
+  // bundled folders are left non-authoritative so version/compatibility decide
+  // among them. Folders not also in setPluginDirs have no effect.
+  //
+  // Relative paths are resolved to absolute against the current working directory
+  // *at this call*, so a later CWD change cannot silently repoint an entry. A
+  // scan folder is matched to an authoritative one by filesystem identity
+  // (std::filesystem::equivalent) when both exist, so symlinks, '.'/'..', and
+  // case-insensitive filesystems all match correctly; a normalized string compare
+  // is the fallback for an authoritative folder not present on disk. Call before
+  // the first scanDirectory()/reload().
+  void setAuthoritativeFolders(std::vector<std::filesystem::path> folders);
 
   // Clears current state and loads every valid plugin under plugin_dir.
   void scanDirectory();
@@ -142,9 +185,11 @@ class PluginRuntimeCatalog {
   [[nodiscard]] std::string listAvailableEncodings() const;
 
  private:
-  // Scans every directory in plugin_dirs_ (in order) and returns the loadable
-  // descriptors de-duplicated by manifest id (first directory wins). Reports
-  // scan diagnostics and one info diagnostic per skipped duplicate.
+  // Scans every directory in plugin_dirs_ (in priority order) and returns the
+  // loadable descriptors de-duplicated by manifest id, choosing each id's winner
+  // by compatibility, then version, then directory priority (see setPluginDirs /
+  // setHostVersion). Reports scan diagnostics and one info diagnostic per skipped
+  // duplicate.
   [[nodiscard]] std::vector<PluginDescriptor> collectDeduplicatedPlugins() const;
 
   // Loads a descriptor using the family-specific loader.
@@ -171,9 +216,18 @@ class PluginRuntimeCatalog {
   // Emits diagnostics produced by DSO discovery.
   void reportScanDiagnostics(const PluginScanResult& scan) const;
 
+  // True if dir refers to one of the authoritative folders (see
+  // setAuthoritativeFolders). Matches by filesystem identity when both paths
+  // exist, falling back to a normalized string compare otherwise — never by a
+  // single canonicalized-string equality, which is not stable across the
+  // set/scan boundary (symlinks, CWD, case-insensitive filesystems).
+  [[nodiscard]] bool isAuthoritativeDir(const std::filesystem::path& dir) const;
+
   std::vector<std::filesystem::path> plugin_dirs_;
   DiagnosticSink sink_;
   std::string diagnostic_source_;
+  std::string host_version_;  ///< host version for compatibility ties; "" disables the check
+  std::vector<std::filesystem::path> authoritative_folders_;  ///< absolute paths of hard-override folders
   std::vector<RuntimeDataSourcePlugin> data_sources_;
   std::vector<RuntimeMessageParserPlugin> message_parsers_;
   std::vector<RuntimeToolboxPlugin> toolbox_plugins_;

--- a/pj_plugins/src/plugin_catalog.cpp
+++ b/pj_plugins/src/plugin_catalog.cpp
@@ -244,6 +244,10 @@ Expected<PluginDescriptor> decodeManifest(
   if (!category) {
     return unexpected(category.error());
   }
+  auto min_plotjuggler_version = optional_string("min_plotjuggler_version");
+  if (!min_plotjuggler_version) {
+    return unexpected(min_plotjuggler_version.error());
+  }
   auto file_extensions = readStringArray(j, "file_extensions");
   if (!file_extensions) {
     return unexpected(file_extensions.error());
@@ -255,6 +259,7 @@ Expected<PluginDescriptor> decodeManifest(
 
   d.description = *description;
   d.category = *category;
+  d.min_plotjuggler_version = *min_plotjuggler_version;
   d.file_extensions = *file_extensions;
   d.capabilities = *capabilities;
 

--- a/pj_plugins/src/plugin_runtime_catalog.cpp
+++ b/pj_plugins/src/plugin_runtime_catalog.cpp
@@ -5,7 +5,9 @@
 
 #include <algorithm>
 #include <nlohmann/json.hpp>
+#include <string_view>
 #include <system_error>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -59,6 +61,53 @@ std::vector<const PluginT*> constPtrs(const std::vector<PluginT>& plugins, uint6
 
 }  // namespace
 
+namespace detail {
+
+// Compares two dotted numeric version strings (e.g. "4.1.0" vs "4.0.2"). Only the
+// leading numeric components matter: each component's digits are read until the
+// first non-digit. A '.' continues to the next component; any other separator
+// ('-', '+', …) ends the numeric part, so a pre-release/build suffix is ignored
+// *in full* even when it contains dots ("1-rc2", "1-rc.2", "3+meta" all compare as
+// "1"/"1"/"3"). A missing trailing component counts as 0 (so "4.1" == "4.1.0").
+// Components are compared as unsigned decimals *without* converting to an integer
+// type — leading zeros are stripped, then the longer digit run is the larger value,
+// else they compare lexicographically. This is overflow-proof: an absurdly long
+// component like "999999999999999999999.0.0" is handled correctly, not wrapped.
+// Returns <0, 0, or >0 like strcmp.
+int compareSemver(std::string_view lhs, std::string_view rhs) {
+  // Consume the leading digit run of the current component; returns it with leading
+  // zeros stripped ("" == numeric 0). Advance to the next component only across a '.'
+  // that immediately follows the digits — any other separator begins a suffix the
+  // comparison ignores, so the numeric part ends there. (Scanning for the next '.'
+  // instead would wrongly step over a suffix like "-rc.2" and read its digits.)
+  auto takeComponent = [](std::string_view& v) -> std::string_view {
+    size_t len = 0;
+    while (len < v.size() && v[len] >= '0' && v[len] <= '9') {
+      ++len;
+    }
+    const std::string_view run = v.substr(0, len);
+    v = (len < v.size() && v[len] == '.') ? v.substr(len + 1) : std::string_view{};
+    size_t first_significant = 0;
+    while (first_significant < run.size() && run[first_significant] == '0') {
+      ++first_significant;
+    }
+    return run.substr(first_significant);
+  };
+  while (!lhs.empty() || !rhs.empty()) {
+    const std::string_view l = takeComponent(lhs);
+    const std::string_view r = takeComponent(rhs);
+    if (l.size() != r.size()) {
+      return l.size() < r.size() ? -1 : 1;
+    }
+    if (const int cmp = l.compare(r); cmp != 0) {
+      return cmp < 0 ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+}  // namespace detail
+
 PluginRuntimeCatalog::PluginRuntimeCatalog(
     std::filesystem::path plugin_dir, DiagnosticSink sink, std::string diagnostic_source)
     : sink_(std::move(sink)), diagnostic_source_(std::move(diagnostic_source)) {
@@ -82,13 +131,77 @@ void PluginRuntimeCatalog::setDiagnosticSink(DiagnosticSink sink) {
   sink_ = std::move(sink);
 }
 
+void PluginRuntimeCatalog::setHostVersion(std::string host_version) {
+  host_version_ = std::move(host_version);
+}
+
+void PluginRuntimeCatalog::setAuthoritativeFolders(std::vector<std::filesystem::path> folders) {
+  authoritative_folders_.clear();
+  for (const std::filesystem::path& folder : folders) {
+    if (folder.empty()) {
+      continue;
+    }
+    // Lock the working directory *now*: std::filesystem::absolute prepends the
+    // current path without touching the filesystem (symlinks stay unresolved, the
+    // folder need not exist yet), so a later CWD change cannot repoint a relative
+    // entry. Filesystem identity is resolved lazily at scan time by
+    // isAuthoritativeDir(), which is stable where a set-time canonicalization is not.
+    std::error_code ec;
+    std::filesystem::path absolute = std::filesystem::absolute(folder, ec);
+    authoritative_folders_.push_back(ec ? folder : std::move(absolute));
+  }
+}
+
+bool PluginRuntimeCatalog::isAuthoritativeDir(const std::filesystem::path& dir) const {
+  return std::ranges::any_of(authoritative_folders_, [&](const std::filesystem::path& folder) {
+    // Prefer filesystem identity: it resolves symlinks, '.'/'..', and
+    // case-insensitive filesystems that a compare of two independent
+    // canonicalizations would miss. equivalent() needs both paths to exist; when
+    // one does not (e.g. an authoritative folder registered before it is created)
+    // it sets ec and returns false, so we fall back to a normalized string compare.
+    std::error_code ec;
+    return (std::filesystem::equivalent(dir, folder, ec) && !ec) || canonicalPath(dir) == canonicalPath(folder);
+  });
+}
+
 std::vector<PluginDescriptor> PluginRuntimeCatalog::collectDeduplicatedPlugins() const {
+  // Winner selection when the same plugin id appears in more than one folder:
+  //
+  //   1. Authoritative folders (custom folders + --plugin-dir; see
+  //      setAuthoritativeFolders) are a HARD override. Once an id is claimed by an
+  //      authoritative folder, the highest-priority authoritative copy wins outright
+  //      — ignoring the version and compatibility of any lower-priority folder.
+  //   2. Among the remaining (managed) folders — marketplace + bundled — the winner
+  //      is by compatibility, then version, then folder priority: a compatible build
+  //      beats an incompatible one (min_plotjuggler_version > host_version_) at any
+  //      version; among equally compatible candidates the higher version wins; a tie
+  //      keeps the higher-priority folder.
+  //
+  // Compatibility only breaks ties between managed candidates — it never excludes a
+  // plugin (a lone incompatible plugin still loads; if every managed candidate is
+  // incompatible the highest version wins). min_plotjuggler_version is an advisory
+  // floor, not a hard gate (the ABI gate runs earlier in scanPluginDsos). An empty
+  // host_version_ disables the compatibility check entirely.
+  const auto compatible = [this](const PluginDescriptor& d) {
+    return host_version_.empty() || d.min_plotjuggler_version.empty() ||
+           detail::compareSemver(d.min_plotjuggler_version, host_version_) <= 0;
+  };
+
   std::vector<PluginDescriptor> winners;
-  std::unordered_set<std::string> seen_ids;
+  std::unordered_map<std::string, size_t> winner_index;  // id -> position in `winners`
+  std::unordered_set<std::string> authoritative_win;     // ids whose current winner is authoritative (locked)
+  std::unordered_set<std::string> scanned_dirs;          // canonical paths already scanned (dedup the list itself)
   for (const std::filesystem::path& dir : plugin_dirs_) {
     if (dir.empty()) {
       continue;
     }
+    // Skip a folder already scanned in a higher-priority slot: without this, the
+    // same folder listed twice compares every plugin against itself and emits a
+    // confusing "ignoring duplicate id … already loaded from <same path>".
+    if (!scanned_dirs.insert(canonicalPath(dir)).second) {
+      continue;
+    }
+    const bool dir_authoritative = isAuthoritativeDir(dir);
     auto scan = scanPluginDsos(dir);
     if (!scan) {
       report(DiagnosticLevel::kError, {}, scan.error());
@@ -96,14 +209,67 @@ std::vector<PluginDescriptor> PluginRuntimeCatalog::collectDeduplicatedPlugins()
     }
     reportScanDiagnostics(*scan);
     for (const PluginDescriptor& descriptor : scan->plugins) {
-      if (!seen_ids.insert(descriptor.id).second) {
-        report(
-            DiagnosticLevel::kInfo, descriptor.id,
-            descriptor.dso_path.string() + ": ignoring duplicate plugin id \"" + descriptor.id +
-                "\" (already provided by a higher-priority folder)");
+      const auto it = winner_index.find(descriptor.id);
+      if (it == winner_index.end()) {
+        winner_index.emplace(descriptor.id, winners.size());
+        winners.push_back(descriptor);
+        if (dir_authoritative) {
+          authoritative_win.insert(descriptor.id);
+        }
         continue;
       }
-      winners.push_back(descriptor);
+      PluginDescriptor& incumbent = winners[it->second];
+      const std::string incumbent_path = incumbent.dso_path.string();
+
+      // (1) A locked authoritative winner is a hard override — nothing displaces it.
+      if (authoritative_win.count(descriptor.id) != 0) {
+        // Note when the loser is itself authoritative (just lower priority), so the
+        // diagnostic does not read as if a managed copy lost to an authoritative one.
+        const std::string candidate_note =
+            dir_authoritative ? "; candidate is also from an authoritative folder (lower priority)" : "";
+        report(
+            DiagnosticLevel::kInfo, descriptor.id,
+            descriptor.dso_path.string() + ": ignoring duplicate plugin id \"" + descriptor.id + "\" v" +
+                descriptor.version + " (authoritative v" + incumbent.version + " already loaded from " +
+                incumbent_path + candidate_note + ")");
+        continue;
+      }
+      // (1) An authoritative candidate overrides a managed incumbent, regardless of
+      //     version or compatibility.
+      if (dir_authoritative) {
+        report(
+            DiagnosticLevel::kInfo, descriptor.id,
+            descriptor.dso_path.string() + ": plugin id \"" + descriptor.id + "\" v" + descriptor.version +
+                " from an authoritative folder supersedes v" + incumbent.version + " from " + incumbent_path);
+        incumbent = descriptor;
+        authoritative_win.insert(descriptor.id);
+        continue;
+      }
+      // (2) Both managed: compatibility, then version, then folder priority.
+      const bool cand_ok = compatible(descriptor);
+      const bool inc_ok = compatible(incumbent);
+      const bool replace =
+          (cand_ok != inc_ok) ? cand_ok : detail::compareSemver(descriptor.version, incumbent.version) > 0;
+      if (replace) {
+        const std::string reason = (cand_ok && !inc_ok)
+                                       ? " supersedes incompatible v" + incumbent.version +
+                                             " (needs PlotJuggler >= " + incumbent.min_plotjuggler_version + ")"
+                                       : " supersedes v" + incumbent.version;
+        report(
+            DiagnosticLevel::kInfo, descriptor.id,
+            descriptor.dso_path.string() + ": plugin id \"" + descriptor.id + "\" v" + descriptor.version + reason +
+                " from " + incumbent_path);
+        incumbent = descriptor;
+      } else {
+        const std::string reason =
+            (!cand_ok && inc_ok)
+                ? "ignoring incompatible plugin id \"" + descriptor.id + "\" v" + descriptor.version +
+                      " (needs PlotJuggler >= " + descriptor.min_plotjuggler_version + "; compatible v" +
+                      incumbent.version + " already loaded from " + incumbent_path + ")"
+                : "ignoring duplicate plugin id \"" + descriptor.id + "\" v" + descriptor.version + " (v" +
+                      incumbent.version + " already loaded from " + incumbent_path + ")";
+        report(DiagnosticLevel::kInfo, descriptor.id, descriptor.dso_path.string() + ": " + reason);
+      }
     }
   }
   return winners;

--- a/pj_plugins/tests/mock_data_source_incompatible_low_plugin.cpp
+++ b/pj_plugins/tests/mock_data_source_incompatible_low_plugin.cpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+// A data-source mock sharing the id "mock-data-source" with the other mocks, at a
+// LOW version (1.5.0) but declaring a min_plotjuggler_version (5.0.0) that no test
+// host satisfies. Paired with mock_data_source_incompatible (v3.0.0, same min) it
+// lets a test place incompatible candidates both below and above a compatible one.
+
+#include "pj_base/data_source_protocol.h"
+
+extern "C" PJ_DATA_SOURCE_EXPORT const uint32_t pj_plugin_abi_version = PJ_ABI_VERSION;
+
+namespace {
+
+void* create() noexcept {
+  return reinterpret_cast<void*>(0x1);
+}
+
+void destroy(void*) noexcept {}
+
+uint64_t capabilities(void*) noexcept {
+  return 0;
+}
+
+bool bind(void*, PJ_service_registry_t, PJ_error_t*) noexcept {
+  return true;
+}
+
+bool save(void*, PJ_string_view_t* out_json, PJ_error_t*) noexcept {
+  static constexpr const char* kJson = "{}";
+  if (out_json != nullptr) {
+    out_json->data = kJson;
+    out_json->size = 2;
+  }
+  return true;
+}
+
+bool load(void*, PJ_string_view_t, PJ_error_t*) noexcept {
+  return true;
+}
+
+bool ok(void*, PJ_error_t*) noexcept {
+  return true;
+}
+
+void stop(void*) noexcept {}
+
+PJ_data_source_state_t state(void*) noexcept {
+  return PJ_DATA_SOURCE_STATE_IDLE;
+}
+
+PJ_borrowed_dialog_t dialog(void*) noexcept {
+  return PJ_borrowed_dialog_t{nullptr, nullptr};
+}
+
+const void* extension(void*, PJ_string_view_t) noexcept {
+  return nullptr;
+}
+
+}  // namespace
+
+extern "C" PJ_DATA_SOURCE_EXPORT const PJ_data_source_vtable_t* PJ_get_data_source_vtable() noexcept {
+  static const PJ_data_source_vtable_t vt = {
+      PJ_DATA_SOURCE_PROTOCOL_VERSION,
+      sizeof(PJ_data_source_vtable_t),
+      create,
+      destroy,
+      R"({"id":"mock-data-source","name":"Mock DataSource","version":"1.5.0","min_plotjuggler_version":"5.0.0"})",
+      capabilities,
+      bind,
+      save,
+      load,
+      ok,
+      stop,
+      ok,
+      ok,
+      ok,
+      state,
+      dialog,
+      extension,
+  };
+  return &vt;
+}

--- a/pj_plugins/tests/mock_data_source_incompatible_plugin.cpp
+++ b/pj_plugins/tests/mock_data_source_incompatible_plugin.cpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+// A data-source mock sharing the id "mock-data-source" with the other mocks, but
+// at a higher version (3.0.0) and declaring a min_plotjuggler_version (5.0.0) that
+// no test host satisfies. Used to exercise the compatibility tie-break in the
+// runtime catalog's de-duplication.
+
+#include "pj_base/data_source_protocol.h"
+
+extern "C" PJ_DATA_SOURCE_EXPORT const uint32_t pj_plugin_abi_version = PJ_ABI_VERSION;
+
+namespace {
+
+void* create() noexcept {
+  return reinterpret_cast<void*>(0x1);
+}
+
+void destroy(void*) noexcept {}
+
+uint64_t capabilities(void*) noexcept {
+  return 0;
+}
+
+bool bind(void*, PJ_service_registry_t, PJ_error_t*) noexcept {
+  return true;
+}
+
+bool save(void*, PJ_string_view_t* out_json, PJ_error_t*) noexcept {
+  static constexpr const char* kJson = "{}";
+  if (out_json != nullptr) {
+    out_json->data = kJson;
+    out_json->size = 2;
+  }
+  return true;
+}
+
+bool load(void*, PJ_string_view_t, PJ_error_t*) noexcept {
+  return true;
+}
+
+bool ok(void*, PJ_error_t*) noexcept {
+  return true;
+}
+
+void stop(void*) noexcept {}
+
+PJ_data_source_state_t state(void*) noexcept {
+  return PJ_DATA_SOURCE_STATE_IDLE;
+}
+
+PJ_borrowed_dialog_t dialog(void*) noexcept {
+  return PJ_borrowed_dialog_t{nullptr, nullptr};
+}
+
+const void* extension(void*, PJ_string_view_t) noexcept {
+  return nullptr;
+}
+
+}  // namespace
+
+extern "C" PJ_DATA_SOURCE_EXPORT const PJ_data_source_vtable_t* PJ_get_data_source_vtable() noexcept {
+  static const PJ_data_source_vtable_t vt = {
+      PJ_DATA_SOURCE_PROTOCOL_VERSION,
+      sizeof(PJ_data_source_vtable_t),
+      create,
+      destroy,
+      R"({"id":"mock-data-source","name":"Mock DataSource","version":"3.0.0","min_plotjuggler_version":"5.0.0"})",
+      capabilities,
+      bind,
+      save,
+      load,
+      ok,
+      stop,
+      ok,
+      ok,
+      ok,
+      state,
+      dialog,
+      extension,
+  };
+  return &vt;
+}

--- a/pj_plugins/tests/plugin_catalog_test.cpp
+++ b/pj_plugins/tests/plugin_catalog_test.cpp
@@ -205,6 +205,265 @@ TEST_F(PluginCatalogTest, RuntimeCatalogDedupsDuplicateIdFirstFolderWins) {
       << "winner " << winner << " is not in the first folder " << dir_a;
 }
 
+TEST_F(PluginCatalogTest, RuntimeCatalogSkipsDuplicateScanFolders) {
+  // The same folder listed twice in setPluginDirs is scanned once: the second pass is
+  // skipped, so no plugin is ever compared against itself — which would otherwise emit a
+  // confusing "ignoring duplicate id … already loaded from <same path>" diagnostic.
+  const std::filesystem::path dir_a = dir_ / "a";
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_a / pluginFileName("ds"));
+
+  std::vector<std::string> messages;
+  PluginRuntimeCatalog catalog({}, [&](const Diagnostic& d) { messages.push_back(d.message); });
+  catalog.setPluginDirs({dir_a, dir_a});  // same folder twice
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  for (const std::string& message : messages) {
+    EXPECT_EQ(message.find("ignoring duplicate"), std::string::npos)
+        << "a folder listed twice must not trigger a self-dedup diagnostic: " << message;
+  }
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogPrefersHigherVersionOverFolderPriority) {
+  // Same plugin id in two folders, but the LOWER-priority folder ships a newer
+  // version (v2.0.0) than the higher-priority one (v1.0.0). Version wins over
+  // folder priority, so the v2 DSO from the second folder is the one loaded.
+  const std::filesystem::path dir_a = dir_ / "a";
+  const std::filesystem::path dir_b = dir_ / "b";
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_a / pluginFileName("ds"));     // v1.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));  // v2.0.0
+
+  PluginRuntimeCatalog catalog;
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].id, "mock-data-source");
+  EXPECT_EQ(catalog.dataSources()[0].version, "2.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_b))
+      << "winner " << winner << " should be the newer v2 in " << dir_b;
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogKeepsHigherPriorityWhenNewerVersionIsHigherPriority) {
+  // Mirror of the above: the newer version now sits in the HIGHER-priority folder.
+  // The winner is still v2.0.0, confirming the tie-break never demotes it.
+  const std::filesystem::path dir_a = dir_ / "a";
+  const std::filesystem::path dir_b = dir_ / "b";
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_a / pluginFileName("ds"));  // v2.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_b / pluginFileName("ds"));     // v1.0.0
+
+  PluginRuntimeCatalog catalog;
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "2.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_a));
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogPrefersCompatibleOverHigherIncompatibleVersion) {
+  // Higher-priority folder ships an incompatible v3.0.0 (needs PlotJuggler 5.0.0);
+  // lower-priority folder ships a compatible v2.0.0. With a 4.0.0 host, the
+  // compatible build wins even though it is both lower version and lower priority.
+  const std::filesystem::path dir_a = dir_ / "a";
+  const std::filesystem::path dir_b = dir_ / "b";
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(
+      PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_PLUGIN_PATH, dir_a / pluginFileName("ds"));               // v3, min 5.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));  // v2, no min
+
+  PluginRuntimeCatalog catalog;
+  catalog.setHostVersion("4.0.0");
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "2.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_b))
+      << "winner " << winner << " should be the compatible v2 in " << dir_b;
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogLoadsLoneIncompatiblePlugin) {
+  // A single incompatible plugin (needs PlotJuggler 5.0.0) still loads on a 4.0.0
+  // host: min_plotjuggler_version only breaks ties, it never excludes.
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_PLUGIN_PATH, dir_ / pluginFileName("ds"));
+
+  PluginRuntimeCatalog catalog;
+  catalog.setHostVersion("4.0.0");
+  catalog.setPluginDir(dir_);
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "3.0.0");
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogPrefersTheOnlyCompatibleAmongMixedCandidates) {
+  // Three folders, same id, mixed compatibility: incompatible v3.0.0 (min 5.0.0) in
+  // the highest-priority folder, compatible v2.0.0 in the middle, incompatible v1.5.0
+  // (min 5.0.0) in the lowest. With a 4.0.0 host the compatible v2.0.0 wins — it is
+  // neither the highest version nor the highest-priority folder.
+  const std::filesystem::path dir_a = dir_ / "a";
+  const std::filesystem::path dir_b = dir_ / "b";
+  const std::filesystem::path dir_c = dir_ / "c";
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::create_directories(dir_c);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_PLUGIN_PATH, dir_a / pluginFileName("ds"));  // v3, min 5
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));            // v2, compat
+  std::filesystem::copy_file(
+      PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_LOW_PLUGIN_PATH, dir_c / pluginFileName("ds"));  // v1.5, min 5
+
+  PluginRuntimeCatalog catalog;
+  catalog.setHostVersion("4.0.0");
+  catalog.setPluginDirs({dir_a, dir_b, dir_c});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "2.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_b))
+      << "winner " << winner << " should be the only compatible candidate in " << dir_b;
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogAuthoritativeFolderOverridesHigherVersion) {
+  // An authoritative (user-explicit) folder is a hard override: its v1.0.0 wins over
+  // a higher v2.0.0 in a lower-priority managed folder. Without the authoritative
+  // mark, version would pick v2.0.0 — this isolates the override.
+  const std::filesystem::path dir_a = dir_ / "a";  // authoritative
+  const std::filesystem::path dir_b = dir_ / "b";  // managed
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_a / pluginFileName("ds"));     // v1.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));  // v2.0.0
+
+  PluginRuntimeCatalog catalog;
+  catalog.setAuthoritativeFolders({dir_a});
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "1.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_a));
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogAuthoritativeFolderWinsEvenWhenIncompatible) {
+  // The authoritative copy wins even if it is incompatible (min 5.0.0 > host 4.0.0)
+  // and the managed alternative is compatible: an explicit choice overrides compat.
+  const std::filesystem::path dir_a = dir_ / "a";  // authoritative, incompatible v3.0.0
+  const std::filesystem::path dir_b = dir_ / "b";  // managed, compatible v2.0.0
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_INCOMPATIBLE_PLUGIN_PATH, dir_a / pluginFileName("ds"));  // v3, min 5
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));            // v2, compat
+
+  PluginRuntimeCatalog catalog;
+  catalog.setHostVersion("4.0.0");
+  catalog.setAuthoritativeFolders({dir_a});
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "3.0.0");
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_a));
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogAuthoritativeFolderSurvivesSymlinkMaterializedAfterRegistration) {
+  // Regression for the non-idempotent-canonicalization trap: an authoritative folder is
+  // registered before it exists on disk, then materializes as a symlink. weakly_canonical
+  // returns the path unresolved at registration but resolves the symlink at scan time, so a
+  // string compare of the two canonicalizations diverges — the folder silently degrades to
+  // managed and version picks the higher v2.0.0. Matching by filesystem identity instead keeps
+  // the authoritative v1.0.0 override intact. This is the shared root cause of all three
+  // divergence scenarios (symlink timing, relative-path + CWD change, case-insensitive
+  // filesystems); the last is not reproducible on a case-sensitive CI filesystem.
+  const std::filesystem::path real_dir = dir_ / "real";  // symlink target, authoritative v1.0.0
+  const std::filesystem::path link_dir = dir_ / "link";  // authoritative spelling (a symlink)
+  const std::filesystem::path dir_b = dir_ / "b";        // managed, v2.0.0
+
+  PluginRuntimeCatalog catalog;
+  // Register the authoritative folder while it does NOT yet exist on disk.
+  catalog.setAuthoritativeFolders({link_dir});
+
+  std::filesystem::create_directories(real_dir);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, real_dir / pluginFileName("ds"));  // v1.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));  // v2.0.0
+  std::error_code ec;
+  std::filesystem::create_directory_symlink(real_dir, link_dir, ec);
+  if (ec) {
+    GTEST_SKIP() << "filesystem does not support directory symlinks: " << ec.message();
+  }
+
+  catalog.setPluginDirs({link_dir, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "1.0.0")
+      << "authoritative override must survive a symlink that only resolves at scan time";
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), real_dir));
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogAuthoritativeFolderSupersedesEarlierManagedIncumbent) {
+  // The authoritative folder is scanned AFTER a managed one (it sits lower in the scan
+  // list), so a managed incumbent is already recorded when the authoritative copy arrives.
+  // The authoritative candidate must still supersede it — the override is not order
+  // dependent. Complements the existing tests, which place the authoritative folder first.
+  const std::filesystem::path dir_managed = dir_ / "managed";  // higher priority, managed, v2.0.0
+  const std::filesystem::path dir_auth = dir_ / "auth";        // lower priority, authoritative, v1.0.0
+  std::filesystem::create_directories(dir_managed);
+  std::filesystem::create_directories(dir_auth);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_managed / pluginFileName("ds"));  // v2.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_auth / pluginFileName("ds"));        // v1.0.0
+
+  PluginRuntimeCatalog catalog;
+  catalog.setAuthoritativeFolders({dir_auth});
+  catalog.setPluginDirs({dir_managed, dir_auth});  // managed scanned first, authoritative second
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "1.0.0")
+      << "an authoritative folder must override an already-recorded managed incumbent";
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_auth));
+}
+
+TEST_F(PluginCatalogTest, RuntimeCatalogAuthoritativeFolderOutsideScanListHasNoEffect) {
+  // An authoritative folder that is NOT among the scan dirs has no effect (docstring
+  // contract): among the two managed scan folders, version decides normally, so the
+  // lower-priority v2.0.0 beats the higher-priority v1.0.0.
+  const std::filesystem::path dir_a = dir_ / "a";          // managed, higher priority, v1.0.0
+  const std::filesystem::path dir_b = dir_ / "b";          // managed, lower priority, v2.0.0
+  const std::filesystem::path dir_other = dir_ / "other";  // authoritative, but never scanned
+  std::filesystem::create_directories(dir_a);
+  std::filesystem::create_directories(dir_b);
+  std::filesystem::create_directories(dir_other);
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_PLUGIN_PATH, dir_a / pluginFileName("ds"));     // v1.0.0
+  std::filesystem::copy_file(PJ_MOCK_DATA_SOURCE_V2_PLUGIN_PATH, dir_b / pluginFileName("ds"));  // v2.0.0
+
+  PluginRuntimeCatalog catalog;
+  catalog.setAuthoritativeFolders({dir_other});  // not in the scan list -> must be inert
+  catalog.setPluginDirs({dir_a, dir_b});
+  catalog.scanDirectory();
+
+  ASSERT_EQ(catalog.dataSources().size(), 1U);
+  EXPECT_EQ(catalog.dataSources()[0].version, "2.0.0")
+      << "an authoritative folder outside the scan list must not change the managed outcome";
+  const std::filesystem::path winner(catalog.dataSources()[0].path);
+  EXPECT_TRUE(std::filesystem::equivalent(winner.parent_path(), dir_b));
+}
+
 TEST_F(PluginCatalogTest, RuntimeCatalogLoadsDistinctIdsFromMultipleFolders) {
   // Different plugins in different folders all load.
   const std::filesystem::path dir_a = dir_ / "a";
@@ -220,6 +479,41 @@ TEST_F(PluginCatalogTest, RuntimeCatalogLoadsDistinctIdsFromMultipleFolders) {
 
   EXPECT_EQ(catalog.dataSources().size(), 1U);
   EXPECT_EQ(catalog.toolboxes().size(), 1U);
+}
+
+// ─── compareSemver (version ordering used by the runtime catalog dedup) ──────────
+
+TEST(CompareSemver, OrdersByNumericComponents) {
+  EXPECT_LT(detail::compareSemver("4.0.2", "4.1.0"), 0);
+  EXPECT_GT(detail::compareSemver("5.0.0", "4.9.9"), 0);
+  EXPECT_EQ(detail::compareSemver("4.1.0", "4.1.0"), 0);
+}
+
+TEST(CompareSemver, TreatsMissingTrailingComponentsAsZero) {
+  EXPECT_EQ(detail::compareSemver("4.1", "4.1.0"), 0);
+  EXPECT_EQ(detail::compareSemver("4", "4.0.0"), 0);
+  EXPECT_LT(detail::compareSemver("4.0", "4.0.1"), 0);
+}
+
+TEST(CompareSemver, IgnoresLeadingZerosAndSuffixes) {
+  EXPECT_EQ(detail::compareSemver("4.01.0", "4.1.0"), 0);
+  EXPECT_EQ(detail::compareSemver("1.0.0-rc2", "1.0.0"), 0);  // pre-release suffix ignored
+  EXPECT_LT(detail::compareSemver("1.0.0", "2.0.0-beta"), 0);
+}
+
+TEST(CompareSemver, IgnoresDottedPreReleaseSuffix) {
+  // The suffix is ignored in full even when it contains dots: the compare must not walk
+  // past the '-' and read the suffix's own numeric parts (regression for a version that
+  // stepped to the next '.' instead of stopping at the pre-release separator).
+  EXPECT_EQ(detail::compareSemver("1.0.0-rc.2", "1.0.0-rc.3"), 0);
+  EXPECT_EQ(detail::compareSemver("1.0-rc.2", "1.0.0"), 0);
+  EXPECT_LT(detail::compareSemver("1.0.0-rc.9", "1.0.1"), 0);
+}
+
+TEST(CompareSemver, DoesNotOverflowOnHugeComponents) {
+  EXPECT_GT(detail::compareSemver("999999999999999999999.0.0", "4.0.0"), 0);
+  EXPECT_LT(detail::compareSemver("4.0.0", "1000000000000000000000.0.0"), 0);
+  EXPECT_EQ(detail::compareSemver("100000000000000000000.0", "100000000000000000000.0"), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

`PluginRuntimeCatalog::collectDeduplicatedPlugins` no longer resolves a duplicate plugin id by "first folder wins". The winner is chosen by, in order: **(0) authoritative override → (1) compatibility → (2) version → (3) folder priority**.

- **Authoritative override:** folders marked authoritative via `setAuthoritativeFolders()` (the host uses this for user-explicit tiers — custom folders + `--plugin-dir`) are a **hard override**. Once an id is claimed by an authoritative folder, the highest-priority authoritative copy wins outright, ignoring version and compatibility of any lower-priority folder. Authoritative folders are matched by **filesystem equivalence** (`std::filesystem::equivalent`) with a canonical-path fallback for paths that do not exist yet, so a folder registered before it materializes — or later exposed as a symlink — is still recognised as authoritative.
- **Compatibility:** among the remaining *managed* folders, a build whose manifest `min_plotjuggler_version` exceeds the host version (see `setHostVersion()`) is dispreferred, so a compatible build beats an incompatible one at any version. It **only breaks ties, never excludes** — a lone incompatible plugin still loads, and if every managed candidate is incompatible the highest version wins (advisory floor; the ABI gate runs earlier in `scanPluginDsos`).
- **Version:** among equally compatible managed candidates the higher version wins. Component-wise comparison over `string_view` digits (no numeric conversion) makes the comparison overflow-safe for arbitrarily large components. Dotted pre-release suffixes (`1.0.0-rc.2`) are treated as a single tag and not walked into.
- **Priority:** a tie keeps the higher-priority folder. The scan also dedups duplicate entries in the folder list so a folder listed twice does not compete with itself.

## Other changes

- Parses `min_plotjuggler_version` into `PluginDescriptor`; adds `PluginRuntimeCatalog::setHostVersion()` and `setAuthoritativeFolders()` (host feeds both). Both document their threading precondition (call before the first scan; not thread-safe).
- `compareSemver` helper (in a `detail` namespace so it is unit-testable): compares dotted numeric versions **without converting to an integer (overflow-safe)**, ignoring pre-release/build suffixes and treating missing components as 0.
- Diagnostics name the exact retained/superseded plugin **path** (instead of a generic "higher-priority folder"), and clarify when an authoritative override is picked against another authoritative candidate.

## Why

The scan hierarchy discovers the same plugin id from several folders (custom paths, `--plugin-dir`, marketplace, FHS). Picking purely by folder priority can load an older build over a newer one; picking a higher version the host cannot run is equally wrong; and a version in a lower-priority folder should not silently override a user's explicit choice. The rule makes user-explicit folders authoritative, and among the rest picks the **newest compatible** build, with priority only breaking ties.

Version, `min_plotjuggler_version` and folder identity are all resolved at dedup time, and ABI-incompatible DSOs are filtered by `scanPluginDsos` before dedup, so the logic stays localised to one function.

## Testing

`plugin_catalog_test` covers:

- `DedupsDuplicateIdFirstFolderWins` (equal version → priority)
- `PrefersHigherVersionOverFolderPriority` / `KeepsHigherPriorityWhenNewerVersionIsHigherPriority`
- `PrefersCompatibleOverHigherIncompatibleVersion` / `LoadsLoneIncompatiblePlugin` / `PrefersTheOnlyCompatibleAmongMixedCandidates`
- `AuthoritativeFolderOverridesHigherVersion` / `WinsEvenWhenIncompatible` / `SupersedesEarlierManagedIncumbent` / `OutsideScanListHasNoEffect`
- `AuthoritativeFolderSurvivesSymlinkMaterializedAfterRegistration`
- `SkipsDuplicateScanFolders`
- `CompareSemver.*` — ordering, missing components, leading zeros/suffixes, overflow (`999999999999999999999.0.0`), dotted pre-release (`1.0.0-rc.2`)
