### PR TITLE
feat(sdk): 0.17.0 — extended dialog protocol (widget_data/event, typed plugin API, host views)

### DIFF
--- a/.github/conda_variants_osx.yaml
+++ b/.github/conda_variants_osx.yaml
@@ -1,5 +1,5 @@
 # osx-64 deployment target. Xcode 16's libc++ hard-errors ("platform no longer
 # supported by libc++", fatal under -Werror) on targets below 10.13; the conda
-# default is 10.9. 10.15 matches the C++20 features the SDK uses.
+# default is 10.9. 13.0 clears the floor of the 2026 conda-forge libc++ (LLVM keeps raising the minimum; 10.15 still tripped it) and covers every Intel Mac that runs Ventura.
 MACOSX_DEPLOYMENT_TARGET:
-  - "10.15"
+  - "13.0"

--- a/.github/conda_variants_osx.yaml
+++ b/.github/conda_variants_osx.yaml
@@ -1,0 +1,5 @@
+# osx-64 deployment target. Xcode 16's libc++ hard-errors ("platform no longer
+# supported by libc++", fatal under -Werror) on targets below 10.13; the conda
+# default is 10.9. 10.15 matches the C++20 features the SDK uses.
+MACOSX_DEPLOYMENT_TARGET:
+  - "10.15"

