### PR TITLE
docs(changelog): fold the 0.25.1 entry into 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to `plotjuggler_sdk` are recorded here. Versioning policy is in
 [`CLAUDE.md`](./CLAUDE.md) → "Release Versioning".
 
-## [0.25.1]
-
-### Fix: cache cleanup revalidates scanned files before removal (PATCH)
-
-Descriptor-import cache cleanup now rechecks an artifact's size and LRU stamp under its
-exclusive identity lock before eviction, and rechecks an orphan partial's age before removal.
-Files replaced, refreshed, or removed after the single cleanup scan are skipped without error.
-
 ## [0.25.0]
 
 ### Feature: plugin-authoring CMake helpers ship with the SDK (MINOR)
@@ -44,6 +36,12 @@ are now kept exported automatically (no need to repeat them in `EXTRA_EXPORTS`).
 
 Plugins that adopt these helpers pin `plotjuggler_sdk/[>=0.25.0 <1.0.0]`. No ABI change;
 `abi/baseline.abi` is untouched.
+
+### Fix: cache cleanup revalidates scanned files before removal
+
+Descriptor-import cache cleanup now rechecks an artifact's size and LRU stamp under its
+exclusive identity lock before eviction, and rechecks an orphan partial's age before removal.
+Files replaced, refreshed, or removed after the single cleanup scan are skipped without error.
 
 ## [0.24.0]
 


### PR DESCRIPTION
0.25.0 was never published before the descriptor-import cleanup fix (#180) landed and `VERSION` was set back to 0.25.0 (6412d9e), so the fix shipped in the v0.25.0 release. This moves its CHANGELOG entry under `[0.25.0]` as a second subsection and drops the `[0.25.1]` heading. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)