### PR TITLE
fix: align PJ_PACKAGE_VERSION with 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
+## [0.19.0]
+
+### Feature: exported manifest decoder — one validation policy for DSO and static plugins (MINOR)
+
+`decodeManifest(source_path, family, manifest_json)` is now part of the
+`pj_plugins/host/plugin_catalog.hpp` API instead of being private to DSO
+discovery. A host that registers statically linked plugins (no DSO scan) can
+decode their embedded manifests through the exact validation the DSO path
+applies — required non-empty `id`/`name`/`version`, typed-field rejection, and
+the message-parser `encoding` requirement — instead of re-implementing a
+second, weaker decoder. Additive; no ABI or protocol change.
+
 ## [0.18.0]
 
 ### Feature: typed table sort keys — numeric columns sort numerically (MINOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.18.0")
+  set(PJ_PACKAGE_VERSION "0.19.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.18.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.19.0` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -30,7 +30,7 @@ import os
 
 class PlotjugglerSdkConan(ConanFile):
     name = "plotjuggler_sdk"
-    version = "0.18.0"
+    version = "0.19.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
+++ b/pj_plugins/include/pj_plugins/host/plugin_catalog.hpp
@@ -64,6 +64,16 @@ struct PluginScanResult {
   std::vector<PluginDiagnostic> diagnostics;
 };
 
+/// Decode a plugin's embedded manifest JSON into a descriptor, applying the
+/// canonical validation both discovery paths share: `id`/`name`/`version` are
+/// required non-empty strings, typed fields reject mismatched JSON types, and
+/// a message parser must declare a non-empty `encoding` array. `source_path`
+/// is recorded as the descriptor's dso_path (for a DSO the file path; a host
+/// registering a statically linked plugin passes a synthetic label instead);
+/// error strings do not embed it — callers prefix their own source context.
+[[nodiscard]] Expected<PluginDescriptor> decodeManifest(
+    const std::filesystem::path& source_path, PluginFamily family, std::string_view manifest_json);
+
 /// Inspect one DSO and return its embedded plugin descriptor.
 [[nodiscard]] Expected<PluginDescriptor> inspectPluginDso(const std::filesystem::path& dso_path);
 

--- a/pj_plugins/src/plugin_catalog.cpp
+++ b/pj_plugins/src/plugin_catalog.cpp
@@ -179,8 +179,10 @@ Expected<std::vector<std::string>> readStringArray(const nlohmann::json& j, std:
   return values;
 }
 
+}  // namespace
+
 Expected<PluginDescriptor> decodeManifest(
-    const std::filesystem::path& dso_path, PluginFamily family, std::string_view manifest_json) {
+    const std::filesystem::path& source_path, PluginFamily family, std::string_view manifest_json) {
   if (manifest_json.empty()) {
     return unexpected("plugin embedded manifest is empty");
   }
@@ -215,7 +217,7 @@ Expected<PluginDescriptor> decodeManifest(
   };
 
   PluginDescriptor d;
-  d.dso_path = dso_path;
+  d.dso_path = source_path;
   d.abi_major = PJ_ABI_VERSION;
   d.family = family;
 
@@ -274,8 +276,6 @@ Expected<PluginDescriptor> decodeManifest(
 
   return d;
 }
-
-}  // namespace
 
 std::string_view toString(PluginFamily family) noexcept {
   switch (family) {

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.18.0"
+  version: "0.19.0"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
The v0.19.0 conda-release run failed its version-agreement guard: #156 bumped conanfile.py, recipe.yaml, and the CHANGELOG but missed the fourth version source — CMakeLists.txt's `PJ_PACKAGE_VERSION` (baked into ConfigVersion.cmake). One line.

After merging, re-run the release by moving the tag: `git tag -f v0.19.0 <merge-commit> && git push -f origin v0.19.0` (the failed run consumed the old tag), or tag v0.19.1 if you prefer immutable tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)