### PR TITLE
feat(plugins): loadStatic accepts a companion dialog vtable for static builds

### DIFF
--- a/pj_plugins/CMakeLists.txt
+++ b/pj_plugins/CMakeLists.txt
@@ -252,6 +252,7 @@ target_link_libraries(legacy_macro_dialog_plugin PRIVATE pj_dialog_protocol)
 # ---------------------------------------------------------------------------
 
 add_executable(data_source_library_test tests/data_source_library_test.cpp)
+add_dependencies(data_source_library_test mock_data_source_plugin missing_required_slots_plugin)
 target_compile_definitions(data_source_library_test PRIVATE
   PJ_MOCK_DATA_SOURCE_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_plugin>"
   PJ_MISSING_REQUIRED_SLOTS_PLUGIN_PATH="$<TARGET_FILE:missing_required_slots_plugin>"
@@ -264,6 +265,7 @@ add_test(NAME data_source_library_test COMMAND data_source_library_test)
 
 # Integration test: DataSource + Dialog
 add_executable(source_dialog_integration_test tests/source_dialog_integration_test.cpp)
+add_dependencies(source_dialog_integration_test mock_source_with_dialog_plugin mock_data_source_plugin)
 target_compile_definitions(source_dialog_integration_test PRIVATE
   PJ_MOCK_SOURCE_WITH_DIALOG_PLUGIN_PATH="$<TARGET_FILE:mock_source_with_dialog_plugin>"
   PJ_MOCK_DATA_SOURCE_PLUGIN_PATH="$<TARGET_FILE:mock_data_source_plugin>"

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -309,12 +309,13 @@ PJ_borrowed_dialog_t borrowDialog(DialogT& dialog) noexcept {
 // `extern "C" PJ_get_dialog_vtable` symbol (and the ABI-version export) would
 // collide at link. The static registry never resolves a dialog via dlsym (the
 // host short-circuits the dialog path on WASM), so emit only a uniquely
-// class-keyed getter — kept so dialogVtableFor<ClassName>() still resolves for
-// any in-binary caller.
+// class-keyed getter. The host's static composition point passes this getter's
+// result alongside the owning source/parser/toolbox vtable, and
+// dialogVtableFor<ClassName>() also uses it inside the plugin.
 #ifdef PJ_STATIC_PLUGINS
 #undef PJ_DIALOG_PLUGIN_WITH_MANIFEST
 #define PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, ManifestJson)                             \
-  inline const PJ_dialog_vtable_t* pj_static_get_dialog_vtable_##ClassName() noexcept {     \
+  const PJ_dialog_vtable_t* pj_static_get_dialog_vtable_##ClassName() noexcept {            \
     static const PJ_dialog_vtable_t* vt = PJ::DialogPluginBase::vtableWithCreate(           \
         []() noexcept -> void* {                                                            \
           try {                                                                             \

--- a/pj_plugins/include/pj_plugins/host/data_source_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/data_source_library.hpp
@@ -53,7 +53,8 @@ class DataSourceLibrary {
 
   /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
   /// @p vtable must have static storage duration (valid for the program lifetime).
-  [[nodiscard]] static Expected<DataSourceLibrary> loadStatic(const PJ_data_source_vtable_t* vtable);
+  [[nodiscard]] static Expected<DataSourceLibrary> loadStatic(
+      const PJ_data_source_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable = nullptr);
 
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
@@ -79,12 +80,15 @@ class DataSourceLibrary {
   }
 
  private:
-  DataSourceLibrary(std::shared_ptr<void> handle, const PJ_data_source_vtable_t* vtable, std::string path);
+  DataSourceLibrary(
+      std::shared_ptr<void> handle, const PJ_data_source_vtable_t* vtable, std::string path,
+      const PJ_dialog_vtable_t* static_dialog_vtable = nullptr);
 
   void reset();
 
   std::shared_ptr<void> handle_;
   const PJ_data_source_vtable_t* vtable_ = nullptr;
+  const PJ_dialog_vtable_t* static_dialog_vtable_ = nullptr;
   std::string path_;
 };
 

--- a/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/message_parser_library.hpp
@@ -53,7 +53,8 @@ class MessageParserLibrary {
 
   /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
   /// @p vtable must have static storage duration (valid for the program lifetime).
-  [[nodiscard]] static Expected<MessageParserLibrary> loadStatic(const PJ_message_parser_vtable_t* vtable);
+  [[nodiscard]] static Expected<MessageParserLibrary> loadStatic(
+      const PJ_message_parser_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable = nullptr);
 
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
@@ -79,12 +80,15 @@ class MessageParserLibrary {
   }
 
  private:
-  MessageParserLibrary(std::shared_ptr<void> handle, const PJ_message_parser_vtable_t* vtable, std::string path);
+  MessageParserLibrary(
+      std::shared_ptr<void> handle, const PJ_message_parser_vtable_t* vtable, std::string path,
+      const PJ_dialog_vtable_t* static_dialog_vtable = nullptr);
 
   void reset();
 
   std::shared_ptr<void> handle_;
   const PJ_message_parser_vtable_t* vtable_ = nullptr;
+  const PJ_dialog_vtable_t* static_dialog_vtable_ = nullptr;
   std::string path_;
 };
 

--- a/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
+++ b/pj_plugins/include/pj_plugins/host/toolbox_library.hpp
@@ -53,7 +53,8 @@ class ToolboxLibrary {
 
   /// Wrap a statically-linked plugin vtable (no dlopen; for WASM/static builds).
   /// @p vtable must have static storage duration (valid for the program lifetime).
-  [[nodiscard]] static Expected<ToolboxLibrary> loadStatic(const PJ_toolbox_vtable_t* vtable);
+  [[nodiscard]] static Expected<ToolboxLibrary> loadStatic(
+      const PJ_toolbox_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable = nullptr);
 
   /// True if the library was loaded and the vtable resolved successfully.
   [[nodiscard]] bool valid() const {
@@ -79,12 +80,15 @@ class ToolboxLibrary {
   }
 
  private:
-  ToolboxLibrary(std::shared_ptr<void> handle, const PJ_toolbox_vtable_t* vtable, std::string path);
+  ToolboxLibrary(
+      std::shared_ptr<void> handle, const PJ_toolbox_vtable_t* vtable, std::string path,
+      const PJ_dialog_vtable_t* static_dialog_vtable = nullptr);
 
   void reset();
 
   std::shared_ptr<void> handle_;
   const PJ_toolbox_vtable_t* vtable_ = nullptr;
+  const PJ_dialog_vtable_t* static_dialog_vtable_ = nullptr;
   std::string path_;
 };
 

--- a/pj_plugins/src/data_source_library.cpp
+++ b/pj_plugins/src/data_source_library.cpp
@@ -11,16 +11,24 @@
 namespace PJ {
 
 DataSourceLibrary::DataSourceLibrary(
-    std::shared_ptr<void> handle, const PJ_data_source_vtable_t* vtable, std::string path)
-    : handle_(std::move(handle)), vtable_(vtable), path_(std::move(path)) {}
+    std::shared_ptr<void> handle, const PJ_data_source_vtable_t* vtable, std::string path,
+    const PJ_dialog_vtable_t* static_dialog_vtable)
+    : handle_(std::move(handle)),
+      vtable_(vtable),
+      static_dialog_vtable_(static_dialog_vtable),
+      path_(std::move(path)) {}
 
 DataSourceLibrary::~DataSourceLibrary() {
   reset();
 }
 
 DataSourceLibrary::DataSourceLibrary(DataSourceLibrary&& other) noexcept
-    : handle_(std::move(other.handle_)), vtable_(other.vtable_), path_(std::move(other.path_)) {
+    : handle_(std::move(other.handle_)),
+      vtable_(other.vtable_),
+      static_dialog_vtable_(other.static_dialog_vtable_),
+      path_(std::move(other.path_)) {
   other.vtable_ = nullptr;
+  other.static_dialog_vtable_ = nullptr;
 }
 
 DataSourceLibrary& DataSourceLibrary::operator=(DataSourceLibrary&& other) noexcept {
@@ -28,8 +36,10 @@ DataSourceLibrary& DataSourceLibrary::operator=(DataSourceLibrary&& other) noexc
     reset();
     handle_ = std::move(other.handle_);
     vtable_ = other.vtable_;
+    static_dialog_vtable_ = other.static_dialog_vtable_;
     path_ = std::move(other.path_);
     other.vtable_ = nullptr;
+    other.static_dialog_vtable_ = nullptr;
   }
   return *this;
 }
@@ -70,7 +80,8 @@ Expected<DataSourceLibrary> DataSourceLibrary::load(std::string_view path) {
   return DataSourceLibrary(std::move(handle), vtable, std::string(path));
 }
 
-Expected<DataSourceLibrary> DataSourceLibrary::loadStatic(const PJ_data_source_vtable_t* vtable) {
+Expected<DataSourceLibrary> DataSourceLibrary::loadStatic(
+    const PJ_data_source_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable) {
   if (vtable == nullptr) {
     return unexpected("static DataSource vtable is null");
   }
@@ -83,14 +94,31 @@ Expected<DataSourceLibrary> DataSourceLibrary::loadStatic(const PJ_data_source_v
   if (auto status = detail::validateRequiredSlots(vtable); !status) {
     return unexpected(status.error());
   }
+  if (dialog_vtable != nullptr) {
+    if (dialog_vtable->protocol_version != PJ_DIALOG_PROTOCOL_VERSION) {
+      return unexpected("Dialog protocol version mismatch");
+    }
+    if (dialog_vtable->struct_size < PJ_DIALOG_MIN_VTABLE_SIZE) {
+      return unexpected("Dialog vtable smaller than v4.0 baseline");
+    }
+    if (auto status = detail::validateRequiredSlots(dialog_vtable); !status) {
+      return unexpected(status.error());
+    }
+  }
   // Statically linked: no DSO to keep alive, but valid()/createHandle() expect a
   // non-null owner. Use a sentinel shared_ptr with a no-op deleter.
   static char anchor = 0;
   std::shared_ptr<void> handle(&anchor, [](void*) {});
-  return DataSourceLibrary(std::move(handle), vtable, "static://");
+  return DataSourceLibrary(std::move(handle), vtable, "static://", dialog_vtable);
 }
 
 Expected<const PJ_dialog_vtable_t*> DataSourceLibrary::resolveDialogVtable() const {
+  if (static_dialog_vtable_ != nullptr) {
+    return static_dialog_vtable_;
+  }
+  if (path_ == "static://") {
+    return unexpected("static DataSource has no registered dialog vtable");
+  }
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {
     return unexpected(sym.error());
@@ -116,6 +144,7 @@ void DataSourceLibrary::reset() {
   if (handle_ != nullptr) {
     handle_.reset();
     vtable_ = nullptr;
+    static_dialog_vtable_ = nullptr;
     path_.clear();
   }
 }

--- a/pj_plugins/src/message_parser_library.cpp
+++ b/pj_plugins/src/message_parser_library.cpp
@@ -11,16 +11,24 @@
 namespace PJ {
 
 MessageParserLibrary::MessageParserLibrary(
-    std::shared_ptr<void> handle, const PJ_message_parser_vtable_t* vtable, std::string path)
-    : handle_(std::move(handle)), vtable_(vtable), path_(std::move(path)) {}
+    std::shared_ptr<void> handle, const PJ_message_parser_vtable_t* vtable, std::string path,
+    const PJ_dialog_vtable_t* static_dialog_vtable)
+    : handle_(std::move(handle)),
+      vtable_(vtable),
+      static_dialog_vtable_(static_dialog_vtable),
+      path_(std::move(path)) {}
 
 MessageParserLibrary::~MessageParserLibrary() {
   reset();
 }
 
 MessageParserLibrary::MessageParserLibrary(MessageParserLibrary&& other) noexcept
-    : handle_(std::move(other.handle_)), vtable_(other.vtable_), path_(std::move(other.path_)) {
+    : handle_(std::move(other.handle_)),
+      vtable_(other.vtable_),
+      static_dialog_vtable_(other.static_dialog_vtable_),
+      path_(std::move(other.path_)) {
   other.vtable_ = nullptr;
+  other.static_dialog_vtable_ = nullptr;
 }
 
 MessageParserLibrary& MessageParserLibrary::operator=(MessageParserLibrary&& other) noexcept {
@@ -28,8 +36,10 @@ MessageParserLibrary& MessageParserLibrary::operator=(MessageParserLibrary&& oth
     reset();
     handle_ = std::move(other.handle_);
     vtable_ = other.vtable_;
+    static_dialog_vtable_ = other.static_dialog_vtable_;
     path_ = std::move(other.path_);
     other.vtable_ = nullptr;
+    other.static_dialog_vtable_ = nullptr;
   }
   return *this;
 }
@@ -68,7 +78,8 @@ Expected<MessageParserLibrary> MessageParserLibrary::load(std::string_view path)
   return MessageParserLibrary(std::move(handle), vtable, std::string(path));
 }
 
-Expected<MessageParserLibrary> MessageParserLibrary::loadStatic(const PJ_message_parser_vtable_t* vtable) {
+Expected<MessageParserLibrary> MessageParserLibrary::loadStatic(
+    const PJ_message_parser_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable) {
   if (vtable == nullptr) {
     return unexpected("static MessageParser vtable is null");
   }
@@ -81,12 +92,29 @@ Expected<MessageParserLibrary> MessageParserLibrary::loadStatic(const PJ_message
   if (auto status = detail::validateRequiredSlots(vtable); !status) {
     return unexpected(status.error());
   }
+  if (dialog_vtable != nullptr) {
+    if (dialog_vtable->protocol_version != PJ_DIALOG_PROTOCOL_VERSION) {
+      return unexpected("Dialog protocol version mismatch");
+    }
+    if (dialog_vtable->struct_size < PJ_DIALOG_MIN_VTABLE_SIZE) {
+      return unexpected("Dialog vtable smaller than v4.0 baseline");
+    }
+    if (auto status = detail::validateRequiredSlots(dialog_vtable); !status) {
+      return unexpected(status.error());
+    }
+  }
   static char anchor = 0;
   std::shared_ptr<void> handle(&anchor, [](void*) {});
-  return MessageParserLibrary(std::move(handle), vtable, "static://");
+  return MessageParserLibrary(std::move(handle), vtable, "static://", dialog_vtable);
 }
 
 Expected<const PJ_dialog_vtable_t*> MessageParserLibrary::resolveDialogVtable() const {
+  if (static_dialog_vtable_ != nullptr) {
+    return static_dialog_vtable_;
+  }
+  if (path_ == "static://") {
+    return unexpected("static MessageParser has no registered dialog vtable");
+  }
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {
     return unexpected(sym.error());
@@ -112,6 +140,7 @@ void MessageParserLibrary::reset() {
   if (handle_ != nullptr) {
     handle_.reset();
     vtable_ = nullptr;
+    static_dialog_vtable_ = nullptr;
     path_.clear();
   }
 }

--- a/pj_plugins/src/toolbox_library.cpp
+++ b/pj_plugins/src/toolbox_library.cpp
@@ -10,16 +10,25 @@
 
 namespace PJ {
 
-ToolboxLibrary::ToolboxLibrary(std::shared_ptr<void> handle, const PJ_toolbox_vtable_t* vtable, std::string path)
-    : handle_(std::move(handle)), vtable_(vtable), path_(std::move(path)) {}
+ToolboxLibrary::ToolboxLibrary(
+    std::shared_ptr<void> handle, const PJ_toolbox_vtable_t* vtable, std::string path,
+    const PJ_dialog_vtable_t* static_dialog_vtable)
+    : handle_(std::move(handle)),
+      vtable_(vtable),
+      static_dialog_vtable_(static_dialog_vtable),
+      path_(std::move(path)) {}
 
 ToolboxLibrary::~ToolboxLibrary() {
   reset();
 }
 
 ToolboxLibrary::ToolboxLibrary(ToolboxLibrary&& other) noexcept
-    : handle_(std::move(other.handle_)), vtable_(other.vtable_), path_(std::move(other.path_)) {
+    : handle_(std::move(other.handle_)),
+      vtable_(other.vtable_),
+      static_dialog_vtable_(other.static_dialog_vtable_),
+      path_(std::move(other.path_)) {
   other.vtable_ = nullptr;
+  other.static_dialog_vtable_ = nullptr;
 }
 
 ToolboxLibrary& ToolboxLibrary::operator=(ToolboxLibrary&& other) noexcept {
@@ -27,8 +36,10 @@ ToolboxLibrary& ToolboxLibrary::operator=(ToolboxLibrary&& other) noexcept {
     reset();
     handle_ = std::move(other.handle_);
     vtable_ = other.vtable_;
+    static_dialog_vtable_ = other.static_dialog_vtable_;
     path_ = std::move(other.path_);
     other.vtable_ = nullptr;
+    other.static_dialog_vtable_ = nullptr;
   }
   return *this;
 }
@@ -67,7 +78,8 @@ Expected<ToolboxLibrary> ToolboxLibrary::load(std::string_view path) {
   return ToolboxLibrary(std::move(handle), vtable, std::string(path));
 }
 
-Expected<ToolboxLibrary> ToolboxLibrary::loadStatic(const PJ_toolbox_vtable_t* vtable) {
+Expected<ToolboxLibrary> ToolboxLibrary::loadStatic(
+    const PJ_toolbox_vtable_t* vtable, const PJ_dialog_vtable_t* dialog_vtable) {
   if (vtable == nullptr) {
     return unexpected("static Toolbox vtable is null");
   }
@@ -80,12 +92,29 @@ Expected<ToolboxLibrary> ToolboxLibrary::loadStatic(const PJ_toolbox_vtable_t* v
   if (auto status = detail::validateRequiredSlots(vtable); !status) {
     return unexpected(status.error());
   }
+  if (dialog_vtable != nullptr) {
+    if (dialog_vtable->protocol_version != PJ_DIALOG_PROTOCOL_VERSION) {
+      return unexpected("Dialog protocol version mismatch");
+    }
+    if (dialog_vtable->struct_size < PJ_DIALOG_MIN_VTABLE_SIZE) {
+      return unexpected("Dialog vtable smaller than v4.0 baseline");
+    }
+    if (auto status = detail::validateRequiredSlots(dialog_vtable); !status) {
+      return unexpected(status.error());
+    }
+  }
   static char anchor = 0;
   std::shared_ptr<void> handle(&anchor, [](void*) {});
-  return ToolboxLibrary(std::move(handle), vtable, "static://");
+  return ToolboxLibrary(std::move(handle), vtable, "static://", dialog_vtable);
 }
 
 Expected<const PJ_dialog_vtable_t*> ToolboxLibrary::resolveDialogVtable() const {
+  if (static_dialog_vtable_ != nullptr) {
+    return static_dialog_vtable_;
+  }
+  if (path_ == "static://") {
+    return unexpected("static Toolbox has no registered dialog vtable");
+  }
   auto sym = detail::resolveSymbol(handle_.get(), "PJ_get_dialog_vtable");
   if (!sym) {
     return unexpected(sym.error());
@@ -111,6 +140,7 @@ void ToolboxLibrary::reset() {
   if (handle_ != nullptr) {
     handle_.reset();
     vtable_ = nullptr;
+    static_dialog_vtable_ = nullptr;
     path_.clear();
   }
 }


### PR DESCRIPTION
## Motivation

Statically-composed applications (the PJ4 WebAssembly build links official plugins as static archives) cannot `dlsym` a plugin's companion dialog getter from a DSO the way the dynamic loader does. This PR lets the application pass the class-keyed dialog vtable directly at registration time.

## What changed

- `DataSourceLibrary::loadStatic`, `MessageParserLibrary::loadStatic`, and `ToolboxLibrary::loadStatic` accept an optional `const PJ_dialog_vtable_t* dialog_vtable` (default `nullptr`, fully backward compatible).
- When a dialog vtable is supplied, it is validated exactly like the dynamic path (protocol version, struct size, required slots) before the library is constructed; `resolveDialogVtable()` then serves it to the host.
- `dialog_plugin_base.hpp` exports the unique class-keyed getter used by static compositions.

## Consumer

PJ4 `feat/wasm-reboot`: `PluginRuntimeCatalog::registerStaticPlugins(StaticPluginSet)` passes these vtables through; the host side adds a registration-time fail-fast when a plugin advertises `HAS_DIALOG` without a dialog vtable (host-side tests in PJ4's `plugin_runtime_catalog_test`).

## Release note

Per the versioning policy this is a backward-compatible API addition → **MINOR bump warranted (0.17.0)** when convenient (three synced sources: `conanfile.py`, `PJ_PACKAGE_VERSION`, `recipe.yaml`). Not bumped in this PR; happy to add it here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)