--- a/.github/workflows/conda-release.yml
+++ b/.github/workflows/conda-release.yml
@@ -27,8 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # linux-64, osx-64 (macos-13 is Intel), win-64.
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        # linux-64, osx-64 (macos-15-intel is the Intel runner — macos-13 was
+        # retired by GitHub and jobs targeting it queue forever), win-64.
+        os: [ubuntu-22.04, macos-15-intel, windows-2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/conda-release.yml
+++ b/.github/workflows/conda-release.yml
@@ -67,10 +67,18 @@ jobs:
       # identically under Git Bash on the Windows runner.
       - name: Build conda package
         shell: bash
+        env:
+          # Belt-and-braces with the variant config below (see that file's comment).
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
         run: |
+          extra=()
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            extra+=(--variant-config .github/conda_variants_osx.yaml)
+          fi
           rattler-build build \
             --recipe recipe.yaml \
             --channel conda-forge \
+            "${extra[@]}" \
             --output-dir conda-output
 
       # Upload only on a release tag or manual dispatch — never on pull_request

--- a/.github/workflows/conda-release.yml
+++ b/.github/workflows/conda-release.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         env:
           # Belt-and-braces with the variant config below (see that file's comment).
-          MACOSX_DEPLOYMENT_TARGET: "10.15"
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: |
           extra=()
           if [[ "$RUNNER_OS" == "macOS" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
+## [0.17.0]
+
+### Feature: dialog-protocol additions for deletable lists and chart/list placeholders (MINOR)
+
+Backward-compatible JSON protocol additions (unknown keys are ignored by old
+hosts/plugins; no C ABI change, `PJ_DIALOG_PROTOCOL_VERSION` unchanged):
+
+- `WidgetData` per-widget keys via `setListItemsDeletable` / `setListPlaceholder` /
+  `setChartPlaceholder`: `list_deletable` (bool — rows grow a delete affordance), `list_placeholder` / `chart_placeholder` (string — centered
+  hint shown while the list/chart is empty).
+- `WidgetEvent` key: `item_delete_index` (int — row whose delete affordance
+  was clicked), with `WidgetEventBuilder::itemDeleteRequested()` on the host
+  side, `WidgetEvent::itemDeleteRequestedIndex()` on the plugin side, and
+  typed dispatch via `DialogPluginTyped::onItemDeleteRequested()`.
+- `WidgetDataView` accessors (`listDeletable` / `listPlaceholder` /
+  `chartPlaceholder`) for host implementations.
+
 ## [0.16.2]
 
 ### Fix: 0.16.1's Apple `to_chars` guard tested a misspelled macro and never engaged (PATCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.16.2")
+  set(PJ_PACKAGE_VERSION "0.16.3")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.16.3")
+  set(PJ_PACKAGE_VERSION "0.17.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class PlotjugglerSdkConan(ConanFile):
     # 0.16.2 fixes 0.16.1's guard, which tested a misspelled macro
     # (__ENVIRONMENT_MACOS_... instead of __ENVIRONMENT_MAC_OS_X_...) and
     # never engaged — PATCH. See CHANGELOG.md.
-    version = "0.16.2"
+    version = "0.16.3"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,10 +47,10 @@ class PlotjugglerSdkConan(ConanFile):
     # 0.16.1 fixes plugin_data_api.hpp double formatting on Apple deployment
     # targets older than macOS 13.3 (FP std::to_chars unavailable there) —
     # PATCH, installed-header bug fix. See CHANGELOG.md.
-    # 0.16.2 fixes 0.16.1's guard, which tested a misspelled macro
-    # (__ENVIRONMENT_MACOS_... instead of __ENVIRONMENT_MAC_OS_X_...) and
-    # never engaged — PATCH. See CHANGELOG.md.
-    version = "0.16.3"
+    # 0.17.0 extends the dialog protocol with backward-compatible additions
+    # (list_deletable / list_placeholder / chart_placeholder keys and the
+    # item_delete_index event) — MINOR. See CHANGELOG.md.
+    version = "0.17.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/docs/dialog-sdk-reference.md
+++ b/docs/dialog-sdk-reference.md
@@ -66,6 +66,8 @@ For the full tutorial, see [dialog-plugin-guide.md](../pj_plugins/docs/dialog-pl
 |--------|-------------|
 | `setListItems(name, vector<string>)` | Set list items |
 | `setSelectedItems(name, vector<string>)` | Set selected items by text |
+| `setListItemsDeletable(name, bool)` | Draw a trailing trash button on every row; a click fires `onItemDeleteRequested`. |
+| `setListPlaceholder(name, text)` | Centered empty-state hint over the list while it has no items; hidden once items appear. |
 
 ### QTableWidget
 
@@ -155,6 +157,7 @@ Override these in your `DialogPluginTyped` subclass. Return `true` when state ch
 | `onFolderSelected(name, path)` | QPushButton (folder picker) | Selected folder path |
 | `onSelectionChanged(name, items)` | QListWidget, QTableWidget | Vector of selected item texts (table: column-0 text) |
 | `onItemDoubleClicked(name, index)` | QListWidget, QTableWidget | Row index of double-clicked item |
+| `onItemDeleteRequested(name, index)` | QListWidget (deletable) | Row whose trash button was clicked (see `setListItemsDeletable`) |
 | `onTableRadioSelected(name, row)` | QTableWidget radio column | Row whose radio was clicked (see `setTableRadioColumn`) |
 | `onCodeChanged(name, code)` | QPlainTextEdit code editor | Edited code |
 | `onCodeChangedWithCursor(name, code, cursor)` | QPlainTextEdit code editor | Edited code + caret offset (`cursor < 0` when no opt-in / not reported); defaults to `onCodeChanged` |

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -76,6 +76,12 @@ class WidgetDataView {
   [[nodiscard]] std::optional<std::vector<std::string>> selectedItems(std::string_view name) const {
     return getStringArray(name, "selected_items");
   }
+  [[nodiscard]] std::optional<bool> listDeletable(std::string_view name) const {
+    return getBool(name, "list_deletable");
+  }
+  [[nodiscard]] std::optional<std::string> listPlaceholder(std::string_view name) const {
+    return getString(name, "list_placeholder");
+  }
   [[nodiscard]] std::optional<std::vector<std::string>> listItemColors(std::string_view name) const {
     return getStringArray(name, "list_item_colors");
   }
@@ -261,6 +267,11 @@ class WidgetDataView {
   /// Returns whether the chart should auto-fit on every series update.
   [[nodiscard]] std::optional<bool> chartAutoZoom(std::string_view name) const {
     return getBool(name, "chart_auto_zoom");
+  }
+
+  /// Placeholder overlay text for the named chart (see WidgetData::setChartPlaceholder).
+  [[nodiscard]] std::optional<std::string> chartPlaceholder(std::string_view name) const {
+    return getString(name, "chart_placeholder");
   }
 
   // --- QPlainTextEdit ---

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -98,6 +98,13 @@ struct WidgetEventBuilder {
     return j.dump();
   }
 
+  /// QListWidget (deletable): a row's trailing delete (trash) button was clicked.
+  [[nodiscard]] static std::string itemDeleteRequested(int index) {
+    nlohmann::json j;
+    j["item_delete_index"] = index;
+    return j.dump();
+  }
+
   /// QTableWidget: a horizontal-header section was clicked (column index).
   /// Lets a plugin own column sorting — it re-sorts its row model and re-emits
   /// rows, keeping index-based selection/visibility consistent.

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -61,6 +61,12 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  /// A row's trailing delete (trash) button was clicked in a QListWidget marked
+  /// deletable via WidgetData::setListItemsDeletable. `index` is the row.
+  virtual bool onItemDeleteRequested(std::string_view /*widget_name*/, int /*index*/) {
+    return false;
+  }
+
   /// QTableWidget: a horizontal-header section (column) was clicked. Plugins
   /// that drive their own column sorting override this, re-order their row
   /// model, and re-emit — index-based selection/visibility stays consistent.
@@ -170,6 +176,9 @@ class DialogPluginTyped : public DialogPluginBase {
     }
     if (auto v = event.itemDoubleClickedIndex()) {
       return onItemDoubleClicked(widget_name, *v);
+    }
+    if (auto v = event.itemDeleteRequestedIndex()) {
+      return onItemDeleteRequested(widget_name, *v);
     }
     if (auto v = event.headerSection()) {
       return onHeaderClicked(widget_name, *v);

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -210,6 +210,23 @@ class WidgetData {
     return *this;
   }
 
+  /// Render a QListWidget with a per-row delete (trash) button pinned to the
+  /// trailing edge of every item. Clicking a row's button fires
+  /// onItemDeleteRequested(name, row). Opt-in and off by default; re-send on
+  /// every build (it is a per-widget flag, like the radio column).
+  WidgetData& setListItemsDeletable(std::string_view name, bool deletable) {
+    entry(name)["list_deletable"] = deletable;
+    return *this;
+  }
+
+  /// Centered empty-state hint drawn over a QListWidget while it holds no items;
+  /// the host hides it the moment items appear and restores it when the list is
+  /// empty again. Mirrors setChartPlaceholder for lists.
+  WidgetData& setListPlaceholder(std::string_view name, std::string_view text) {
+    entry(name)["list_placeholder"] = std::string(text);
+    return *this;
+  }
+
   // --- QTableWidget ---
   WidgetData& setTableHeaders(std::string_view name, const std::vector<std::string>& headers) {
     entry(name)["headers"] = headers;
@@ -338,6 +355,14 @@ class WidgetData {
   /// Mirrors the Transform/Filter editor "AutoZoom" checkbox.
   WidgetData& setChartAutoZoom(std::string_view name, bool enabled) {
     entry(name)["chart_auto_zoom"] = enabled;
+    return *this;
+  }
+
+  /// Placeholder text shown as a floating overlay banner centered on the named
+  /// chart QFrame while it has no series (e.g. a drag-and-drop hint). The host
+  /// hides it automatically once the chart receives data.
+  WidgetData& setChartPlaceholder(std::string_view name, std::string_view text) {
+    entry(name)["chart_placeholder"] = std::string(text);
     return *this;
   }
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -96,6 +96,9 @@ class WidgetEvent {
   std::optional<int> itemDoubleClickedIndex() const {
     return getInt("item_double_clicked_index");
   }
+  std::optional<int> itemDeleteRequestedIndex() const {
+    return getInt("item_delete_index");
+  }
 
   /// QTableWidget: horizontal-header section clicked (returns column index)
   std::optional<int> headerSection() const {

--- a/pj_plugins/dialog_protocol/tests/dialog_plugin_typed_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/dialog_plugin_typed_test.cpp
@@ -103,6 +103,13 @@ class RecordingPlugin : public PJ::DialogPluginTyped {
     return true;
   }
 
+  bool onItemDeleteRequested(std::string_view widget_name, int index) override {
+    last_handler = "item_delete_requested";
+    last_widget = std::string(widget_name);
+    last_int = index;
+    return true;
+  }
+
   // Recorded state
   std::string last_handler;
   std::string last_widget;
@@ -261,4 +268,11 @@ TEST_F(TypedDispatchTest, CodeChangedWithoutCursorPassesNegativeOne) {
   EXPECT_TRUE(dispatch(plugin_, "editor", R"({"code_changed": "x"})"));
   EXPECT_EQ(plugin_.last_handler, "code_changed");
   EXPECT_EQ(plugin_.last_int, -1);
+}
+
+TEST_F(TypedDispatchTest, ItemDeleteRequestedReachesTypedHandler) {
+  EXPECT_TRUE(dispatch(plugin_, "lst", R"({"item_delete_index": 2})"));
+  EXPECT_EQ(plugin_.last_handler, "item_delete_requested");
+  EXPECT_EQ(plugin_.last_widget, "lst");
+  EXPECT_EQ(plugin_.last_int, 2);
 }

--- a/pj_plugins/dialog_protocol/tests/widget_data_view_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_data_view_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <pj_plugins/host/widget_data_view.hpp>
+#include <pj_plugins/sdk/widget_data.hpp>
 
 // --- QLineEdit ---
 
@@ -270,4 +271,36 @@ TEST(WidgetDataViewTest, CodeCaretTracking) {
 TEST(WidgetDataViewTest, CodeCaretTrackingAbsent) {
   PJ::WidgetDataView v(R"({"editor": {"code_content": "x"}})");
   EXPECT_FALSE(v.codeCaretTracking("editor").has_value());
+}
+
+// WidgetData -> toJson -> WidgetDataView round trips for the dialog-protocol
+// additions in 0.17.0. A key-name mismatch between the setter and the view
+// accessor would silently suppress the feature at the plugin boundary.
+TEST(WidgetDataViewTest, ListDeletableRoundTrip) {
+  PJ::WidgetData wd;
+  wd.setListItemsDeletable("lst", true);
+  PJ::WidgetDataView v(wd.toJson());
+  ASSERT_TRUE(v.listDeletable("lst").has_value());
+  EXPECT_TRUE(*v.listDeletable("lst"));
+}
+
+TEST(WidgetDataViewTest, ListDeletableAbsent) {
+  PJ::WidgetDataView v(R"({"lst": {"items": []}})");
+  EXPECT_FALSE(v.listDeletable("lst").has_value());
+}
+
+TEST(WidgetDataViewTest, ListPlaceholderRoundTrip) {
+  PJ::WidgetData wd;
+  wd.setListPlaceholder("lst", "Drop a series here");
+  PJ::WidgetDataView v(wd.toJson());
+  ASSERT_TRUE(v.listPlaceholder("lst").has_value());
+  EXPECT_EQ(*v.listPlaceholder("lst"), "Drop a series here");
+}
+
+TEST(WidgetDataViewTest, ChartPlaceholderRoundTrip) {
+  PJ::WidgetData wd;
+  wd.setChartPlaceholder("chart", "No data yet");
+  PJ::WidgetDataView v(wd.toJson());
+  ASSERT_TRUE(v.chartPlaceholder("chart").has_value());
+  EXPECT_EQ(*v.chartPlaceholder("chart"), "No data yet");
 }

--- a/pj_plugins/dialog_protocol/tests/widget_event_builder_test.cpp
+++ b/pj_plugins/dialog_protocol/tests/widget_event_builder_test.cpp
@@ -172,3 +172,16 @@ TEST(WidgetEventBuilderTest, CodeChangedWithoutCursorOmitsField) {
   EXPECT_EQ(*ev.codeChanged(), "x");
   EXPECT_FALSE(ev.codeCursor().has_value());
 }
+
+TEST(WidgetEventBuilderTest, ItemDeleteRequestedRoundTrip) {
+  std::string json = PJ::WidgetEventBuilder::itemDeleteRequested(3);
+  PJ::WidgetEvent ev(json);
+  ASSERT_TRUE(ev.itemDeleteRequestedIndex().has_value());
+  EXPECT_EQ(*ev.itemDeleteRequestedIndex(), 3);
+}
+
+TEST(WidgetEventBuilderTest, ItemDeleteRequestedAbsentOnOtherEvents) {
+  std::string json = PJ::WidgetEventBuilder::textChanged("x");
+  PJ::WidgetEvent ev(json);
+  EXPECT_FALSE(ev.itemDeleteRequestedIndex().has_value());
+}

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.16.2"
+  version: "0.17.0"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
Dialog-protocol additions consumed by the PJ4 host + official plugins, released as **0.17.0** (MINOR per the versioning policy — backward-compatible JSON additions, no C ABI change):

- `WidgetData`: `setListItemsDeletable` / `setListPlaceholder` / `setChartPlaceholder` (keys `list_deletable`, `list_placeholder`, `chart_placeholder`)
- `WidgetEvent`: `item_delete_index` via `WidgetEventBuilder::itemDeleteRequested()` → `WidgetEvent::itemDeleteRequestedIndex()` → typed `DialogPluginTyped::onItemDeleteRequested()`
- `WidgetDataView` accessors for all of the above
- Version triple aligned (recipe.yaml / CMake / conanfile all 0.17.0), CHANGELOG entry, and round-trip tests for every new wire path

Consumed by PlotJuggler/PJ4#397 (submodule pin) and PlotJuggler/pj-official-plugins#200 (SDK_VERSION pin). Tagging the tip `v0.17.0` is the release-time step after merge.