### PR TITLE
feat(sdk): canonical builtin_object_type metadata builder and typed topic registration

### DIFF
--- a/.claude/skills/plotjuggler-plugin/references/builtin-objects.md
+++ b/.claude/skills/plotjuggler-plugin/references/builtin-objects.md
@@ -46,6 +46,7 @@ it, then register a topic once and push per sample:
 
 ```cpp
 #include <pj_base/builtin/image_annotations_codec.hpp>   // the matching codec
+#include <pj_base/sdk/object_topic_metadata.hpp>
 
 const auto* objectHost = objectWriteHost();          // DataSource accessor; nullable
 if (!objectHost) return PJ::unexpected("object store unavailable");
@@ -53,12 +54,10 @@ if (!objectHost) return PJ::unexpected("object store unavailable");
 PJ::sdk::ImageAnnotations anno = /* fill in */;
 std::vector<uint8_t> bytes = PJ::serializeImageAnnotations(anno);   // PJ:: (not PJ::sdk::); infallible
 
-// metadata_json is opaque to the store but read by VIEWERS to pick a renderer —
-// an empty "{}" makes the topic unrenderable. Build it with MediaMetadataBuilder
-// (pj_base/sdk/media_metadata.hpp):
-const std::string meta = PJ::sdk::MediaMetadataBuilder().mediaClass("image_annotations").build();
-
-auto topic = objectHost->registerTopic("overlays", meta);
+// The typed overload emits the canonical builtin_object_type metadata with the
+// exact PJ::sdk::name() value ("kImageAnnotations") used by viewers.
+auto topic = objectHost->registerTopic(
+    "overlays", PJ::sdk::BuiltinObjectType::kImageAnnotations);
 if (!topic) return PJ::unexpected(topic.error());
 auto st = objectHost->pushOwned(*topic, timestamp_ns, bytes);      // host copies the bytes
 if (!st) return PJ::unexpected(st.error());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is
 - Added `PJ::sdk::ObjectTopicMetadataBuilder`. Its typed
   `builtinObjectType()` method emits the canonical `builtin_object_type` key
   using the exact `PJ::sdk::name()` value, while custom string metadata is
-  escaped and emitted in deterministic key order.
+  escaped and emitted in deterministic key order. `build()` returns
+  `Expected<std::string>` so invalid/reserved types and attempts to insert the
+  canonical key as custom metadata remain errors even when assertions are
+  disabled.
 - Added typed C++ registration overloads on `SourceObjectWriteHostView` and
   `ToolboxHostView` (including existing-dataset registration). Existing raw
-  JSON overloads remain source-compatible, and no C ABI struct, vtable, or
-  protocol changed.
+  JSON overloads remain source-compatible—including calls with `{}`—and
+  invalid typed metadata is returned without calling the raw host slot. No C
+  ABI struct, vtable, or protocol changed.
 - Clarified that `MediaMetadataBuilder::mediaClass()` supplies supplemental
   media metadata and does not select a canonical built-in renderer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is
 
 ## [0.21.0]
 
+### Feature: canonical object-topic renderer metadata (MINOR)
+
+- Added `PJ::sdk::ObjectTopicMetadataBuilder`. Its typed
+  `builtinObjectType()` method emits the canonical `builtin_object_type` key
+  using the exact `PJ::sdk::name()` value, while custom string metadata is
+  escaped and emitted in deterministic key order.
+- Added typed C++ registration overloads on `SourceObjectWriteHostView` and
+  `ToolboxHostView` (including existing-dataset registration). Existing raw
+  JSON overloads remain source-compatible, and no C ABI struct, vtable, or
+  protocol changed.
+- Clarified that `MediaMetadataBuilder::mediaClass()` supplies supplemental
+  media metadata and does not select a canonical built-in renderer.
+
 ### Feature: message-parser runtime diagnostics service (MINOR)
 
 MessageParser plugins can now acquire the optional

--- a/V4_STORE.md
+++ b/V4_STORE.md
@@ -27,7 +27,11 @@ DataSource plugins resolve `pj.source_object_write.v1` when they need to publish
 object topics. The source-scoped write host supports:
 
 - `registerTopic(name, metadata_json)`: create an object topic under the current
-  dataset. The metadata JSON is opaque to core and is retained verbatim.
+  dataset. The metadata JSON is opaque to core and is retained verbatim. A
+  renderable built-in object uses `builtin_object_type` with the exact
+  `PJ::sdk::name()` value (for example, `"kImage"`). The C++ view also offers
+  `registerTopic(name, BuiltinObjectType, extra_metadata)` to build this
+  canonical field safely.
 - `pushOwned(topic, timestamp, bytes)`: eager write; the store copies the bytes.
 - `pushLazy(topic, timestamp, fetch)`: lazy write; the store keeps a fetch
   closure and resolves bytes on demand.
@@ -89,7 +93,9 @@ to the resolved byte buffer.
 ObjectStore is byte-oriented and domain-agnostic. It does not decode payloads,
 choose renderers, maintain UI state, or define topic-specific presentation
 policy. Metadata is stored as opaque JSON so callers can layer their own
-interpretation above the core store.
+interpretation above the core store. At the SDK/application boundary,
+`builtin_object_type` is the one canonical renderer-discovery key; values are
+the exact names emitted by `PJ::sdk::name()`.
 
 ## Tests
 

--- a/docs/builtin_type.md
+++ b/docs/builtin_type.md
@@ -124,6 +124,23 @@ annotations, frame transforms, or no builtin object.
 | `kLog` | `PJ::sdk::Log` | Textual log message (severity level + text + originating name). |
 | `kPosesInFrame` | `PJ::sdk::PosesInFrame` | Array of poses in one frame (PoseArray / particle clouds); styling is viewer-side. |
 | `kVoxelGrid` | `PJ::sdk::VoxelGrid` | Dense 3D voxel grid (occupancy/cost/ESDF/semantic); the volumetric sibling of `OccupancyGrid`. |
+| `kPlotMarkers` | `PJ::sdk::PlotMarkers` | Findings on a time-series plot (regions, events, bands, and labels). |
+
+### Object-topic renderer metadata
+
+An object topic that contains one of these built-in types announces it in
+registration metadata with the single canonical key `builtin_object_type`. Its
+value is the exact string returned by `PJ::sdk::name(BuiltinObjectType)`, which
+is the enum name shown in the first table column, including the leading `k`.
+For example, an image topic uses
+`{"builtin_object_type":"kImage"}`. The C++ SDK's
+`ObjectTopicMetadataBuilder` and typed object-topic registration overloads
+produce this field without a free-form type string.
+
+`object_type` and `media_class` are not renderer-discovery aliases.
+`MediaMetadataBuilder` remains available for supplemental fields such as media
+classification, encoding, and schema, and custom untyped object topics remain
+valid.
 
 `BuiltinObject` is `std::any`. Producers store a concrete builtin value in it;
 consumers recover the concrete type with `std::any_cast<T>(&object)` or ask

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -113,6 +113,7 @@ if(PJ_BUILD_TESTS)
     tests/image_annotations_codec_test.cpp
     tests/image_annotations_decoder_test.cpp
     tests/media_metadata_test.cpp
+    tests/object_topic_metadata_test.cpp
     tests/push_message_test.cpp
     tests/notify_available_topics_test.cpp
     tests/dataset_ingest_view_test.cpp

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -580,10 +580,11 @@ typedef struct PJ_toolbox_host_vtable_t {
   /* [stream-thread] Register an object topic for media payloads (images, point
    * clouds, annotations). The topic is namespaced under the data source
    * previously created via create_data_source. `metadata_json` is opaque to
-   * the host — viewers and parsers read it to pick a renderer (e.g.
-   * {"object_type":"image"} for the MediaViewerWidget). Returns false (with
-   * out_error populated) if the source handle is unknown or a topic with
-   * this name already exists for the data source. */
+   * the host. Built-in renderer discovery uses the canonical key
+   * `builtin_object_type`; its value is the exact C++ PJ::sdk::name() string
+   * for the type (for example, {"builtin_object_type":"kImage"}). Returns
+   * false (with out_error populated) if the source handle is unknown or a
+   * topic with this name already exists for the data source. */
   bool (*register_object_topic)(
       void* ctx, PJ_data_source_handle_t source, PJ_string_view_t topic_name, PJ_string_view_t metadata_json,
       PJ_object_topic_handle_t* out_handle, PJ_error_t* out_error) PJ_NOEXCEPT;
@@ -603,8 +604,10 @@ typedef struct PJ_toolbox_host_vtable_t {
    * loaded by another source. Idempotent — if a topic with this name already
    * exists on the dataset, its existing handle is returned (so a producer that
    * republishes its whole set just re-resolves the handle each time).
-   * `metadata_json` is opaque (as in register_object_topic). Returns false (with
-   * out_error populated) if the dataset does not exist.
+   * `metadata_json` is opaque (as in register_object_topic); built-in renderer
+   * discovery uses its canonical `builtin_object_type` key and C++
+   * PJ::sdk::name() values. Returns false (with out_error populated) if the
+   * dataset does not exist.
    * ABI-APPENDED slot: gate via struct_size before calling. */
   bool (*register_object_topic_on_dataset)(
       void* ctx, uint32_t dataset_id, PJ_string_view_t topic_name, PJ_string_view_t metadata_json,
@@ -667,9 +670,11 @@ typedef struct PJ_object_write_host_vtable_t {
 
   /* [stream-thread] Register an object topic under this data source with
    * the given metadata JSON. `metadata_json` is opaque to the store and
-   * retained verbatim; viewers and parsers read it to pick a renderer.
-   * Returns false (with out_error populated) if a topic with this name
-   * already exists for the data source. */
+   * retained verbatim. Built-in renderer discovery uses the canonical key
+   * `builtin_object_type`; its value is the exact C++ PJ::sdk::name() string
+   * for the type (for example, {"builtin_object_type":"kImage"}). Returns
+   * false (with out_error populated) if a topic with this name already exists
+   * for the data source. */
   bool (*register_topic)(
       void* ctx, PJ_string_view_t topic_name, PJ_string_view_t metadata_json, PJ_object_topic_handle_t* out_handle,
       PJ_error_t* out_error) PJ_NOEXCEPT;

--- a/pj_base/include/pj_base/sdk/detail/json.hpp
+++ b/pj_base/include/pj_base/sdk/detail/json.hpp
@@ -1,0 +1,57 @@
+#pragma once
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+#include <string_view>
+
+namespace PJ::sdk::detail {
+
+/// Append the escaped contents of a JSON string, without the surrounding quotes.
+inline void appendJsonEscaped(std::string& out, std::string_view value) {
+  for (const char c : value) {
+    const auto byte = static_cast<unsigned char>(c);
+    switch (c) {
+      case '"':
+        out.append("\\\"");
+        break;
+      case '\\':
+        out.append("\\\\");
+        break;
+      case '\b':
+        out.append("\\b");
+        break;
+      case '\f':
+        out.append("\\f");
+        break;
+      case '\n':
+        out.append("\\n");
+        break;
+      case '\r':
+        out.append("\\r");
+        break;
+      case '\t':
+        out.append("\\t");
+        break;
+      default:
+        if (byte < 0x20U) {
+          static constexpr char kHex[] = "0123456789abcdef";
+          out.append("\\u00");
+          out.push_back(kHex[(byte >> 4U) & 0xFU]);
+          out.push_back(kHex[byte & 0xFU]);
+        } else {
+          out.push_back(c);
+        }
+        break;
+    }
+  }
+}
+
+/// Append a complete quoted and escaped JSON string.
+inline void appendJsonString(std::string& out, std::string_view value) {
+  out.push_back('"');
+  appendJsonEscaped(out, value);
+  out.push_back('"');
+}
+
+}  // namespace PJ::sdk::detail

--- a/pj_base/include/pj_base/sdk/media_metadata.hpp
+++ b/pj_base/include/pj_base/sdk/media_metadata.hpp
@@ -5,13 +5,15 @@
 #include <string>
 #include <string_view>
 
+#include "pj_base/sdk/detail/json.hpp"
+
 namespace PJ::sdk {
 
-/// Builder for the `metadata_json` string attached to an ObjectStore topic
-/// at registration time. Viewers and parsers read this to pick a renderer
-/// or decoder. The builder emits minimal valid JSON with no external
-/// dependency; the three documented keys from OBJECT_STORE_DESIGN.md §4
-/// become typed methods so typos fail to compile.
+/// Builder for supplemental media fields in the `metadata_json` string
+/// attached to an ObjectStore topic at registration time. `media_class`,
+/// `encoding`, and `schema` describe media or decoder details; they do not
+/// select a canonical built-in renderer. In particular, `media_class` is not
+/// an alias for the canonical `builtin_object_type` discovery key.
 ///
 /// Example:
 ///   auto meta = MediaMetadataBuilder()
@@ -21,9 +23,14 @@ namespace PJ::sdk {
 ///       .build();
 ///   host.registerTopic(name, meta);
 ///
-/// Custom keys via `extra()` for format-specific metadata.
+/// For a renderable built-in object, use `ObjectTopicMetadataBuilder`, call
+/// `builtinObjectType()`, and compose supplemental fields with its `string()`
+/// method. Custom, untyped object topics may continue to use this builder.
+/// Custom keys are available through `extra()` for format-specific metadata.
 class MediaMetadataBuilder {
  public:
+  /// Set a supplemental media classification. This does not select a built-in
+  /// renderer; use `ObjectTopicMetadataBuilder::builtinObjectType()` for that.
   MediaMetadataBuilder& mediaClass(std::string_view v) {
     media_class_ = v;
     return *this;
@@ -70,7 +77,7 @@ class MediaMetadataBuilder {
       out.push_back('"');
       out.append(key);
       out.append("\":\"");
-      appendEscaped(out, value);
+      detail::appendJsonEscaped(out, value);
       out.push_back('"');
     };
     kv_string("media_class", media_class_);
@@ -103,49 +110,10 @@ class MediaMetadataBuilder {
     extras_.append("\":");
     if (quoted) {
       extras_.push_back('"');
-      appendEscaped(extras_, value);
+      detail::appendJsonEscaped(extras_, value);
       extras_.push_back('"');
     } else {
       extras_.append(value);
-    }
-  }
-
-  /// Minimal JSON-string escape for ", \, and control chars < 0x20.
-  static void appendEscaped(std::string& out, std::string_view s) {
-    for (char c : s) {
-      switch (c) {
-        case '"':
-          out.append("\\\"");
-          break;
-        case '\\':
-          out.append("\\\\");
-          break;
-        case '\b':
-          out.append("\\b");
-          break;
-        case '\f':
-          out.append("\\f");
-          break;
-        case '\n':
-          out.append("\\n");
-          break;
-        case '\r':
-          out.append("\\r");
-          break;
-        case '\t':
-          out.append("\\t");
-          break;
-        default:
-          if (static_cast<unsigned char>(c) < 0x20) {
-            static constexpr char kHex[] = "0123456789abcdef";
-            out.append("\\u00");
-            out.push_back(kHex[(c >> 4) & 0xF]);
-            out.push_back(kHex[c & 0xF]);
-          } else {
-            out.push_back(c);
-          }
-          break;
-      }
     }
   }
 };

--- a/pj_base/include/pj_base/sdk/object_topic_metadata.hpp
+++ b/pj_base/include/pj_base/sdk/object_topic_metadata.hpp
@@ -1,0 +1,93 @@
+#pragma once
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "pj_base/assert.hpp"
+#include "pj_base/builtin/builtin_object.hpp"
+#include "pj_base/sdk/detail/json.hpp"
+
+namespace PJ::sdk {
+
+/// Canonical metadata key used by hosts to discover a built-in object renderer.
+/// @since 0.21.0
+inline constexpr std::string_view kBuiltinObjectTypeMetadataKey = "builtin_object_type";
+
+/// Builds deterministic metadata JSON for an object topic.
+///
+/// `builtinObjectType()` accepts only the SDK enum and serializes its canonical
+/// `name()` (for example, `BuiltinObjectType::kImage` becomes `"kImage"`).
+/// Custom string fields are emitted in lexicographic key order after the
+/// canonical type field.
+///
+/// @since 0.21.0
+class ObjectTopicMetadataBuilder {
+ public:
+  /// Select the canonical built-in object renderer for this topic.
+  ///
+  /// `kNone`, reserved values, and values unknown to this SDK are contract
+  /// violations and are never added to the output.
+  /// @since 0.21.0
+  ObjectTopicMetadataBuilder& builtinObjectType(BuiltinObjectType type) {
+    const auto parsed = parseBuiltinObjectType(name(type));
+    const bool is_known_type = type != BuiltinObjectType::kNone && parsed.has_value() && *parsed == type;
+    if (!is_known_type) {
+      PJ_ASSERT(is_known_type, "builtin object topic type must be a known, non-reserved value other than kNone");
+      return *this;
+    }
+    builtin_object_type_ = type;
+    return *this;
+  }
+
+  /// Add or replace a custom string field.
+  ///
+  /// The canonical `builtin_object_type` key is reserved; set it through
+  /// `builtinObjectType()` instead.
+  /// @since 0.21.0
+  ObjectTopicMetadataBuilder& string(std::string_view key, std::string_view value) {
+    const bool is_custom_key = key != kBuiltinObjectTypeMetadataKey;
+    if (!is_custom_key) {
+      PJ_ASSERT(is_custom_key, "builtin_object_type must be set through builtinObjectType()");
+      return *this;
+    }
+    strings_.insert_or_assign(std::string(key), std::string(value));
+    return *this;
+  }
+
+  /// Serialize the accumulated metadata as a deterministic JSON object.
+  /// @since 0.21.0
+  [[nodiscard]] std::string build() const {
+    std::string out;
+    out.reserve(48U + strings_.size() * 16U);
+    out.push_back('{');
+    bool first = true;
+    const auto append_string = [&](std::string_view key, std::string_view value) {
+      if (!first) {
+        out.push_back(',');
+      }
+      first = false;
+      detail::appendJsonString(out, key);
+      out.push_back(':');
+      detail::appendJsonString(out, value);
+    };
+
+    if (builtin_object_type_.has_value()) {
+      append_string(kBuiltinObjectTypeMetadataKey, name(*builtin_object_type_));
+    }
+    for (const auto& [key, value] : strings_) {
+      append_string(key, value);
+    }
+    out.push_back('}');
+    return out;
+  }
+
+ private:
+  std::optional<BuiltinObjectType> builtin_object_type_;
+  std::map<std::string, std::string> strings_;
+};
+
+}  // namespace PJ::sdk

--- a/pj_base/include/pj_base/sdk/object_topic_metadata.hpp
+++ b/pj_base/include/pj_base/sdk/object_topic_metadata.hpp
@@ -9,6 +9,7 @@
 
 #include "pj_base/assert.hpp"
 #include "pj_base/builtin/builtin_object.hpp"
+#include "pj_base/expected.hpp"
 #include "pj_base/sdk/detail/json.hpp"
 
 namespace PJ::sdk {
@@ -22,7 +23,8 @@ inline constexpr std::string_view kBuiltinObjectTypeMetadataKey = "builtin_objec
 /// `builtinObjectType()` accepts only the SDK enum and serializes its canonical
 /// `name()` (for example, `BuiltinObjectType::kImage` becomes `"kImage"`).
 /// Custom string fields are emitted in lexicographic key order after the
-/// canonical type field.
+/// canonical type field. `build()` returns an error after any invalid setter
+/// call, including in release builds where assertions are disabled.
 ///
 /// @since 0.21.0
 class ObjectTopicMetadataBuilder {
@@ -36,6 +38,8 @@ class ObjectTopicMetadataBuilder {
     const auto parsed = parseBuiltinObjectType(name(type));
     const bool is_known_type = type != BuiltinObjectType::kNone && parsed.has_value() && *parsed == type;
     if (!is_known_type) {
+      builtin_object_type_.reset();
+      setError("builtin object topic type must be a known, non-reserved value other than kNone");
       PJ_ASSERT(is_known_type, "builtin object topic type must be a known, non-reserved value other than kNone");
       return *this;
     }
@@ -51,6 +55,8 @@ class ObjectTopicMetadataBuilder {
   ObjectTopicMetadataBuilder& string(std::string_view key, std::string_view value) {
     const bool is_custom_key = key != kBuiltinObjectTypeMetadataKey;
     if (!is_custom_key) {
+      builtin_object_type_.reset();
+      setError("metadata key \"builtin_object_type\" is reserved; use builtinObjectType()");
       PJ_ASSERT(is_custom_key, "builtin_object_type must be set through builtinObjectType()");
       return *this;
     }
@@ -58,9 +64,14 @@ class ObjectTopicMetadataBuilder {
     return *this;
   }
 
-  /// Serialize the accumulated metadata as a deterministic JSON object.
+  /// Serialize the accumulated metadata as a deterministic JSON object, or
+  /// return the first contract error recorded by a setter.
   /// @since 0.21.0
-  [[nodiscard]] std::string build() const {
+  [[nodiscard]] Expected<std::string> build() const {
+    if (error_.has_value()) {
+      return unexpected(*error_);
+    }
+
     std::string out;
     out.reserve(48U + strings_.size() * 16U);
     out.push_back('{');
@@ -88,6 +99,13 @@ class ObjectTopicMetadataBuilder {
  private:
   std::optional<BuiltinObjectType> builtin_object_type_;
   std::map<std::string, std::string> strings_;
+  std::optional<std::string> error_;
+
+  void setError(std::string_view error) {
+    if (!error_.has_value()) {
+      error_ = error;
+    }
+  }
 };
 
 }  // namespace PJ::sdk

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <charconv>
+#include <concepts>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -806,11 +807,17 @@ class SourceObjectWriteHostView {
 
   /// Register a built-in object topic using canonical renderer metadata.
   /// Custom string fields already present in `extra_metadata` are preserved.
+  /// Invalid metadata returns `unexpected` without calling the raw host slot.
   /// @since 0.21.0
+  template <typename ObjectType>
+    requires std::same_as<ObjectType, BuiltinObjectType>
   [[nodiscard]] Expected<ObjectTopicHandle> registerTopic(
-      std::string_view name, BuiltinObjectType type, ObjectTopicMetadataBuilder extra_metadata = {}) const {
-    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
-    return registerTopic(name, metadata_json);
+      std::string_view name, ObjectType type, ObjectTopicMetadataBuilder extra_metadata = {}) const {
+    const auto metadata_json = extra_metadata.builtinObjectType(type).build();
+    if (!metadata_json) {
+      return unexpected(metadata_json.error());
+    }
+    return registerTopic(name, *metadata_json);
   }
 
   /// Eager push — host copies the bytes into its own storage.
@@ -1291,12 +1298,18 @@ class ToolboxHostView {
 
   /// Register a built-in object topic using canonical renderer metadata.
   /// Custom string fields already present in `extra_metadata` are preserved.
+  /// Invalid metadata returns `unexpected` without calling the raw host slot.
   /// @since 0.21.0
+  template <typename ObjectType>
+    requires std::same_as<ObjectType, BuiltinObjectType>
   [[nodiscard]] Expected<ObjectTopicHandle> registerObjectTopic(
-      DataSourceHandle source, std::string_view name, BuiltinObjectType type,
+      DataSourceHandle source, std::string_view name, ObjectType type,
       ObjectTopicMetadataBuilder extra_metadata = {}) const {
-    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
-    return registerObjectTopic(source, name, metadata_json);
+    const auto metadata_json = extra_metadata.builtinObjectType(type).build();
+    if (!metadata_json) {
+      return unexpected(metadata_json.error());
+    }
+    return registerObjectTopic(source, name, *metadata_json);
   }
 
   /// Eager push of an object payload — host copies the bytes into its own
@@ -1345,13 +1358,18 @@ class ToolboxHostView {
 
   /// Register a built-in object topic on an existing dataset using canonical
   /// renderer metadata. Custom string fields already present in
-  /// `extra_metadata` are preserved.
+  /// `extra_metadata` are preserved. Invalid metadata returns `unexpected`
+  /// without calling the raw host slot.
   /// @since 0.21.0
+  template <typename ObjectType>
+    requires std::same_as<ObjectType, BuiltinObjectType>
   [[nodiscard]] Expected<ObjectTopicHandle> registerObjectTopicOnDataset(
-      DatasetId dataset, std::string_view name, BuiltinObjectType type,
-      ObjectTopicMetadataBuilder extra_metadata = {}) const {
-    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
-    return registerObjectTopicOnDataset(dataset, name, metadata_json);
+      DatasetId dataset, std::string_view name, ObjectType type, ObjectTopicMetadataBuilder extra_metadata = {}) const {
+    const auto metadata_json = extra_metadata.builtinObjectType(type).build();
+    if (!metadata_json) {
+      return unexpected(metadata_json.error());
+    }
+    return registerObjectTopicOnDataset(dataset, name, *metadata_json);
   }
 
   /// Bound a topic's retention to the last `max_entries` snapshots (0 = unlimited).

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -25,6 +25,7 @@
 #include "pj_base/plugin_data_api.h"
 #include "pj_base/sdk/arrow.hpp"
 #include "pj_base/sdk/object_bytes.hpp"
+#include "pj_base/sdk/object_topic_metadata.hpp"
 #include "pj_base/span.hpp"
 #include "pj_base/type_tree.hpp"
 #include "pj_base/types.hpp"
@@ -788,7 +789,9 @@ class SourceObjectWriteHostView {
   }
 
   /// Register an object topic with opaque metadata JSON. The JSON is retained
-  /// verbatim by the store; viewers and parsers use it to pick a renderer.
+  /// verbatim by the store. For a built-in renderable object, the canonical
+  /// discovery field is `"builtin_object_type":"<name>"`, where `<name>` is
+  /// the exact string returned by `PJ::sdk::name()` (for example, `"kImage"`).
   [[nodiscard]] Expected<ObjectTopicHandle> registerTopic(std::string_view name, std::string_view metadata_json) const {
     if (!valid()) {
       return unexpected("source object write host is not bound");
@@ -799,6 +802,15 @@ class SourceObjectWriteHostView {
       return unexpected(errorToString(err));
     }
     return handle;
+  }
+
+  /// Register a built-in object topic using canonical renderer metadata.
+  /// Custom string fields already present in `extra_metadata` are preserved.
+  /// @since 0.21.0
+  [[nodiscard]] Expected<ObjectTopicHandle> registerTopic(
+      std::string_view name, BuiltinObjectType type, ObjectTopicMetadataBuilder extra_metadata = {}) const {
+    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
+    return registerTopic(name, metadata_json);
   }
 
   /// Eager push — host copies the bytes into its own storage.
@@ -1252,8 +1264,10 @@ class ToolboxHostView {
 
   /// Register an object topic for media payloads (images, point clouds,
   /// annotations) under a previously created data source. `metadata_json`
-  /// is opaque to the store and retained verbatim; viewers and parsers
-  /// read it to pick a renderer.
+  /// is opaque to the store and retained verbatim. For a built-in renderable
+  /// object, the canonical discovery field is
+  /// `"builtin_object_type":"<name>"`, where `<name>` is the exact string
+  /// returned by `PJ::sdk::name()` (for example, `"kImage"`).
   ///
   /// Returns `unexpected` if the host predates this ABI slot — older hosts
   /// can be detected via the ABI's `PJ_HAS_TAIL_SLOT` macro; in this
@@ -1273,6 +1287,16 @@ class ToolboxHostView {
       return unexpected(errorToString(err));
     }
     return handle;
+  }
+
+  /// Register a built-in object topic using canonical renderer metadata.
+  /// Custom string fields already present in `extra_metadata` are preserved.
+  /// @since 0.21.0
+  [[nodiscard]] Expected<ObjectTopicHandle> registerObjectTopic(
+      DataSourceHandle source, std::string_view name, BuiltinObjectType type,
+      ObjectTopicMetadataBuilder extra_metadata = {}) const {
+    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
+    return registerObjectTopic(source, name, metadata_json);
   }
 
   /// Eager push of an object payload — host copies the bytes into its own
@@ -1297,7 +1321,9 @@ class ToolboxHostView {
   /// another source loaded. Idempotent: returns the existing topic's handle if
   /// one with this name already exists on the dataset, so a producer that
   /// republishes its whole set just re-resolves the handle each time. Returns
-  /// `unexpected` on older hosts that don't expose the slot.
+  /// `unexpected` on older hosts that don't expose the slot. Built-in
+  /// renderable objects use the same canonical `builtin_object_type` field and
+  /// `PJ::sdk::name()` values documented by `registerObjectTopic()`.
   [[nodiscard]] Expected<ObjectTopicHandle> registerObjectTopicOnDataset(
       DatasetId dataset, std::string_view name, std::string_view metadata_json) const {
     if (!valid()) {
@@ -1315,6 +1341,17 @@ class ToolboxHostView {
       return unexpected(errorToString(err));
     }
     return handle;
+  }
+
+  /// Register a built-in object topic on an existing dataset using canonical
+  /// renderer metadata. Custom string fields already present in
+  /// `extra_metadata` are preserved.
+  /// @since 0.21.0
+  [[nodiscard]] Expected<ObjectTopicHandle> registerObjectTopicOnDataset(
+      DatasetId dataset, std::string_view name, BuiltinObjectType type,
+      ObjectTopicMetadataBuilder extra_metadata = {}) const {
+    const std::string metadata_json = extra_metadata.builtinObjectType(type).build();
+    return registerObjectTopicOnDataset(dataset, name, metadata_json);
   }
 
   /// Bound a topic's retention to the last `max_entries` snapshots (0 = unlimited).

--- a/pj_base/tests/object_topic_metadata_test.cpp
+++ b/pj_base/tests/object_topic_metadata_test.cpp
@@ -1,0 +1,192 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pj_base/sdk/object_topic_metadata.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "pj_base/sdk/plugin_data_api.hpp"
+
+namespace PJ::sdk {
+namespace {
+
+using SourceRawRegistration =
+    Expected<ObjectTopicHandle> (SourceObjectWriteHostView::*)(std::string_view, std::string_view) const;
+using ToolboxRawRegistration =
+    Expected<ObjectTopicHandle> (ToolboxHostView::*)(DataSourceHandle, std::string_view, std::string_view) const;
+using ToolboxDatasetRawRegistration =
+    Expected<ObjectTopicHandle> (ToolboxHostView::*)(DatasetId, std::string_view, std::string_view) const;
+
+static_assert(std::is_same_v<
+              decltype(static_cast<SourceRawRegistration>(&SourceObjectWriteHostView::registerTopic)),
+              SourceRawRegistration>);
+static_assert(
+    std::is_same_v<
+        decltype(static_cast<ToolboxRawRegistration>(&ToolboxHostView::registerObjectTopic)), ToolboxRawRegistration>);
+static_assert(std::is_same_v<
+              decltype(static_cast<ToolboxDatasetRawRegistration>(&ToolboxHostView::registerObjectTopicOnDataset)),
+              ToolboxDatasetRawRegistration>);
+
+constexpr std::array kBuiltinObjectTypes{
+    BuiltinObjectType::kImage,
+    BuiltinObjectType::kPointCloud,
+    BuiltinObjectType::kDepthImage,
+    BuiltinObjectType::kImageAnnotations,
+    BuiltinObjectType::kFrameTransforms,
+    BuiltinObjectType::kOccupancyGrid,
+    BuiltinObjectType::kCompressedPointCloud,
+    BuiltinObjectType::kMesh3D,
+    BuiltinObjectType::kVideoFrame,
+    BuiltinObjectType::kSceneEntities,
+    BuiltinObjectType::kRobotDescription,
+    BuiltinObjectType::kCameraInfo,
+    BuiltinObjectType::kOccupancyGridUpdate,
+    BuiltinObjectType::kLog,
+    BuiltinObjectType::kPosesInFrame,
+    BuiltinObjectType::kVoxelGrid,
+    BuiltinObjectType::kPlotMarkers,
+};
+
+struct RegistrationRecorder {
+  uint32_t call_count = 0;
+  uint32_t source_id = 0;
+  DatasetId dataset_id = 0;
+  std::string topic_name;
+  std::string metadata_json;
+};
+
+std::string copyString(PJ_string_view_t value) {
+  return std::string(value.data, static_cast<size_t>(value.size));
+}
+
+bool sourceRegisterTopic(
+    void* ctx, PJ_string_view_t topic_name, PJ_string_view_t metadata_json, PJ_object_topic_handle_t* out_handle,
+    PJ_error_t*) noexcept {
+  auto& recorder = *static_cast<RegistrationRecorder*>(ctx);
+  ++recorder.call_count;
+  recorder.topic_name = copyString(topic_name);
+  recorder.metadata_json = copyString(metadata_json);
+  *out_handle = PJ_object_topic_handle_t{41};
+  return true;
+}
+
+bool toolboxRegisterObjectTopic(
+    void* ctx, PJ_data_source_handle_t source, PJ_string_view_t topic_name, PJ_string_view_t metadata_json,
+    PJ_object_topic_handle_t* out_handle, PJ_error_t*) noexcept {
+  auto& recorder = *static_cast<RegistrationRecorder*>(ctx);
+  ++recorder.call_count;
+  recorder.source_id = source.id;
+  recorder.topic_name = copyString(topic_name);
+  recorder.metadata_json = copyString(metadata_json);
+  *out_handle = PJ_object_topic_handle_t{42};
+  return true;
+}
+
+bool toolboxRegisterObjectTopicOnDataset(
+    void* ctx, uint32_t dataset_id, PJ_string_view_t topic_name, PJ_string_view_t metadata_json,
+    PJ_object_topic_handle_t* out_handle, PJ_error_t*) noexcept {
+  auto& recorder = *static_cast<RegistrationRecorder*>(ctx);
+  ++recorder.call_count;
+  recorder.dataset_id = dataset_id;
+  recorder.topic_name = copyString(topic_name);
+  recorder.metadata_json = copyString(metadata_json);
+  *out_handle = PJ_object_topic_handle_t{43};
+  return true;
+}
+
+TEST(ObjectTopicMetadataBuilderTest, EveryBuiltinTypeUsesCanonicalRoundTrippableName) {
+  for (const BuiltinObjectType type : kBuiltinObjectTypes) {
+    const auto parsed = parseBuiltinObjectType(name(type));
+    ASSERT_TRUE(parsed.has_value()) << name(type);
+    EXPECT_EQ(*parsed, type) << name(type);
+
+    const std::string expected = "{\"builtin_object_type\":\"" + std::string(name(type)) + "\"}";
+    EXPECT_EQ(ObjectTopicMetadataBuilder().builtinObjectType(type).build(), expected);
+  }
+}
+
+TEST(ObjectTopicMetadataBuilderTest, EscapesCustomKeysAndValuesInStableKeyOrder) {
+  std::string key = "z\"\\";
+  key.push_back('\n');
+  key.push_back('\x01');
+
+  std::string value = "value\"\\";
+  value.push_back('\b');
+  value.push_back('\f');
+  value.push_back('\n');
+  value.push_back('\r');
+  value.push_back('\t');
+  value.push_back('\x02');
+
+  const std::string json = ObjectTopicMetadataBuilder()
+                               .string(key, value)
+                               .string("a_first", "original")
+                               .string("a_first", "replaced")
+                               .builtinObjectType(BuiltinObjectType::kImage)
+                               .build();
+
+  const std::string expected =
+      "{\"builtin_object_type\":\"kImage\",\"a_first\":\"replaced\","
+      "\"z\\\"\\\\\\n\\u0001\":\"value\\\"\\\\\\b\\f\\n\\r\\t\\u0002\"}";
+  EXPECT_EQ(json, expected);
+}
+
+TEST(ObjectTopicMetadataRegistrationTest, SourceTypedOverloadForwardsBuiltJson) {
+  RegistrationRecorder recorder;
+  const PJ_object_write_host_vtable_t vtable = {
+      .abi_version = PJ_PLUGIN_DATA_API_VERSION,
+      .struct_size = sizeof(PJ_object_write_host_vtable_t),
+      .register_topic = sourceRegisterTopic,
+  };
+  const SourceObjectWriteHostView view(PJ_object_write_host_t{.ctx = &recorder, .vtable = &vtable});
+
+  ObjectTopicMetadataBuilder extra_metadata;
+  extra_metadata.string("image_codec", "pj_image_v1");
+  const auto result = view.registerTopic("camera", BuiltinObjectType::kImage, extra_metadata);
+
+  ASSERT_TRUE(result) << result.error();
+  EXPECT_EQ(result->id, 41U);
+  EXPECT_EQ(recorder.call_count, 1U);
+  EXPECT_EQ(recorder.topic_name, "camera");
+  EXPECT_EQ(recorder.metadata_json, R"({"builtin_object_type":"kImage","image_codec":"pj_image_v1"})");
+}
+
+TEST(ObjectTopicMetadataRegistrationTest, ToolboxTypedOverloadsForwardBuiltJson) {
+  RegistrationRecorder recorder;
+  const PJ_toolbox_host_vtable_t vtable = {
+      .abi_version = PJ_PLUGIN_DATA_API_VERSION,
+      .struct_size = sizeof(PJ_toolbox_host_vtable_t),
+      .register_object_topic = toolboxRegisterObjectTopic,
+      .register_object_topic_on_dataset = toolboxRegisterObjectTopicOnDataset,
+  };
+  const ToolboxHostView view(PJ_toolbox_host_t{.ctx = &recorder, .vtable = &vtable});
+
+  const auto source_result = view.registerObjectTopic(DataSourceHandle{7}, "points", BuiltinObjectType::kPointCloud);
+  ASSERT_TRUE(source_result) << source_result.error();
+  EXPECT_EQ(source_result->id, 42U);
+  EXPECT_EQ(recorder.call_count, 1U);
+  EXPECT_EQ(recorder.source_id, 7U);
+  EXPECT_EQ(recorder.topic_name, "points");
+  EXPECT_EQ(recorder.metadata_json, R"({"builtin_object_type":"kPointCloud"})");
+
+  ObjectTopicMetadataBuilder extra_metadata;
+  extra_metadata.string("producer", "annotations");
+  const auto dataset_result =
+      view.registerObjectTopicOnDataset(9, "markers", BuiltinObjectType::kPlotMarkers, extra_metadata);
+  ASSERT_TRUE(dataset_result) << dataset_result.error();
+  EXPECT_EQ(dataset_result->id, 43U);
+  EXPECT_EQ(recorder.call_count, 2U);
+  EXPECT_EQ(recorder.dataset_id, 9U);
+  EXPECT_EQ(recorder.topic_name, "markers");
+  EXPECT_EQ(recorder.metadata_json, R"({"builtin_object_type":"kPlotMarkers","producer":"annotations"})");
+}
+
+}  // namespace
+}  // namespace PJ::sdk

--- a/pj_base/tests/object_topic_metadata_test.cpp
+++ b/pj_base/tests/object_topic_metadata_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -33,6 +34,13 @@ static_assert(
 static_assert(std::is_same_v<
               decltype(static_cast<ToolboxDatasetRawRegistration>(&ToolboxHostView::registerObjectTopicOnDataset)),
               ToolboxDatasetRawRegistration>);
+
+// The typed overload is a constrained template, so an untyped braced-init-list
+// cannot deduce it. This expression can therefore only select the raw
+// std::string_view overload.
+static_assert(requires(const SourceObjectWriteHostView& view) {
+  { view.registerTopic("x", {}) } -> std::same_as<Expected<ObjectTopicHandle>>;
+});
 
 constexpr std::array kBuiltinObjectTypes{
     BuiltinObjectType::kImage,
@@ -63,6 +71,9 @@ struct RegistrationRecorder {
 };
 
 std::string copyString(PJ_string_view_t value) {
+  if (value.data == nullptr) {
+    return {};
+  }
   return std::string(value.data, static_cast<size_t>(value.size));
 }
 
@@ -108,7 +119,9 @@ TEST(ObjectTopicMetadataBuilderTest, EveryBuiltinTypeUsesCanonicalRoundTrippable
     EXPECT_EQ(*parsed, type) << name(type);
 
     const std::string expected = "{\"builtin_object_type\":\"" + std::string(name(type)) + "\"}";
-    EXPECT_EQ(ObjectTopicMetadataBuilder().builtinObjectType(type).build(), expected);
+    const auto metadata = ObjectTopicMetadataBuilder().builtinObjectType(type).build();
+    ASSERT_TRUE(metadata) << name(type);
+    EXPECT_EQ(*metadata, expected);
   }
 }
 
@@ -125,17 +138,67 @@ TEST(ObjectTopicMetadataBuilderTest, EscapesCustomKeysAndValuesInStableKeyOrder)
   value.push_back('\t');
   value.push_back('\x02');
 
-  const std::string json = ObjectTopicMetadataBuilder()
-                               .string(key, value)
-                               .string("a_first", "original")
-                               .string("a_first", "replaced")
-                               .builtinObjectType(BuiltinObjectType::kImage)
-                               .build();
+  const auto json = ObjectTopicMetadataBuilder()
+                        .string(key, value)
+                        .string("a_first", "original")
+                        .string("a_first", "replaced")
+                        .builtinObjectType(BuiltinObjectType::kImage)
+                        .build();
 
   const std::string expected =
       "{\"builtin_object_type\":\"kImage\",\"a_first\":\"replaced\","
       "\"z\\\"\\\\\\n\\u0001\":\"value\\\"\\\\\\b\\f\\n\\r\\t\\u0002\"}";
-  EXPECT_EQ(json, expected);
+  ASSERT_TRUE(json);
+  EXPECT_EQ(*json, expected);
+}
+
+TEST(ObjectTopicMetadataBuilderTest, InvalidTypesAreErrorsWhenAssertionsAreDisabled) {
+#if !defined(NDEBUG) || defined(PJ_ASSERT_THROWS)
+  GTEST_SKIP() << "release-mode behavior requires elided debug assertions";
+#else
+  for (const BuiltinObjectType type : {
+           BuiltinObjectType::kNone,
+           static_cast<BuiltinObjectType>(2),
+           static_cast<BuiltinObjectType>(12),
+           static_cast<BuiltinObjectType>(999),
+       }) {
+    ObjectTopicMetadataBuilder metadata;
+    metadata.builtinObjectType(type);
+    const auto result = metadata.build();
+
+    ASSERT_FALSE(result);
+    EXPECT_NE(result.error().find("known, non-reserved"), std::string::npos);
+  }
+#endif
+}
+
+TEST(ObjectTopicMetadataBuilderTest, InvalidTypeClearsEarlierValidTypeAndLeavesError) {
+#if !defined(NDEBUG) || defined(PJ_ASSERT_THROWS)
+  GTEST_SKIP() << "release-mode behavior requires elided debug assertions";
+#else
+  ObjectTopicMetadataBuilder metadata;
+  metadata.builtinObjectType(BuiltinObjectType::kImage);
+  metadata.builtinObjectType(static_cast<BuiltinObjectType>(12));
+  metadata.builtinObjectType(BuiltinObjectType::kPointCloud);
+
+  const auto result = metadata.build();
+  ASSERT_FALSE(result);
+  EXPECT_NE(result.error().find("known, non-reserved"), std::string::npos);
+#endif
+}
+
+TEST(ObjectTopicMetadataBuilderTest, CanonicalKeyCannotBeInsertedAsCustomMetadata) {
+#if !defined(NDEBUG) || defined(PJ_ASSERT_THROWS)
+  GTEST_SKIP() << "release-mode behavior requires elided debug assertions";
+#else
+  ObjectTopicMetadataBuilder metadata;
+  metadata.builtinObjectType(BuiltinObjectType::kImage);
+  metadata.string(kBuiltinObjectTypeMetadataKey, "kPointCloud");
+
+  const auto result = metadata.build();
+  ASSERT_FALSE(result);
+  EXPECT_NE(result.error().find("reserved"), std::string::npos);
+#endif
 }
 
 TEST(ObjectTopicMetadataRegistrationTest, SourceTypedOverloadForwardsBuiltJson) {
@@ -156,6 +219,23 @@ TEST(ObjectTopicMetadataRegistrationTest, SourceTypedOverloadForwardsBuiltJson) 
   EXPECT_EQ(recorder.call_count, 1U);
   EXPECT_EQ(recorder.topic_name, "camera");
   EXPECT_EQ(recorder.metadata_json, R"({"builtin_object_type":"kImage","image_codec":"pj_image_v1"})");
+}
+
+TEST(ObjectTopicMetadataRegistrationTest, EmptyBracesUseRawMetadataOverload) {
+  RegistrationRecorder recorder;
+  const PJ_object_write_host_vtable_t vtable = {
+      .abi_version = PJ_PLUGIN_DATA_API_VERSION,
+      .struct_size = sizeof(PJ_object_write_host_vtable_t),
+      .register_topic = sourceRegisterTopic,
+  };
+  const SourceObjectWriteHostView view(PJ_object_write_host_t{.ctx = &recorder, .vtable = &vtable});
+
+  const auto result = view.registerTopic("raw", {});
+
+  ASSERT_TRUE(result);
+  EXPECT_EQ(recorder.call_count, 1U);
+  EXPECT_EQ(recorder.topic_name, "raw");
+  EXPECT_TRUE(recorder.metadata_json.empty());
 }
 
 TEST(ObjectTopicMetadataRegistrationTest, ToolboxTypedOverloadsForwardBuiltJson) {
@@ -186,6 +266,47 @@ TEST(ObjectTopicMetadataRegistrationTest, ToolboxTypedOverloadsForwardBuiltJson)
   EXPECT_EQ(recorder.dataset_id, 9U);
   EXPECT_EQ(recorder.topic_name, "markers");
   EXPECT_EQ(recorder.metadata_json, R"({"builtin_object_type":"kPlotMarkers","producer":"annotations"})");
+}
+
+TEST(ObjectTopicMetadataRegistrationTest, InvalidTypedRegistrationsNeverReachRawVtables) {
+#if !defined(NDEBUG) || defined(PJ_ASSERT_THROWS)
+  GTEST_SKIP() << "release-mode behavior requires elided debug assertions";
+#else
+  RegistrationRecorder source_recorder;
+  const PJ_object_write_host_vtable_t source_vtable = {
+      .abi_version = PJ_PLUGIN_DATA_API_VERSION,
+      .struct_size = sizeof(PJ_object_write_host_vtable_t),
+      .register_topic = sourceRegisterTopic,
+  };
+  const SourceObjectWriteHostView source_view(
+      PJ_object_write_host_t{.ctx = &source_recorder, .vtable = &source_vtable});
+
+  const auto source_result = source_view.registerTopic("invalid", BuiltinObjectType::kNone);
+  ASSERT_FALSE(source_result);
+  EXPECT_NE(source_result.error().find("known, non-reserved"), std::string::npos);
+  EXPECT_EQ(source_recorder.call_count, 0U);
+
+  RegistrationRecorder toolbox_recorder;
+  const PJ_toolbox_host_vtable_t toolbox_vtable = {
+      .abi_version = PJ_PLUGIN_DATA_API_VERSION,
+      .struct_size = sizeof(PJ_toolbox_host_vtable_t),
+      .register_object_topic = toolboxRegisterObjectTopic,
+      .register_object_topic_on_dataset = toolboxRegisterObjectTopicOnDataset,
+  };
+  const ToolboxHostView toolbox_view(PJ_toolbox_host_t{.ctx = &toolbox_recorder, .vtable = &toolbox_vtable});
+
+  const auto toolbox_result =
+      toolbox_view.registerObjectTopic(DataSourceHandle{7}, "invalid", static_cast<BuiltinObjectType>(12));
+  ASSERT_FALSE(toolbox_result);
+  EXPECT_NE(toolbox_result.error().find("known, non-reserved"), std::string::npos);
+  EXPECT_EQ(toolbox_recorder.call_count, 0U);
+
+  const auto dataset_result =
+      toolbox_view.registerObjectTopicOnDataset(9, "invalid", static_cast<BuiltinObjectType>(999));
+  ASSERT_FALSE(dataset_result);
+  EXPECT_NE(dataset_result.error().find("known, non-reserved"), std::string::npos);
+  EXPECT_EQ(toolbox_recorder.call_count, 0U);
+#endif
 }
 
 }  // namespace

--- a/pj_plugins/docs/toolbox-guide.md
+++ b/pj_plugins/docs/toolbox-guide.md
@@ -201,7 +201,8 @@ data store.
 | `appendArrowStream(topic, stream, ts_col)` | Hand an `ArrowArrayStream*` (Arrow C Data Interface) to the host for bulk ingest. Same ownership rule as the source write path: success transfers, failure retains. |
 | `catalogSnapshot()` | Acquire a read-only snapshot of all data sources, topics, and fields. |
 | `readSeriesArrow(field, schema*, array*)` | Read one field's full time series into host-owned `ArrowSchema` + `ArrowArray` out-params (two columns: `timestamp` int64 ns, then the typed field value). |
-| `registerObjectTopic(source, name, metadata_json)` | Register a media/object topic under a data source. `metadata_json` is opaque to the store and retained verbatim; viewers and parsers read it to pick a renderer. Returns an `ObjectTopicHandle`. |
+| `registerObjectTopic(source, name, type[, extra_metadata])` | Register a built-in media/object topic under a data source. The typed overload emits the canonical `builtin_object_type` renderer metadata and returns an `ObjectTopicHandle`. |
+| `registerObjectTopic(source, name, metadata_json)` | Raw-metadata overload for custom or untyped object topics. The store retains the JSON verbatim. |
 | `pushOwnedObject(topic, ts, payload)` | Eager-push serialized object bytes into the ObjectStore under an object topic; the host copies the bytes, so the plugin's buffer is free immediately after the call returns. |
 
 ### Runtime host — control plane
@@ -262,10 +263,11 @@ auto status = toolboxHost().appendArrowStream(
 overlay — use the object-write surface, which routes to the host `ObjectStore`
 rather than the columnar engine:
 
-1. `registerObjectTopic(source, name, metadata_json)` declares a topic under a
-   data source you created. The `metadata_json` is opaque to the store; viewers
-   and parsers read it to choose a renderer (e.g. `{"object_type":"image"}` for
-   the MediaViewer). It returns an `ObjectTopicHandle`.
+1. `registerObjectTopic(source, name, type[, extra_metadata])` declares a topic
+   under a data source you created. The typed overload writes the canonical
+   `builtin_object_type` metadata key with the exact `PJ::sdk::name()` value
+   (for example, `"kImage"`). It returns an `ObjectTopicHandle`. The raw
+   `metadata_json` overload remains available for custom or untyped topics.
 2. `pushOwnedObject(topic, ts, payload)` pushes serialized bytes (e.g. a
    `PJ.Image` produced via `serializeImage()` from `pj_base/builtin/image_codec.hpp`).
    The push is **eager**: the host copies the bytes immediately, so your buffer
@@ -274,8 +276,11 @@ rather than the columnar engine:
    time it writes them.
 
 ```cpp
