### PR TITLE
fix(sdk): correct the Apple to_chars guard macro spelling + release 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
+## [0.16.2]
+
+### Fix: 0.16.1's Apple `to_chars` guard tested a misspelled macro and never engaged (PATCH)
+
+The 0.16.1 fallback guard checked `__ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__`,
+which does not exist — the compiler defines
+`__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__` (verified against clang's
+`OSTargets.cpp`) — so `defined(...)` was always false and every Apple build
+still compiled the floating-point `std::to_chars` path. The guard now uses the
+correct macro and is fail-safe: any Apple target not provably macOS ≥ 13.3
+(including non-macOS Apple platforms, which spell the macro differently) takes
+the `snprintf` fallback. Guard behavior verified by preprocessing the header's
+exact `#if` line under deployment targets 13.0 / 13.3 / 26.0 / undefined /
+non-Apple.
+
 ## [0.16.1]
 
 ### Fix: double formatting in `plugin_data_api.hpp` on older Apple deployment targets (PATCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.16.1")
+  set(PJ_PACKAGE_VERSION "0.16.2")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.16.1` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.16.2` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -47,7 +47,10 @@ class PlotjugglerSdkConan(ConanFile):
     # 0.16.1 fixes plugin_data_api.hpp double formatting on Apple deployment
     # targets older than macOS 13.3 (FP std::to_chars unavailable there) —
     # PATCH, installed-header bug fix. See CHANGELOG.md.
-    version = "0.16.1"
+    # 0.16.2 fixes 0.16.1's guard, which tested a misspelled macro
+    # (__ENVIRONMENT_MACOS_... instead of __ENVIRONMENT_MAC_OS_X_...) and
+    # never engaged — PATCH. See CHANGELOG.md.
+    version = "0.16.2"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/packaging/conan-center-index/README.md
+++ b/packaging/conan-center-index/README.md
@@ -22,7 +22,7 @@ tree for local dev/consume. The CCI recipe instead downloads the released
 
 ## Prerequisites before submitting
 
-The recipe is seeded with **`0.16.1`** — the first tag that satisfies these:
+The recipe is seeded with **`0.16.2`** — the first tag that satisfies these:
 
 1. **The `-Werror` gate ships in the consumed tag.** The recipe sets
    `-DPJ_WARNINGS_AS_ERRORS=OFF` so a not-yet-pinned compiler on CCI's build
@@ -35,8 +35,9 @@ The recipe is seeded with **`0.16.1`** — the first tag that satisfies these:
    "no breaking changes within 0.x" promise for CCI consumers.
 3. **The tag builds on CCI's macOS deployment target.** CCI's macOS builders
    target below 13.3, where libc++ marks the floating-point `std::to_chars`
-   overloads unavailable — `v0.16.0` failed there (`plugin_data_api.hpp`).
-   `0.16.1` adds the `snprintf` fallback.
+   overloads unavailable — `v0.16.0` failed there (`plugin_data_api.hpp`), and
+   `v0.16.1`'s fallback guard misspelled the availability macro and never
+   engaged. `0.16.2` carries the working `snprintf` fallback.
 4. **Confirm dependencies exist in CCI** (verified 2026-07-01, all present):
    `nlohmann_json/3.12.0`, `fmt/12.1.0`, `fast_float/8.1.0`.
 
@@ -57,10 +58,10 @@ cd recipes/plotjuggler_sdk
 # Build + run the test_package. The recipe validate()s C++20, so a profile
 # whose compiler.cppstd is < 20 (e.g. the common gnu17 default) is correctly
 # rejected — pass an explicit C++20 std:
-conan create all --version=0.16.1 -s compiler.cppstd=20 --build=missing
+conan create all --version=0.16.2 -s compiler.cppstd=20 --build=missing
 # Exercise the option matrix CCI will build:
-conan create all --version=0.16.1 -s compiler.cppstd=20 -o "&:with_host=False" --build=missing
-conan create all --version=0.16.1 -s compiler.cppstd=20 -o "&:assert_throws=True" --build=missing
+conan create all --version=0.16.2 -s compiler.cppstd=20 -o "&:with_host=False" --build=missing
+conan create all --version=0.16.2 -s compiler.cppstd=20 -o "&:assert_throws=True" --build=missing
 ```
 
 Then run the Conan Center hooks locally (catches KB-Hxxx violations the reviewer
@@ -69,13 +70,13 @@ bot will flag):
 ```bash
 conan config install https://github.com/conan-io/conan-center-index.git \
   -sf .c3i/hooks -tf .conan2/extensions/hooks   # one-time
