### PR TITLE
fix(sdk): FP std::to_chars fallback for Apple targets < 13.3 + release 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
+## [0.16.1]
+
+### Fix: double formatting in `plugin_data_api.hpp` on older Apple deployment targets (PATCH)
+
+`SettingsStoreView::setValue(key, double)` — an inline method in an installed
+public header — used the floating-point `std::to_chars` overload, which libc++
+marks *unavailable* below a macOS 13.3 deployment target. Any macOS build with
+an older target (Conan Center's build farm, or a consumer setting
+`CMAKE_OSX_DEPLOYMENT_TARGET`) failed to compile. On such targets the method
+now falls back to `snprintf("%.17g")`, which round-trips any IEEE double; all
+other platforms keep the shortest-round-trip `std::to_chars` path. Behavioral
+difference on the fallback path only: non-minimal digit strings (e.g. `0.1` →
+`0.10000000000000001`) — values are preserved exactly.
+
+Also seeds the Conan Center recipe at `0.16.1` (its `tool_requires
+cmake/[>=3.22]` fix from `618b92e` plus this header fix are both required for
+CCI's macOS builders).
+
 ## [0.16.0]
 
 ### SDK slimming: duplicate-resolution catalog moved to the host (HOST-FACING REMOVAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.16.0")
+  set(PJ_PACKAGE_VERSION "0.16.1")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.16.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.16.1` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -44,7 +44,10 @@ class PlotjugglerSdkConan(ConanFile):
     # policy moved to the app, pj_runtime). No plugin links it and
     # abi/baseline.abi is unchanged, so per the plugin-impact rule this is a
     # MINOR, not a MAJOR. See CHANGELOG.md.
-    version = "0.16.0"
+    # 0.16.1 fixes plugin_data_api.hpp double formatting on Apple deployment
+    # targets older than macOS 13.3 (FP std::to_chars unavailable there) —
+    # PATCH, installed-header bug fix. See CHANGELOG.md.
+    version = "0.16.1"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/packaging/conan-center-index/README.md
+++ b/packaging/conan-center-index/README.md
@@ -22,7 +22,7 @@ tree for local dev/consume. The CCI recipe instead downloads the released
 
 ## Prerequisites before submitting
 
-The recipe is seeded with **`0.16.0`** — the first tag that satisfies these:
+The recipe is seeded with **`0.16.1`** — the first tag that satisfies these:
 
 1. **The `-Werror` gate ships in the consumed tag.** The recipe sets
    `-DPJ_WARNINGS_AS_ERRORS=OFF` so a not-yet-pinned compiler on CCI's build
@@ -32,10 +32,21 @@ The recipe is seeded with **`0.16.0`** — the first tag that satisfies these:
    host-side duplicate-resolution catalog (moved to the app). Whatever CCI
    accepts first becomes the floor consumers pin against — seeding with
    `0.15.0` would publish API that `0.16.0` removes, breaking the repo's
-   "no breaking changes within 0.x" promise for CCI consumers. `0.16.0` is the
-   first tag with the final thin-SDK surface.
-3. **Confirm dependencies exist in CCI** (verified 2026-07-01, all present):
+   "no breaking changes within 0.x" promise for CCI consumers.
+3. **The tag builds on CCI's macOS deployment target.** CCI's macOS builders
+   target below 13.3, where libc++ marks the floating-point `std::to_chars`
+   overloads unavailable — `v0.16.0` failed there (`plugin_data_api.hpp`).
+   `0.16.1` adds the `snprintf` fallback.
+4. **Confirm dependencies exist in CCI** (verified 2026-07-01, all present):
    `nlohmann_json/3.12.0`, `fmt/12.1.0`, `fast_float/8.1.0`.
+
+## After tagging a new release
+
+The digest of a tag tarball cannot be known before the tag is cut, so a
+release-prep PR carries an all-zeros placeholder `sha256` in `conandata.yml`.
+Once the `vX.Y.Z` tag is pushed, recompute with the `curl … | sha256sum`
+one-liner in `conandata.yml` and replace the placeholder before copying this
+tree into the conan-center-index fork.
 
 ## Test locally before opening the PR
 
@@ -46,10 +57,10 @@ cd recipes/plotjuggler_sdk
 # Build + run the test_package. The recipe validate()s C++20, so a profile
 # whose compiler.cppstd is < 20 (e.g. the common gnu17 default) is correctly
 # rejected — pass an explicit C++20 std:
-conan create all --version=0.16.0 -s compiler.cppstd=20 --build=missing
+conan create all --version=0.16.1 -s compiler.cppstd=20 --build=missing
 # Exercise the option matrix CCI will build:
-conan create all --version=0.16.0 -s compiler.cppstd=20 -o "&:with_host=False" --build=missing
-conan create all --version=0.16.0 -s compiler.cppstd=20 -o "&:assert_throws=True" --build=missing
+conan create all --version=0.16.1 -s compiler.cppstd=20 -o "&:with_host=False" --build=missing
+conan create all --version=0.16.1 -s compiler.cppstd=20 -o "&:assert_throws=True" --build=missing
 ```
 
 Then run the Conan Center hooks locally (catches KB-Hxxx violations the reviewer
@@ -58,13 +69,13 @@ bot will flag):
 ```bash
 conan config install https://github.com/conan-io/conan-center-index.git \
   -sf .c3i/hooks -tf .conan2/extensions/hooks   # one-time
-conan create all --version=0.16.0 -s compiler.cppstd=20 --build=missing   # hooks run inline
+conan create all --version=0.16.1 -s compiler.cppstd=20 --build=missing   # hooks run inline
 ```
 
 ## Open the PR
 
 Fork `conan-io/conan-center-index`, drop this tree under `recipes/`, commit, and
-open a PR titled `plotjuggler_sdk/0.16.0`. Expect one or more review rounds —
+open a PR titled `plotjuggler_sdk/0.16.1`. Expect one or more review rounds —
 the usual notes are around option count (`with_host`, `assert_throws`), license
 packaging, and the compiler-minimum map. Acceptance is at CCI maintainer
 discretion.

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
@@ -3,10 +3,13 @@ sources:
   # of these archive-by-tag tarballs, so this digest is fixed for the tag.
   # Recompute for a new release with:
   #   curl -sL https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/vX.Y.Z.tar.gz | sha256sum
-  # v0.16.0 is the seed version: the first tag with the PJ_WARNINGS_AS_ERRORS
-  # gate the recipe relies on AND without the host-side PluginRuntimeCatalog
-  # (removed in #144) — so CCI never publishes API a later 0.x removes. Older
-  # tags are intentionally not listed here.
-  "0.16.0":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.0.tar.gz"
-    sha256: "9f1cd9c619c7137068c91160514879de9d5c35b53b54b645a30ab447419c5b52"
+  # v0.16.1 is the seed version: the first tag that builds on CCI's macOS
+  # deployment target (FP std::to_chars fallback), carries the
+  # PJ_WARNINGS_AS_ERRORS gate, and has the thin post-#144 SDK surface — so CCI
+  # never publishes API a later 0.x removes. Older tags are intentionally not
+  # listed here.
+  "0.16.1":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.1.tar.gz"
+    # PLACEHOLDER — v0.16.1 is not tagged yet. After tagging, recompute with the
+    # curl command above and replace before copying this tree into the CCI fork.
+    sha256: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.16.0":
+  "0.16.1":
     folder: all

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <array>
+#include <charconv>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <functional>
 #include <initializer_list>
@@ -1634,11 +1636,22 @@ class SettingsView {
 
   [[nodiscard]] Status setValue(std::string_view key, double value) const {
     char buf[40];
+#if defined(__APPLE__) && defined(__ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__) && \
+    __ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__ < 130300
+    // libc++ marks the floating-point std::to_chars overloads unavailable below
+    // a macOS 13.3 deployment target; %.17g round-trips any IEEE double.
+    const int n = std::snprintf(buf, sizeof(buf), "%.17g", value);
+    if (n <= 0 || static_cast<std::size_t>(n) >= sizeof(buf)) {
+      return unexpected("settings: failed to format double value");
+    }
+    return setValue(key, std::string_view(buf, static_cast<std::size_t>(n)));
+#else
     auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value);
     if (ec != std::errc{}) {
       return unexpected("settings: failed to format double value");
     }
     return setValue(key, std::string_view(buf, static_cast<std::size_t>(ptr - buf)));
+#endif
   }
 
   [[nodiscard]] Status setValue(std::string_view key, bool value) const {

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.16.0"
+  version: "0.16.1"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## Summary

CCI PR [conan-io/conan-center-index#30605](https://github.com/conan-io/conan-center-index/pull/30605) round 2 failed on macOS with a real SDK bug: `SettingsStoreView::setValue(key, double)` — an **inline method in the installed** `plugin_data_api.hpp` — uses the floating-point `std::to_chars` overload, which libc++ marks *unavailable* below a macOS 13.3 deployment target. CCI's macOS builders target lower, and any consumer setting an older `CMAKE_OSX_DEPLOYMENT_TARGET` hits the same compile error. (The SDK's own macOS CI passes only because GitHub runners default to the host's new-enough target.)

## Fix

On Apple targets below 13.3 (`__ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__ < 130300`), fall back to `snprintf("%.17g")` — round-trips any IEEE double (verified standalone for max double, min subnormal, zero; longest output is 24 chars in the 40-byte buffer). All other platforms keep the shortest-round-trip `std::to_chars` path. Only observable difference on the fallback path: non-minimal digits (`0.1` → `0.10000000000000001`), values preserved exactly. The header is also made self-contained (`<charconv>`/`<cstdio>` were only transitive).

## Release 0.16.1 (PATCH)

Installed-header bug fix → PATCH per the versioning policy. Bumps the three version sources + docstring, adds the `[0.16.1]` CHANGELOG entry, and re-seeds the CCI staging recipe at `0.16.1` (placeholder sha256 until the tag exists; the README post-tag note is now release-agnostic instead of naming a version). `abi/baseline.abi` untouched (header-only inline change, no plugin impact).

## Testing

- `./build.sh --debug` + `./test.sh` — 49/49 pass.
- Fallback branch compiled standalone with `-Wall -Wextra -Werror` and round-trip-tested.

## After merge

Tag `v0.16.1` → fill the real sha256 into `conandata.yml` → update CCI PR #30605 to `plotjuggler_sdk/0.16.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
