### PR TITLE
feat(dialog): list per-item disable + selection-mode control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 if(PJ_INSTALL_SDK)
   include(CMakePackageConfigHelpers)
 
-  set(PJ_PACKAGE_VERSION "0.19.0")
+  set(PJ_PACKAGE_VERSION "0.20.0")
   set(PJ_PACKAGE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/plotjuggler_sdk)
 
   install(EXPORT plotjuggler_sdkTargets

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ Exposes three CMake components under the `plotjuggler_sdk::` namespace:
   plugin_sdk   — umbrella for plugin authors (base + dialog SDK + parser SDK)
   plugin_host  — umbrella for host loaders (data_source/parser/toolbox/dialog)
 
-A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.19.0` and then:
+A consuming Conan recipe declares e.g. `plotjuggler_sdk/0.20.0` and then:
 
     find_package(plotjuggler_sdk REQUIRED COMPONENTS plugin_sdk)
     target_link_libraries(my_plugin PRIVATE plotjuggler_sdk::plugin_sdk)
@@ -30,7 +30,7 @@ import os
 
 class PlotjugglerSdkConan(ConanFile):
     name = "plotjuggler_sdk"
-    version = "0.19.0"
+    version = "0.20.0"
     # Apache-2.0 covers the whole SDK (pj_base + pj_plugins). See LICENSE.
     license = "Apache-2.0"
     url = "https://github.com/PlotJuggler/plotjuggler_sdk"

--- a/docs/dialog-sdk-reference.md
+++ b/docs/dialog-sdk-reference.md
@@ -68,6 +68,8 @@ For the full tutorial, see [dialog-plugin-guide.md](../pj_plugins/docs/dialog-pl
 | `setSelectedItems(name, vector<string>)` | Set selected items by text |
 | `setListItemsDeletable(name, bool)` | Draw a trailing trash button on every row; a click fires `onItemDeleteRequested`. |
 | `setListPlaceholder(name, text)` | Centered empty-state hint over the list while it has no items; hidden once items appear. |
+| `setListItemsDisabled(name, vector<string>)` | Grey out (disable + make unselectable) the items whose text is in the set, keeping them visible; matched by item text. An empty/absent set re-enables every item. |
+| `setListSelectionMode(name, bool multi)` | Switch a list between single (`false`, default) and multi (`true`, extended) selection. |
 
 ### QTableWidget
 

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_data_view.hpp
@@ -87,6 +87,12 @@ class WidgetDataView {
   [[nodiscard]] std::optional<std::vector<std::string>> listItemColors(std::string_view name) const {
     return getStringArray(name, "list_item_colors");
   }
+  [[nodiscard]] std::optional<std::vector<std::string>> listDisabledItems(std::string_view name) const {
+    return getStringArray(name, "list_disabled_items");
+  }
+  [[nodiscard]] std::optional<bool> listMultiSelect(std::string_view name) const {
+    return getBool(name, "list_multi_select");
+  }
 
   // --- QTableWidget ---
   [[nodiscard]] std::optional<std::vector<std::string>> tableHeaders(std::string_view name) const {

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_data.hpp
@@ -280,6 +280,23 @@ class WidgetData {
     return *this;
   }
 
+  /// Grey out (disable + make unselectable) the QListWidget items whose text is
+  /// in `disabled`, keeping them visible. Matched by item text, like
+  /// setSelectedItems. Re-send on every build; an empty/absent set re-enables
+  /// every item.
+  WidgetData& setListItemsDisabled(std::string_view name, const std::vector<std::string>& disabled) {
+    entry(name)["list_disabled_items"] = disabled;
+    return *this;
+  }
+
+  /// Switch a QListWidget between single (false, the default) and multi
+  /// (true, extended) selection. Re-send on every build; the host applies the
+  /// requested mode each time.
+  WidgetData& setListSelectionMode(std::string_view name, bool multi) {
+    entry(name)["list_multi_select"] = multi;
+    return *this;
+  }
+
   /// Centered empty-state hint drawn over a QListWidget while it holds no items;
   /// the host hides it the moment items appear and restores it when the list is
   /// empty again. Mirrors setChartPlaceholder for lists.

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.19.0"
+  version: "0.20.0"
 
 package:
   name: plotjuggler_sdk


### PR DESCRIPTION
## What

Adds two backward-compatible list-widget controls to the dialog protocol:

- `WidgetData::setListItemsDisabled(name, items)` — grey out and make
  unselectable a subset of a list's items (host clears
  `Qt::ItemIsEnabled|ItemIsSelectable` on the named entries).
- `WidgetData::setListSelectionMode(name, multi)` — switch a list between
  single- and multi-selection.

Host-side readers (`WidgetDataView::listDisabledItems` / `listMultiSelect`)
and the `docs/dialog-sdk-reference.md` entries are included.

## Why

The reworked CSV-loader "Multiple Columns" timestamp mode needs to multi-select
the date + time columns while greying out every non-time column. These are the
generic protocol primitives that support it; the host binding and the plugin
that consume them live in the PJ4 and pj-official-plugins PRs.

## Versioning

Additive, no ABI break → **MINOR** bump `0.19.0 → 0.20.0` (all three version
sources + docstring updated). `abidiff` should show additions only.

**Release coordination:** the PJ4 host PR bumps its submodule to this commit, and
the pj-official-plugins CSV PR pins `SDK_VERSION = 0.20.0`. This SDK must be
merged and released as `v0.20.0` before the plugin CI can resolve the Conan
package. Tagging/release is left to the maintainer.
