### PR TITLE
fix(message-parser): gate the functional route on the bound schema

### DIFF
--- a/pj_plugins/include/pj_plugins/sdk/detail/message_parser_trampolines.hpp
+++ b/pj_plugins/include/pj_plugins/sdk/detail/message_parser_trampolines.hpp
@@ -124,11 +124,18 @@ inline const void* MessageParserPluginBase::trampoline_get_plugin_extension(void
   auto* self = static_cast<MessageParserPluginBase*>(ctx);
   try {
     std::string_view sv = id.data == nullptr ? std::string_view{} : std::string_view(id.data, id.size);
-    // Do not falsely advertise the functional route for a newly rebuilt
-    // plugin that still implements only legacy parse(). Schema handlers may
-    // be registered in the constructor or bindSchema(); hosts query again
-    // after binding and do not cache an earlier absence.
-    if (sv == PJ_PARSER_FUNCTIONAL_EXTENSION_V1 && !self->handlers_.empty()) {
+    // Once a schema is bound, advertise the functional route only if THIS
+    // schema has a handler. A mixed-model plugin may register handlers for
+    // some schemas and keep legacy parse() for the rest; gating on "any
+    // handler exists" would make the host prefer a functional route that
+    // parseScalars/parseObject then reject for the unhandled schema. Before
+    // binding, any registered handler still advertises the capability, since
+    // no schema-specific answer exists yet and hosts query again after
+    // binding without caching an earlier absence.
+    const bool functional_route_available = self->bound_type_name_.empty()
+                                                ? !self->handlers_.empty()
+                                                : self->findSchemaHandler(self->bound_type_name_) != nullptr;
+    if (sv == PJ_PARSER_FUNCTIONAL_EXTENSION_V1 && functional_route_available) {
       static const PJ_parser_functional_v1_t extension{
           .struct_size = sizeof(PJ_parser_functional_v1_t),
           .parse_scalars = trampoline_parse_scalars_functional,

--- a/pj_plugins/tests/message_parser_functional_extension_test.cpp
+++ b/pj_plugins/tests/message_parser_functional_extension_test.cpp
@@ -78,6 +78,23 @@ class CustomExtensionParser final : public PJ::MessageParserPluginBase {
   int marker_ = 17;
 };
 
+/// Registers a handler for one schema and keeps legacy parse() for every
+/// other schema — the mixed model the parse() doc-comment sanctions.
+class MixedModelParser final : public PJ::MessageParserPluginBase {
+ public:
+  MixedModelParser() {
+    PJ::sdk::SchemaHandler handler;
+    handler.parse_scalars = [](PJ::Timestamp, PJ::Span<const uint8_t>) -> PJ::Expected<PJ::sdk::ScalarRecord> {
+      return PJ::sdk::ScalarRecord{};
+    };
+    registerSchemaHandler(kSchema, std::move(handler));
+  }
+
+  PJ::Status parse(PJ::Timestamp, PJ::Span<const uint8_t>) override {
+    return PJ::okStatus();
+  }
+};
+
 class BindRegisteredParser final : public PJ::MessageParserPluginBase {
  public:
   PJ::Status bindSchema(std::string_view type_name, PJ::Span<const uint8_t> schema) override {
@@ -273,6 +290,32 @@ TEST(MessageParserFunctionalExtension, HandlerRegisteredDuringBindEnablesExtensi
   EXPECT_FALSE(handle.supportsFunctionalParsing());
   ASSERT_TRUE(handle.bindSchema("dynamic/Type", {}));
   EXPECT_TRUE(handle.supportsFunctionalParsing());
+}
+
+TEST(MessageParserFunctionalExtension, MixedModelParserAdvertisesOnlyForHandledSchemas) {
+  PJ::MessageParserHandle handled(parserVtable<MixedModelParser>());
+  ASSERT_TRUE(handled.bindSchema(kSchema, {}));
+  EXPECT_TRUE(handled.supportsFunctionalParsing());
+
+  // The same plugin bound to a schema it only implements through legacy
+  // parse() must not claim the functional route, or the host would take a
+  // route that parseScalars/parseObject can only reject.
+  PJ::MessageParserHandle unhandled(parserVtable<MixedModelParser>());
+  ASSERT_TRUE(unhandled.bindSchema("example/Unhandled", {}));
+  EXPECT_FALSE(unhandled.supportsFunctionalParsing());
+  const auto status = unhandled.parseScalarsFunctional(
+      0, {}, [](std::optional<PJ::Timestamp>, PJ::Span<const PJ_named_field_value_t>) { return PJ::okStatus(); });
+  EXPECT_FALSE(status);
+  EXPECT_NE(status.error().find(PJ_PARSER_FUNCTIONAL_EXTENSION_V1), std::string::npos);
+}
+
+TEST(MessageParserFunctionalExtension, RebindingToAnUnhandledSchemaWithdrawsTheFunctionalRoute) {
+  PJ::MessageParserHandle handle(parserVtable<MixedModelParser>());
+  ASSERT_TRUE(handle.bindSchema(kSchema, {}));
+  ASSERT_TRUE(handle.supportsFunctionalParsing());
+
+  ASSERT_TRUE(handle.bindSchema("example/Unhandled", {}));
+  EXPECT_FALSE(handle.supportsFunctionalParsing());
 }
 
 TEST(MessageParserFunctionalExtension, LegacyParserWithoutExtensionRemainsDetectable) {


### PR DESCRIPTION
Closes #171.

## Problem

`trampoline_get_plugin_extension` advertised `pj.parser_functional.v1` whenever the instance had **any** registered `SchemaHandler`:

```cpp
if (sv == PJ_PARSER_FUNCTIONAL_EXTENSION_V1 && !self->handlers_.empty()) {
```

But `parseScalars`/`parseObject` are `final` and dispatch on the **bound** schema, erroring with `"parser does not register schema: <bound>"` when that specific schema has no handler. So a mixed-model plugin — handlers for some schemas, legacy `parse()` for the rest, which is exactly the shape `parse()`'s own doc-comment sanctions ("a fallback for type names not in the registered table (e.g. a ROS-style generic flattener)") — claimed the functional route on **every** schema. An SDK 0.21 host that prefers that route then fails every message on the unhandled topics.

This isn't hypothetical: PJ4's `streaming_caching_parser_plugin` test fixture had this shape and went zero-rows the moment the host started preferring the functional route; it had to have its handler removed to keep working.

## Fix

Once a schema is bound, advertisement requires a handler for **that** schema. Before binding, any registered handler still advertises the capability — no schema-specific answer exists yet, and hosts are already required to re-query after binding rather than cache an earlier absence (the contract `HandlerRegisteredDuringBindEnablesExtensionWithoutCapabilityCaching` pins).

Header-inline behavior change only: no ABI, vtable, protocol, `struct_size`, or member-layout change; `abi/baseline.abi` untouched.

## Tests

Two new cases, both observed failing before the fix with `Actual: true` (i.e. they reproduce the bug), passing after:

- `MixedModelParserAdvertisesOnlyForHandledSchemas` — a plugin with a handler for `example/Image` plus legacy `parse()`: bound to the handled schema it advertises; bound to `example/Unhandled` it does **not**, and `parseScalarsFunctional` reports the extension as unavailable rather than the host discovering it via a per-message parse error.
- `RebindingToAnUnhandledSchemaWithdrawsTheFunctionalRoute` — advertisement follows a re-bind in both directions.

Pre-existing contracts verified unchanged: `NewlyBuiltParserExposesStableExtensionAutomatically` (pre-bind capability advertisement) and `HandlerRegisteredDuringBindEnablesExtensionWithoutCapabilityCaching` (handler registered during `bindSchema`) both still pass. Full suite green (64/64).

## Release

Per the versioning policy this is a **PATCH**-level fix to installed-header behavior; I propose `0.21.1` when a release is next cut. Following the precedent of #169 (same class of fix) I have **not** bumped `VERSION` in this PR, and have not tagged anything. Note that open PRs #172/#173 currently claim `0.22.0`/`0.23.0`.

## Downstream

No PJ4 change is required — its parser host already re-queries `supportsFunctionalParsing()` per call on both routes, so it simply stops taking the functional route for unhandled schemas. This should land before the official plugin fleet rebuilds on 0.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)