### PR TITLE
fix(dialog): make PJ_DIALOG_PLUGIN arg-count dispatch MSVC-legacy-preprocessor-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ JSON addition; no C ABI change, `PJ_DIALOG_PROTOCOL_VERSION` unchanged):
   omit-unchanged-fields pattern (with measured costs) and the delta ops.
 - SDK-side only: hosts apply `table_delta` from the companion PlotJuggler
   change onward; older hosts ignore the key (harmless no-op).
-  
+
 ### Feature: QDateTimeEdit event surface (MINOR)
 
 The dialog protocol's QDateTimeEdit setters (`setDateTime` / `setDateTimeRange`,
@@ -41,6 +41,28 @@ input, not just a display (backward-compatible JSON addition; no C ABI change,
   section; the setter contract is clarified (empty/unparsable strings are
   ignored — the widget keeps its current value; `QDateEdit`/`QTimeEdit`
   subclasses share the binding).
+
+### Fix: PJ_DIALOG_PLUGIN two-arg form broke under the MSVC legacy preprocessor (PATCH-level)
+
+The overload-by-arg-count dispatch behind `PJ_DIALOG_PLUGIN(Class, kManifest)`
+mis-expanded under MSVC's traditional preprocessor (the default without
+`/Zc:preprocessor`): `__VA_ARGS__` was forwarded into the selector as a single
+glued argument, so the two-arg call silently picked the one-arg legacy branch
+with `"Class, kManifest"` as the class name (C2064/C2912 at the call site —
+found via pj-official-plugins#230's Windows CI).
+
+- `PJ_DIALOG_PLUGIN_EXPAND` rescan added to the dispatch — the macro now
+  expands identically under both MSVC preprocessors and GCC/Clang. No ABI or
+  call-site change; purely a header fix.
+- `pj_dialog_sdk` no longer injects `INTERFACE /Zc:preprocessor` into
+  consumers — the flag is unnecessary now, and it never reached Conan
+  consumers anyway (CMakeDeps regenerates targets from `package_info()` and
+  drops upstream `INTERFACE_COMPILE_OPTIONS`, which is how the breakage
+  shipped unnoticed). Consumers that want the conformant preprocessor set it
+  themselves.
+- New compile-only regression target `mock_dialog_legacy_pp_plugin` builds the
+  mock dialog with `/Zc:preprocessor-` on MSVC, so Windows CI now exercises
+  the legacy-preprocessor path the SDK's conformant-only build never covered.
 
 ## [0.17.0]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,11 @@ option(PJ_WARNINGS_AS_ERRORS "Treat compiler warnings as errors (-Werror / /WX)"
 # ---------------------------------------------------------------------------
 
 if(MSVC)
-  # /Zc:preprocessor: conformant preprocessor — required so __VA_ARGS__ inside
-  # nested macro calls (e.g. PJ_DIALOG_PLUGIN's overload-by-arg-count idiom)
-  # splits on commas instead of being passed as a single token.
+  # /Zc:preprocessor: conformant preprocessor. A strictness choice for the
+  # SDK's own build — no installed header requires it anymore
+  # (PJ_DIALOG_PLUGIN's overload-by-arg-count idiom is legacy-PP-safe via
+  # PJ_DIALOG_PLUGIN_EXPAND; a dedicated /Zc:preprocessor- target in
+  # dialog_protocol guards that).
   set(PJ_WARNING_FLAGS /W4 /permissive- /Zc:preprocessor)
   if(PJ_WARNINGS_AS_ERRORS)
     list(APPEND PJ_WARNING_FLAGS /WX)

--- a/pj_plugins/dialog_protocol/CMakeLists.txt
+++ b/pj_plugins/dialog_protocol/CMakeLists.txt
@@ -16,10 +16,12 @@ find_package(nlohmann_json REQUIRED)
 
 add_library(pj_dialog_sdk INTERFACE)
 target_compile_features(pj_dialog_sdk INTERFACE cxx_std_17)
-# PJ_DIALOG_PLUGIN's variadic overload needs conformant __VA_ARGS__ expansion on MSVC.
-target_compile_options(pj_dialog_sdk INTERFACE
-  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor>
-)
+# NOTE: no INTERFACE /Zc:preprocessor here. PJ_DIALOG_PLUGIN's arg-count
+# dispatch is legacy-preprocessor-safe via PJ_DIALOG_PLUGIN_EXPAND (see
+# dialog_plugin_base.hpp), so the SDK no longer imposes a preprocessor mode
+# on consumers. (The old INTERFACE flag never reached Conan consumers anyway:
+# CMakeDeps regenerates targets from package_info(), which drops upstream
+# INTERFACE_COMPILE_OPTIONS.)
 target_link_libraries(pj_dialog_sdk INTERFACE pj_dialog_protocol nlohmann_json::nlohmann_json)
 target_include_directories(pj_dialog_sdk INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -70,6 +72,20 @@ if(PJ_BUILD_TESTS)
 add_library(mock_dialog_plugin SHARED examples/mock_dialog.cpp)
 target_compile_options(mock_dialog_plugin PRIVATE ${PJ_WARNING_FLAGS})
 target_link_libraries(mock_dialog_plugin PRIVATE pj_dialog_sdk)
+
+# Regression guard for the PJ_DIALOG_PLUGIN arg-count dispatch: compile the
+# same example under MSVC's TRADITIONAL preprocessor (/Zc:preprocessor- undoes
+# the conformant-mode flag PJ_WARNING_FLAGS adds). The SDK's own CI otherwise
+# builds everything conformant-only, which is exactly how the legacy-PP
+# breakage of the two-arg macro form shipped unnoticed (pj-official-plugins
+# PR #230). On non-MSVC compilers the flag is a no-op and this is just a
+# second compile of the example.
+add_library(mock_dialog_legacy_pp_plugin SHARED examples/mock_dialog.cpp)
+target_compile_options(mock_dialog_legacy_pp_plugin PRIVATE
+  ${PJ_WARNING_FLAGS}
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor->
+)
+target_link_libraries(mock_dialog_legacy_pp_plugin PRIVATE pj_dialog_sdk)
 
 add_library(missing_dialog_abi_plugin SHARED tests/missing_dialog_abi_plugin.cpp)
 target_compile_options(missing_dialog_abi_plugin PRIVATE ${PJ_WARNING_FLAGS})

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_base.hpp
@@ -277,8 +277,16 @@ PJ_borrowed_dialog_t borrowDialog(DialogT& dialog) noexcept {
 ///      the vtable pointer type-safely via `PJ::borrowDialog(member)` —
 ///      no `extern "C"` forward declaration required in the plugin source.
 #define PJ_DIALOG_PLUGIN_SELECT(_1, _2, NAME, ...) NAME
+// The extra PJ_DIALOG_PLUGIN_EXPAND pass makes the overload-by-arg-count
+// dispatch correct under BOTH MSVC preprocessors. The traditional MSVC
+// preprocessor (the default without /Zc:preprocessor) forwards __VA_ARGS__
+// into a nested macro call as a single argument, so without this rescan a
+// two-argument PJ_DIALOG_PLUGIN(Class, kManifest) selects the one-arg LEGACY
+// branch with the glued pair as ClassName (C2064/C2912 at the call site).
+#define PJ_DIALOG_PLUGIN_EXPAND(x) x
 #define PJ_DIALOG_PLUGIN(...) \
-  PJ_DIALOG_PLUGIN_SELECT(__VA_ARGS__, PJ_DIALOG_PLUGIN_WITH_MANIFEST, PJ_DIALOG_PLUGIN_LEGACY)(__VA_ARGS__)
+  PJ_DIALOG_PLUGIN_EXPAND(    \
+      PJ_DIALOG_PLUGIN_SELECT(__VA_ARGS__, PJ_DIALOG_PLUGIN_WITH_MANIFEST, PJ_DIALOG_PLUGIN_LEGACY)(__VA_ARGS__))
 #define PJ_DIALOG_PLUGIN_LEGACY(ClassName) PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, nullptr)
 #define PJ_DIALOG_PLUGIN_WITH_MANIFEST(ClassName, ManifestJson)                             \
   PJ_EXPORT_PLUGIN_ABI_VERSION(PJ_DIALOG_EXPORT)                                            \


### PR DESCRIPTION
## The bug

The SDK's *recommended* two-arg `PJ_DIALOG_PLUGIN(Class, kManifest)` form mis-expands under MSVC's **traditional preprocessor** (the default — `/Zc:preprocessor` off): `__VA_ARGS__` forwarded into `PJ_DIALOG_PLUGIN_SELECT` arrives as a single glued argument, so the arity dispatch picks the one-arg `LEGACY` branch with `"Class, kManifest"` as `ClassName` → `C2064` (`new Class, kManifest()`) and `C2912` (`dialogVtableFor<Class, &kManifest>`) at every call site. Found by [pj-official-plugins#230](https://github.com/PlotJuggler/pj-official-plugins/pull/230)'s Windows CI.

**Why three layers of protection all missed it:**
- The SDK's own Windows CI builds everything with `/Zc:preprocessor` (in `PJ_WARNING_FLAGS`), so the legacy-PP path of the macro was never compiled anywhere.
- `pj_dialog_sdk` carried an `INTERFACE /Zc:preprocessor` flag for CMake consumers — but Conan's CMakeDeps regenerates targets from `package_info()` and **drops upstream `INTERFACE_COMPILE_OPTIONS`**, so Conan consumers (the official plugins) never received it.

## The fix

1. **`PJ_DIALOG_PLUGIN_EXPAND` rescan** around the selected call — the canonical MSVC workaround. The macro now expands identically under both MSVC preprocessors and GCC/Clang. Header-only; no ABI change, no call-site change; the existing docs' two-arg examples become true on Windows.
2. **Drop the `INTERFACE /Zc:preprocessor` injection** from `pj_dialog_sdk` — no installed header requires it anymore (this was the only `__VA_ARGS__` macro in the installed tree), and silently imposing a preprocessor mode on consumers was ineffective for the consumers that needed it. *Consumer-visible: CMake consumers' TUs that include dialog headers will no longer be forced into conformant-PP mode — flag it if you'd rather keep it.*
3. **New regression target `mock_dialog_legacy_pp_plugin`** — compiles the mock dialog with `/Zc:preprocessor-` on MSVC, so `windows-ci` now exercises the exact path that broke (no-op extra compile on other platforms).

## Versioning

Recorded in the CHANGELOG under the in-flight **0.18.0** — no version bump in this PR per Davide. `abi/baseline.abi` untouched (header macro + build-system only).

## Validation

- `./build.sh --debug && ./test.sh` — **49/49 tests pass**.
- Both mock-dialog targets rebuilt clean after clang-format.
- The MSVC legacy-PP failure mode is reproduced/covered by the new CI target (will be exercised by `windows-ci` on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)