+PJ::sdk::ObjectTopicMetadataBuilder metadata;
+metadata.string("image_codec", "pj_image_v1");
+
 auto topic = toolboxHost().registerObjectTopic(
-    source, "mosaic/preview", R"({"object_type":"image"})");
+    source, "mosaic/preview", PJ::sdk::BuiltinObjectType::kImage, metadata);
 if (!topic) {
   runtimeHost().reportMessage(PJ::ToolboxMessageLevel::kError, topic.error());
   return;


### PR DESCRIPTION
Companion G2 of the dialog-tree / SDK-compatibility plan (SDK 0.21.0 train). Independent of #164; trivial CHANGELOG conflict expected with sibling PRs.

## What

Three incompatible renderer-selection keys circulate today: docs recommended `{"object_type": ...}`, `MediaMetadataBuilder` emits `media_class`, but the application discovers renderers ONLY via `builtin_object_type` (canonical `PJ::sdk::name()` values, e.g. `"kImage"`). Emitting the wrong key leaves an object topic silently invisible. This PR makes `builtin_object_type` the one canonical key at the SDK level.

- **`ObjectTopicMetadataBuilder`**: accepts `BuiltinObjectType` only (never free-form strings); validates via `parse(name(type))` round-trip (rejects `kNone`, reserved values, unknown casts); deterministic key order (canonical key first, then lexicographic); correct JSON escaping via a shared `detail` escaper (`MediaMetadataBuilder` now reuses it — byte-for-byte output-equivalent to its old private helper).
- **Non-elidable validation**: invalid input puts the builder into a persistent error state (clearing any earlier valid type) and `build()` returns `Expected<std::string>` — behavior does not degrade under `NDEBUG`. Typed registration on invalid metadata returns the error and never touches the vtable.
- **Typed registration sugar** on `SourceObjectWriteHostView` / toolbox views (`registerTopic` / `registerObjectTopic` / `registerObjectTopicOnDataset` overloads taking `BuiltinObjectType`), constrained so existing `registerTopic("x", {})` calls keep binding the raw string overload (covered by a compile-time test). No C-ABI changes.
- **Doc corrections** across the toolbox guide, builtin-type docs, header comments, and the plugin-authoring skill reference: `media_class` does not select a renderer.

## Verification

54/54 ctest, warnings-as-errors, pre-commit clean; independent adversarial review passed after fixes (release-mode validation, `{}` overload compatibility, missed authoring doc); release-mode invalid-input tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)