### PR TITLE
chore(release): prepare 0.16.0 + seed the Conan Center recipe at 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ pj_media/testdata/
 /.pixi/
 /output/
 /build-test/
+# Local `conan create` artifacts from testing the staged Conan Center recipe
+# (see packaging/conan-center-index/README.md). Anchored here so they never
+# leak into the recipe tree that gets copied into the conan-center-index fork.
+/packaging/conan-center-index/recipes/plotjuggler_sdk/all/test_package/build/
+/packaging/conan-center-index/recipes/plotjuggler_sdk/all/test_package/CMakeUserPresets.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,26 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
-## [Unreleased] — not yet publicly tagged
+## [0.16.0]
+
+### SDK slimming: duplicate-resolution catalog moved to the host (HOST-FACING REMOVAL)
+
+`PluginRuntimeCatalog` — the layer that resolved duplicate plugin ids across scan
+folders by authoritative → compatibility → version → folder priority — is host
+*policy*, not a plugin-facing mechanism, so it moved to the PlotJuggler app
+(`pj_runtime`). The SDK stays a thin discovery + loader layer: `scanPluginDsos`,
+`inspectPluginDso`, the RAII loaders, and the C ABI are unchanged. (#144)
+
+- **Removed** `pj_plugins/host/plugin_runtime_catalog.hpp` and the installed
+  `pj_plugin_runtime_catalog` library (dropped from the `pj_plugin_host`
+  umbrella and the install set).
+
+**Versioning note.** No plugin links `PluginRuntimeCatalog` (it was host-side
+only) and `abi/baseline.abi` is unchanged, so by the plugin-impact rule this is
+a MINOR, not a MAJOR. It does remove host-facing public API: a *host* built
+against 0.15.0's catalog must adopt the app-side implementation (`pj_runtime`).
+
+## [0.15.0]
 
 ### DataSource: per-topic pause/resume — advertise-without-subscribe + demand-driven control (ADDITIVE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.15.0")
+  set(PJ_PACKAGE_VERSION "0.16.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.15.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.16.0` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -40,7 +40,11 @@ class PlotjugglerSdkConan(ConanFile):
     # so no released plugin broke.
     # 0.15.0 adds DataSource per-topic pause (advertise + demand-driven
     # subscription) — strictly additive. See CHANGELOG.md.
-    version = "0.15.0"
+    # 0.16.0 removes the host-side PluginRuntimeCatalog (duplicate-resolution
+    # policy moved to the app, pj_runtime). No plugin links it and
+    # abi/baseline.abi is unchanged, so per the plugin-impact rule this is a
+    # MINOR, not a MAJOR. See CHANGELOG.md.
+    version = "0.16.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"
@@ -172,7 +176,6 @@ class PlotjugglerSdkConan(ConanFile):
             host = self.cpp_info.components["plugin_host"]
             host.set_property("cmake_target_name", "plotjuggler_sdk::plugin_host")
             host.libs = [
-                "pj_plugin_runtime_catalog",
                 "pj_data_source_host",
                 "pj_message_parser_host",
                 "pj_toolbox_host",

--- a/packaging/conan-center-index/README.md
+++ b/packaging/conan-center-index/README.md
@@ -22,18 +22,33 @@ tree for local dev/consume. The CCI recipe instead downloads the released
 
 ## Prerequisites before submitting
 
-1. **Ship the `-Werror` gate in a released tag.** The recipe sets
+The recipe is seeded with **`0.16.0`** — the first tag that satisfies these:
+
+1. **The `-Werror` gate ships in the consumed tag.** The recipe sets
    `-DPJ_WARNINGS_AS_ERRORS=OFF` so a not-yet-pinned compiler on CCI's build
-   matrix cannot fail the build on a new warning. That option was added on this
-   branch (`CMakeLists.txt`). It must be present in the tag CCI consumes:
-   merge this branch, cut a new release tag, then update `config.yml` +
-   `conandata.yml` (new version + new sha256). The sha256 currently pinned is
-   for the *pre-gate* `v0.14.0` tag and is only good for local smoke testing.
-2. **Pick the entry version.** Per the SDK's own versioning note, the first
-   public release carrying the unified `pj.data_processors.v1` service must be
-   `1.0.0`. Decide whether CCI is seeded with `0.14.x` or `1.0.0`.
+   matrix cannot fail the build on a new warning. That option landed in
+   `CMakeLists.txt` via #139 (first present in `v0.15.0`).
+2. **The tag no longer ships `PluginRuntimeCatalog`.** #144 removed the
+   host-side duplicate-resolution catalog (moved to the app). Whatever CCI
+   accepts first becomes the floor consumers pin against — seeding with
+   `0.15.0` would publish API that `0.16.0` removes, breaking the repo's
+   "no breaking changes within 0.x" promise for CCI consumers. `0.16.0` is the
+   first tag with the final thin-SDK surface.
 3. **Confirm dependencies exist in CCI** (verified 2026-07-01, all present):
    `nlohmann_json/3.12.0`, `fmt/12.1.0`, `fast_float/8.1.0`.
+
+## After tagging `v0.16.0`
+
+The `sha256` in `conandata.yml` is a **placeholder** until the release tag
+exists (the digest of a tag tarball cannot be known before the tag is cut).
+Once `v0.16.0` is tagged and pushed:
+
+```bash
+curl -sL https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.0.tar.gz | sha256sum
+```
+
+and replace the placeholder in `conandata.yml` before copying this tree into
+the conan-center-index fork.
 
 ## Test locally before opening the PR
 
@@ -41,12 +56,13 @@ From inside a checkout of the conan-center-index fork:
 
 ```bash
 cd recipes/plotjuggler_sdk
-# Build + run the test_package for the default profile:
-conan create all --version=0.14.0 --build=missing
+# Build + run the test_package. The recipe validate()s C++20, so a profile
+# whose compiler.cppstd is < 20 (e.g. the common gnu17 default) is correctly
+# rejected — pass an explicit C++20 std:
+conan create all --version=0.16.0 -s compiler.cppstd=20 --build=missing
 # Exercise the option matrix CCI will build:
-conan create all --version=0.14.0 -o "&:with_host=False" --build=missing
-conan create all --version=0.14.0 -o "&:assert_throws=True" --build=missing
-conan create all --version=0.14.0 -s compiler.cppstd=20 --build=missing
+conan create all --version=0.16.0 -s compiler.cppstd=20 -o "&:with_host=False" --build=missing
+conan create all --version=0.16.0 -s compiler.cppstd=20 -o "&:assert_throws=True" --build=missing
 ```
 
 Then run the Conan Center hooks locally (catches KB-Hxxx violations the reviewer
@@ -55,13 +71,13 @@ bot will flag):
 ```bash
 conan config install https://github.com/conan-io/conan-center-index.git \
   -sf .c3i/hooks -tf .conan2/extensions/hooks   # one-time
-conan create all --version=0.14.0 --build=missing               # hooks run inline
+conan create all --version=0.16.0 -s compiler.cppstd=20 --build=missing   # hooks run inline
 ```
 
 ## Open the PR
 
 Fork `conan-io/conan-center-index`, drop this tree under `recipes/`, commit, and
-open a PR titled `plotjuggler_sdk/0.14.0`. Expect one or more review rounds —
+open a PR titled `plotjuggler_sdk/0.16.0`. Expect one or more review rounds —
 the usual notes are around option count (`with_host`, `assert_throws`), license
 packaging, and the compiler-minimum map. Acceptance is at CCI maintainer
 discretion.

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,10 +1,14 @@
 sources:
-  # NOTE: this sha256 is for the v0.14.0 tag *as it exists today*, which does
-  # NOT yet contain the PJ_WARNINGS_AS_ERRORS gate (added on the conan-center
-  # branch). Before submitting to Conan Center, cut a release tag that includes
-  # that CMake change and replace both the version (here + config.yml) and the
-  # sha256 below. Recompute with:
+  # sha256 of the GitHub-generated tag tarball. GitHub commits to the stability
+  # of these archive-by-tag tarballs, so this digest is fixed for the tag.
+  # Recompute for a new release with:
   #   curl -sL https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/vX.Y.Z.tar.gz | sha256sum
-  "0.14.0":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.14.0.tar.gz"
-    sha256: "49aecfdc5ddf46930e56a5ee4843a1435c3fb8e47b1a4ab0289fd9646dc1986d"
+  # v0.16.0 is the seed version: the first tag with the PJ_WARNINGS_AS_ERRORS
+  # gate the recipe relies on AND without the host-side PluginRuntimeCatalog
+  # (removed in #144) — so CCI never publishes API a later 0.x removes. Older
+  # tags are intentionally not listed here.
+  "0.16.0":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.0.tar.gz"
+    # PLACEHOLDER — v0.16.0 is not tagged yet. After tagging, recompute with the
+    # curl command above and replace before copying this tree into the CCI fork.
+    sha256: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conanfile.py
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conanfile.py
@@ -179,7 +179,6 @@ class PlotjugglerSdkConan(ConanFile):
             host = self.cpp_info.components["plugin_host"]
             host.set_property("cmake_target_name", "plotjuggler_sdk::plugin_host")
             host.libs = [
-                "pj_plugin_runtime_catalog",
                 "pj_data_source_host",
                 "pj_message_parser_host",
                 "pj_toolbox_host",

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.14.0":
+  "0.16.0":
     folder: all

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.15.0"
+  version: "0.16.0"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## Summary

Repurposes this PR (was: pin the CCI recipe to v0.15.0) into the **0.16.0 release-prep PR**. Rebased on `main` so it sits on top of #144.

**Version bump 0.15.0 → 0.16.0 (MINOR).** Covers #144, which removed the host-side `PluginRuntimeCatalog` (moved to the app, `pj_runtime`). No plugin links it and `abi/baseline.abi` is unchanged (verified: empty diff since v0.15.0), so per the plugin-impact rule this is **not** a MAJOR — but it *does* remove host-facing public API, which is exactly why the CCI seed moves to 0.16.0: whatever version CCI accepts first becomes the floor consumers pin against, and seeding 0.15.0 would publish API that 0.16.0 removes.

## Changes

- **Version sources** → 0.16.0: `conanfile.py`, `PJ_PACKAGE_VERSION` in `CMakeLists.txt`, `context.version` in `recipe.yaml`, + the conanfile docstring example (the set the `conda-release.yml` tag-verify job checks).
- **CHANGELOG.md**: adds the `[0.16.0]` entry for #144, and relabels the per-topic-pause section from `[Unreleased]` to `[0.15.0]` — it shipped in the v0.15.0 tag but the changelog was never relabeled.
- **CCI recipe re-seeded at 0.16.0**: `config.yml`, `conandata.yml`, README (rationale, `conan create` commands, CCI PR title).
- **Bug fix (leftover from #144)**: `pj_plugin_runtime_catalog` was still declared in the `plugin_host` component `libs` of **both** the root `conanfile.py` and the CCI recipe. The library no longer exists, so any `conan create`/consume of the package would break. Removed from both.

## The tag ↔ sha256 chicken-and-egg

The digest of the v0.16.0 tag tarball cannot exist before the tag is cut (and the tarball *contains* `conandata.yml`, so the true digest can never be embedded in the tag itself). Resolution: `conandata.yml` ships an explicit all-zeros **placeholder** sha256 with a loud comment, and the README gains an "After tagging v0.16.0" section with the one-liner to recompute it. The in-repo tree is only staging — the authoritative copy is the one pasted into the conan-center-index fork *after* the tag exists.

## Release flow after merge

1. Merge this PR.
2. Tag `v0.16.0` on the merge commit and push the tag (release workflow verifies tag == all three version sources).
3. `curl -sL .../v0.16.0.tar.gz | sha256sum` → replace the placeholder in `conandata.yml` (one-line follow-up commit on main).
4. Copy `packaging/conan-center-index/recipes/plotjuggler_sdk/` into the CCI fork and open `plotjuggler_sdk/0.16.0`.

## Testing

- `./build.sh --debug` (Debug+ASAN) — passes.
- `./test.sh` — 49/49 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
