### PR TITLE
fix(tests): suppress GCC 14 maybe-uninitialized false positive in parser library test

### DIFF
--- a/pj_plugins/tests/message_parser_library_test.cpp
+++ b/pj_plugins/tests/message_parser_library_test.cpp
@@ -104,6 +104,13 @@ TEST(MessageParserLibraryTest, HandleKeepsSharedLibraryLoadedAfterLibraryObjectD
   handle.reset();
 }
 
+// GCC 14's -O2 inliner falsely reports the moved-into optional's std::any
+// payload as maybe-uninitialized when ~ObjectRecord() is fully inlined
+// (observed with GCC 14.4). Clang has no -Wmaybe-uninitialized group.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 TEST(MessageParserLibraryTest, FunctionalObjectRemainsHostOwnedAfterPluginAndLibraryDie) {
   functional_plugin_unloaded = false;
   std::optional<PJ::sdk::ObjectRecord> record;
@@ -140,6 +147,9 @@ TEST(MessageParserLibraryTest, FunctionalObjectRemainsHostOwnedAfterPluginAndLib
 
   record.reset();  // host-side destruction must not jump into the unloaded DSO
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 TEST(MessageParserLibraryTest, LoadNonexistentFails) {
   auto result = PJ::MessageParserLibrary::load("/nonexistent_path/fake_plugin.so");


### PR DESCRIPTION
## Problem

PJ4's pixi CI (conda GCC 14.4, `-O2 -Werror`) fails to compile `pj_plugins/tests/message_parser_library_test.cpp`:

```
include/c++/any:332:46: error: '...std::any::_M_manager' may be used uninitialized [-Werror=maybe-uninitialized]
```

The warning fires inside `MessageParserLibraryTest.FunctionalObjectRemainsHostOwnedAfterPluginAndLibraryDie` when GCC 14's inliner flattens `std::optional<ObjectRecord>`'s destructor chain. It is a false positive: the optional is only engaged via `record = std::move(*parsed)` and every later access is guarded by `has_value()` assertions. This is the SDK-side half of the PJ4 `release-4.0` baseline-CI repair (the "SDK GCC 14.4 false-positive warning" debt noted in the marketplace production-readiness review).

## Fix

Scope a GCC-only `#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"` around the single affected test, mirroring the existing `-Winvalid-offsetof` suppression in `message_parser_abi_layout_sentinels_test.cpp`. The guard excludes clang (`!defined(__clang__)`) because clang has no `-Wmaybe-uninitialized` group and would emit `-Wunknown-warning-option` under `-Werror` on macOS CI.

No behavior change; test-only. No version bump (invisible to consumers).

## Verification

- Local `./build.sh && ./test.sh`: 64/64 tests pass.
- Authoritative GCC 14.4 validation happens on the PJ4 `release-4.0` prep PR that bumps the submodule to this commit (its pixi job is the environment that fails today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)