-conan create all --version=0.16.1 -s compiler.cppstd=20 --build=missing   # hooks run inline
+conan create all --version=0.16.2 -s compiler.cppstd=20 --build=missing   # hooks run inline
 ```
 
 ## Open the PR
 
 Fork `conan-io/conan-center-index`, drop this tree under `recipes/`, commit, and
-open a PR titled `plotjuggler_sdk/0.16.1`. Expect one or more review rounds —
+open a PR titled `plotjuggler_sdk/0.16.2`. Expect one or more review rounds —
 the usual notes are around option count (`with_host`, `assert_throws`), license
 packaging, and the compiler-minimum map. Acceptance is at CCI maintainer
 discretion.

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/all/conandata.yml
@@ -3,11 +3,13 @@ sources:
   # of these archive-by-tag tarballs, so this digest is fixed for the tag.
   # Recompute for a new release with:
   #   curl -sL https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/vX.Y.Z.tar.gz | sha256sum
-  # v0.16.1 is the seed version: the first tag that builds on CCI's macOS
-  # deployment target (FP std::to_chars fallback), carries the
-  # PJ_WARNINGS_AS_ERRORS gate, and has the thin post-#144 SDK surface — so CCI
-  # never publishes API a later 0.x removes. Older tags are intentionally not
-  # listed here.
-  "0.16.1":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.1.tar.gz"
-    sha256: "e41266e9d0d827941e20f4a5dfb3cfff340170d649c4fe3351e027a9e81c42bf"
+  # v0.16.2 is the seed version: the first tag that builds on CCI's macOS
+  # deployment target (working FP std::to_chars fallback — v0.16.1's guard
+  # never engaged), carries the PJ_WARNINGS_AS_ERRORS gate, and has the thin
+  # post-#144 SDK surface — so CCI never publishes API a later 0.x removes.
+  # Older tags are intentionally not listed here.
+  "0.16.2":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.2.tar.gz"
+    # PLACEHOLDER — v0.16.2 is not tagged yet. After tagging, recompute with the
+    # curl command above and replace before copying this tree into the CCI fork.
+    sha256: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
+++ b/packaging/conan-center-index/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.16.1":
+  "0.16.2":
     folder: all

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1636,10 +1636,13 @@ class SettingsView {
 
   [[nodiscard]] Status setValue(std::string_view key, double value) const {
     char buf[40];
-#if defined(__APPLE__) && defined(__ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__) && \
-    __ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__ < 130300
+#if defined(__APPLE__) && (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || \
+                           __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300)
     // libc++ marks the floating-point std::to_chars overloads unavailable below
-    // a macOS 13.3 deployment target; %.17g round-trips any IEEE double.
+    // a macOS 13.3 deployment target; %.17g round-trips any IEEE double. The
+    // guard is fail-safe: any Apple target that is not provably macOS >= 13.3
+    // (including non-macOS Apple platforms, which spell the macro differently
+    // and have their own availability floors) takes the snprintf path.
     const int n = std::snprintf(buf, sizeof(buf), "%.17g", value);
     if (n <= 0 || static_cast<std::size_t>(n) >= sizeof(buf)) {
       return unexpected("settings: failed to format double value");

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.16.1"
+  version: "0.16.2"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## Summary

CCI round 3 failed at the **same** `to_chars` line — because 0.16.1's guard could never engage: it tested `__ENVIRONMENT_MACOS_VERSION_MIN_REQUIRED__`, **a macro that does not exist**. The compiler defines `__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__` (historic `MAC_OS_X` spelling — verified against clang's `OSTargets.cpp`, line 123). `defined(...)` of a misspelled macro is silently false on every platform, so all Apple builds still compiled the floating-point `std::to_chars` path.

## Fix

- Correct macro spelling.
- Guard made **fail-safe**: any Apple target that is not provably macOS ≥ 13.3 — including non-macOS Apple platforms, which spell the macro differently — takes the `snprintf` fallback. Worst case is a slightly slower, non-minimal-digits (but exact) formatting where `to_chars` was actually available.

## Verification (no Mac required)

The 0.16.1 bug slipped through because I tested a re-typed copy of the branch body, not the header's actual `#if`. This time the header's exact guard lines are extracted verbatim and run through the preprocessor across the matrix:

| Scenario | Branch taken |
|---|---|
| `__APPLE__`, target 13.0 (= CCI's `MACOSX_DEPLOYMENT_TARGET`) | snprintf fallback ✅ |
| `__APPLE__`, target 13.3 | `std::to_chars` |
| `__APPLE__`, target 26.0 | `std::to_chars` |
| `__APPLE__`, macro undefined (e.g. iOS) | snprintf fallback |
| non-Apple | `std::to_chars` |

Plus `./build.sh --debug` + `./test.sh` — 49/49 pass.

## Release 0.16.2 (PATCH)

Same drill: three version sources + docstring, `[0.16.2]` CHANGELOG entry, CCI staging recipe re-seeded at 0.16.2 with placeholder sha256.

## After merge

Tag `v0.16.2` → fill real sha256 → update CCI PR #30605 to `plotjuggler_sdk/0.16.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
