### PR TITLE
feat(sdk): dataset-qualified names + pj.playback/viewport/plot_tabs host services (0.28.0)

### DIFF
--- a/.claude/skills/plotjuggler-plugin/references/toolbox.md
+++ b/.claude/skills/plotjuggler-plugin/references/toolbox.md
@@ -65,6 +65,18 @@ PJ_TOOLBOX_PLUGIN(MyToolbox,
   it returns a nullable `const ToolboxObjectReadHostView*`. Null-check it before
   reading ObjectStore data.
 - **`runtimeHost()`** — control plane: `notifyDataChanged()`, `reportMessage()`.
+- **SDK 0.28.0 optional services**, via `services().get<T>()` from
+  `pj_base/sdk/service_traits.hpp`: `PlaybackHostService`, `ViewportHostService`,
+  and `PlotTabHostService`. Playback is global; viewport and tabs are scoped to
+  the caller's own tabs. Tab IDs are independent of visible titles and indices.
+  Prefer `playback->toDisplayTimeForSource(source_handle, absolute_ns)` for
+  dataset-specific time conversion; get the handle from catalog `dataSources()`
+  or a topic's `source`. Check errors: older hosts may lack the tail slot, and
+  unloaded handles fail. `toDisplayTime(topic, ns)` rejects ambiguous topics;
+  empty topic explicitly selects the representative dataset. Recompute display
+  seconds after offset edits. Full examples and the catalog-dependent
+  `dataset_source:topic/field` lookup rules are in
+  `pj_plugins/docs/toolbox-guide.md` → "Playback, viewport, and owned tabs".
 
 ## Reading a series (Arrow)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,14 @@ as `PJ.Vector2` on the wire). The `PointField` wire helpers shared by the PointC
 VoxelGrid and GridMap codecs now live in one private header. Additive: no existing struct,
 slot, or wire format changes.
 
+### Fixed — `deserializePlotMarkers` accepts the empty buffer as an empty set
+
+An empty buffer is the canonical proto encoding of an empty `PlotMarkers` set —
+the "clear my markers" tombstone a producer publishes to a replace-only store —
+but the decoder rejected `size == 0` as an error, making the tombstone
+unrepresentable on the wire. It now decodes to an empty set; null-with-size,
+truncated, and malformed payloads still error.
+
 ## [0.25.0]
 
 ### Feature: plugin-authoring CMake helpers ship with the SDK (MINOR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,78 @@ value into range. Negative inputs are rebased toward zero before multiplication,
 the conversion stays checked and C++17-compatible at both signed boundaries. Invalid
 nanosecond fractions and final overflow remain rejected. No API or ABI change.
 
+### Feature: dataset-qualified series names — contract and shared helper (MINOR)
+
+`pj.data_processors.v1` addressed input series by bare `topic/field` names and never said
+what a name means when several loaded datasets share topic names — so conforming hosts
+filled the gap incompatibly (PJ4's transform path refused duplicates while its marker path
+silently bound the first-loaded dataset; fixed by PlotJuggler/PJ4#619). The contract is now
+explicit in the `PJ_data_processors_host_vtable_t` doc block (DATASET-QUALIFIED NAMES):
+
+- A series' full identity is (dataset, topic, field); a bare name is an abbreviation. An
+  input MAY carry the qualifier `dataset_source:topic/field` — the same form hosts print
+  as a series identity, so displayed names round-trip as inputs.
+- The qualifier is matched against the **loaded** source names (longest match wins), never
+  split blindly at `:` — stream-style source names like `[stream] UDP Server` need no
+  escaping.
+- A qualifier matching no loaded dataset is an error (no fallback to the bare reading); a
+  bare name that exists in several datasets MUST be refused with the qualified candidates,
+  never resolved by load order; qualified inputs of one processor must agree on a single
+  dataset. Marker per-series output keys accept the qualifier the same way.
+
+New installed header `pj_base/sdk/dataset_qualified_name.hpp` ships the shared
+parser/composer (`splitDatasetQualifier` / `qualifiedSeriesName`, header-only) so hosts
+and plugins use one implementation instead of the two copies that exist today.
+
+Plugins that emit qualified names pin `plotjuggler_sdk/[>=0.28.0 <1.0.0]`. No ABI change;
+`abi/baseline.abi` is untouched. Addressing two datasets that share one source name stays
+out of contract (ambiguous → error); a typed dataset id would be a tail-appended addition.
+
+### Added — host services `pj.playback.v1` and `pj.viewport.v1` (MINOR, additions only)
+
+Two new optional host services so a plugin (first consumer: the Assistant Agent
+toolbox) can drive the app like a user — transport and zoom — without any new
+executable surface crossing the ABI:
+
+- **`pj.playback.v1`** (`PJ_playback_host_vtable_t`, `sdk::PlaybackHostView`,
+  `sdk::PlaybackHostService`): `play` / `pause` / `seek` / `set_playback_rate` /
+  `get_state` (ABI-frozen `PJ_playback_state_t` snapshot) / `to_display_time`
+  (absolute int64 ns → display-axis seconds, per-topic dataset offset;
+  current-frame semantics). All times are display-axis seconds.
+- **`pj.viewport.v1`** (`PJ_viewport_host_vtable_t`, `sdk::ViewportHostView`,
+  `sdk::ViewportHostService`): `zoom_to_time_range` (X window in display-axis
+  seconds; per-plot Y preserved; XY/empty plots untouched) and `zoom_reset`
+  (fit). Both are **scoped to the tabs the calling plugin owns** — see
+  `pj.plot_tabs.v1` below; a plugin owning none has nothing to zoom, which is an
+  error rather than a silent no-op.
+- **`pj.plot_tabs.v1`** (`PJ_plot_tab_host_vtable_t`, `sdk::PlotTabHostView`,
+  `sdk::PlotTabHostService`): a plugin composes plotting tabs of its own —
+  `create_tab` / `close_tab` / `list_tab_ids` / `tab_config` / `add_curve` /
+  `remove_curve` / `clear_tab`. Ids are plugin-chosen and namespaced per plugin
+  (the `pj.data_processors.v1` discipline), and every slot is scoped to the
+  caller's own tabs, so the user's tabs are neither disclosed nor mutable
+  through it. Curves are addressed by their parts — topic, field, dataset
+  source — rather than a joined path, because field paths contain `/` and
+  dataset names contain `:`, and an empty dataset source requires the pair to be
+  unique. `tab_config` reads back what a tab actually holds, so a caller can
+  report what was drawn instead of what it asked for.
+
+The boundary these two draw is the VIEW. `pj.playback.v1` stays global by
+nature: one time cursor is shared by every plot.
+
+No existing struct or vtable slot was touched — every already-built plugin keeps
+working with no recompile (`abidiff`: additions only). `pj.viewport.v1`'s two
+slots keep their signatures; only their documented scope narrowed, and it has
+never shipped.
+
+### Fixed — `deserializePlotMarkers` accepts the empty buffer as an empty set
+
+An empty buffer is the canonical proto encoding of an empty `PlotMarkers` set —
+the "clear my markers" tombstone a producer publishes to a replace-only store —
+but the decoder rejected `size == 0` as an error, making the tombstone
+unrepresentable on the wire. It now decodes to an empty set; null-with-size,
+truncated, and malformed payloads still error.
+
 ## [0.27.1]
 
 ### Fix: hosts validate a spliced `GridMap` right after attaching its bytes (PATCH)
@@ -90,14 +162,6 @@ parser-module `ObjectWriter`, and `sdk::Vector2` in the geometry vocabulary (alr
 as `PJ.Vector2` on the wire). The `PointField` wire helpers shared by the PointCloud,
 VoxelGrid and GridMap codecs now live in one private header. Additive: no existing struct,
 slot, or wire format changes.
-
-### Fixed — `deserializePlotMarkers` accepts the empty buffer as an empty set
-
-An empty buffer is the canonical proto encoding of an empty `PlotMarkers` set —
-the "clear my markers" tombstone a producer publishes to a replace-only store —
-but the decoder rejected `size == 0` as an error, making the tombstone
-unrepresentable on the wire. It now decodes to an empty set; null-with-size,
-truncated, and malformed payloads still error.
 
 ## [0.25.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,9 @@ Plugins that emit qualified names pin `plotjuggler_sdk/[>=0.28.0 <1.0.0]`. No AB
 `abi/baseline.abi` is untouched. Addressing two datasets that share one source name stays
 out of contract (ambiguous → error); a typed dataset id would be a tail-appended addition.
 
-### Added — host services `pj.playback.v1` and `pj.viewport.v1` (MINOR, additions only)
+### Added — host services `pj.playback.v1`, `pj.viewport.v1`, and `pj.plot_tabs.v1` (MINOR)
 
-Two new optional host services so a plugin (first consumer: the Assistant Agent
+Three new optional host services so a plugin (first consumer: the Assistant Agent
 toolbox) can drive the app like a user — transport and zoom — without any new
 executable surface crossing the ABI:
 
@@ -96,15 +96,15 @@ executable surface crossing the ABI:
   source — rather than a joined path, because field paths contain `/` and
   dataset names contain `:`, and an empty dataset source requires the pair to be
   unique. `tab_config` reads back what a tab actually holds, so a caller can
-  report what was drawn instead of what it asked for.
+  report what was drawn instead of what it asked for. The C++ list wrapper
+  reports an error if the count grows between enumeration calls, allowing a
+  retry without reading past the allocated buffer.
 
 The boundary these two draw is the VIEW. `pj.playback.v1` stays global by
 nature: one time cursor is shared by every plot.
 
-No existing struct or vtable slot was touched — every already-built plugin keeps
-working with no recompile (`abidiff`: additions only). `pj.viewport.v1`'s two
-slots keep their signatures; only their documented scope narrowed, and it has
-never shipped.
+These services add new types without changing existing vtable slots, so
+already-built plugins keep working with no recompile.
 
 ### Added — `QListWidget` row context menu: `onItemContextAction` (MINOR, additions only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,13 @@ explicit in the `PJ_data_processors_host_vtable_t` doc block (DATASET-QUALIFIED 
 
 - A series' full identity is (dataset, topic, field); a bare name is an abbreviation. An
   input MAY carry the qualifier `dataset_source:topic/field` — the same form hosts print
-  as a series identity, so displayed names round-trip as inputs.
+  as a series label. This is a catalog-dependent lookup syntax.
 - The qualifier is matched against the **loaded** source names (longest match wins), never
   split blindly at `:` — stream-style source names like `[stream] UDP Server` need no
-  escaping.
-- A qualifier matching no loaded dataset is an error (no fallback to the bare reading); a
-  bare name that exists in several datasets MUST be refused with the qualified candidates,
+  escaping. Colons in both source and bare names can create overlapping prefixes;
+  composition round-trips only while the intended source is the longest loaded match.
+- An unmatched prefix leaves the entire name as a bare lookup, without stripping it;
+  unknown whole names fail. A bare name in several datasets MUST be refused with qualified candidates,
   never resolved by load order; qualified inputs of one processor must agree on a single
   dataset. Marker per-series output keys accept the qualifier the same way.
 
@@ -79,7 +80,12 @@ executable surface crossing the ABI:
   `sdk::PlaybackHostService`): `play` / `pause` / `seek` / `set_playback_rate` /
   `get_state` (ABI-frozen `PJ_playback_state_t` snapshot) / `to_display_time`
   (absolute int64 ns → display-axis seconds, per-topic dataset offset;
-  current-frame semantics). All times are display-axis seconds.
+  current-frame semantics). Nonempty topics must identify exactly one dataset;
+  unknown or ambiguous topics fail. The optional tail slot `to_display_time_for_source`
+  (`sdk::PlaybackHostView::toDisplayTimeForSource`) selects a catalog data-source
+  handle explicitly, allowing conversion when topic or source names repeat. Invalid
+  or unloaded handles fail. Its wrapper checks `struct_size` and reports unsupported
+  on older hosts, preserving the existing topic-based call. All times are display-axis seconds.
 - **`pj.viewport.v1`** (`PJ_viewport_host_vtable_t`, `sdk::ViewportHostView`,
   `sdk::ViewportHostService`): `zoom_to_time_range` (X window in display-axis
   seconds; per-plot Y preserved; XY/empty plots untouched) and `zoom_reset`
@@ -90,7 +96,9 @@ executable surface crossing the ABI:
   `sdk::PlotTabHostService`): a plugin composes plotting tabs of its own —
   `create_tab` / `close_tab` / `list_tab_ids` / `tab_config` / `add_curve` /
   `remove_curve` / `clear_tab`. Ids are plugin-chosen and namespaced per plugin
-  (the `pj.data_processors.v1` discipline), and every slot is scoped to the
+  (the `pj.data_processors.v1` discipline). IDs are independent of visible titles,
+  which may repeat or be renamed; recreating an ID replaces its tab contents.
+  Every slot is scoped to the
   caller's own tabs, so the user's tabs are neither disclosed nor mutable
   through it. Curves are addressed by their parts — topic, field, dataset
   source — rather than a joined path, because field paths contain `/` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,17 @@ working with no recompile (`abidiff`: additions only). `pj.viewport.v1`'s two
 slots keep their signatures; only their documented scope narrowed, and it has
 never shipped.
 
+### Added — `QListWidget` row context menu: `onItemContextAction` (MINOR, additions only)
+
+A dialog plugin can now learn that a row's right-click context menu fired one
+of its actions: `WidgetEventBuilder::itemContextAction(index, action_id)` /
+`WidgetEvent::itemContextAction()` (the pair, optional) /
+`DialogPluginTyped::onItemContextAction(widget_name, index, action_id)`,
+dispatched ahead of the selection/double-click chain. The action set itself is
+not part of this ABI — it is a host-side `.ui` dynamic property
+(`pj_context_actions`, see `dialog-plugin-guide.md`), the same shape as
+`pj_enable_when`/`pj_visible_when`. No struct or vtable slot changed.
+
 ### Fixed — `deserializePlotMarkers` accepts the empty buffer as an empty set
 
 An empty buffer is the canonical proto encoding of an empty `PlotMarkers` set —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ documentation check before commit.
 **Plugin system** (`pj_plugins/docs/`): `REQUIREMENTS.md` (families, capability system, config
 contract) · `ARCHITECTURE.md` (C ABI protocols, SDK base classes, host loaders, dialog protocol) ·
 `data-source-guide.md` · `message-parser-guide.md` · `dialog-plugin-guide.md` · `toolbox-guide.md`.
+For SDK 0.28.0 playback, plugin-owned tabs, viewport control, and dataset-qualified
+inputs, start with `pj_plugins/docs/toolbox-guide.md` → "Playback, viewport, and
+owned tabs". It covers explicit source-handle time conversion, optional-slot
+compatibility, tab ID/title separation, and qualifier limits. The normative C
+contract is `pj_base/include/pj_base/plugin_data_api.h`; C++ wrappers and service
+traits live alongside it under `sdk/`.
 The concise native functional-module authoring reference is
 `.claude/skills/plotjuggler-plugin/references/parser-module.md`.
 

--- a/docs/dialog-sdk-reference.md
+++ b/docs/dialog-sdk-reference.md
@@ -511,11 +511,15 @@ public:
 };
 ```
 
-## Conditional field enabling (`pj_enable_when`)
+## Conditional field enabling and visibility (`pj_enable_when`, `pj_visible_when`)
 
-Declarative, host-driven enable/disable: give any widget the string dynamic
-property `pj_enable_when` = `"<comboObjectName>:<index>[,<index>...]"` and it
-stays enabled only while that combo sits on one of the listed indices. Works
-inside modal sub-dialogs (where the plugin cannot push widget data); rules
-re-assert after every widget-data apply. Malformed/unresolvable rules are
-ignored. See dialog-plugin-guide.md → "Optional: conditional field enabling".
+Declarative, host-driven: give any widget the string dynamic property
+`pj_enable_when` (or `pj_visible_when`) = `"<comboObjectName>:<index>[,<index>...]"`
+and it stays enabled (or visible) only while that combo sits on one of the
+listed indices. Several clauses separated by `;` must ALL hold
+(`"backendCombo:0;modelCombo:1"`). Works inside modal sub-dialogs (where the
+plugin cannot push widget data); rules re-assert after every widget-data apply,
+so a rule wins over a plugin-pushed `enabled`/`visible`. A hidden widget leaves
+its layout row: tag the label and the editor of a form row both, and the row
+collapses. Malformed/unresolvable rules are ignored. See dialog-plugin-guide.md
+→ "Optional: conditional field enabling and visibility".

--- a/docs/dialog-sdk-reference.md
+++ b/docs/dialog-sdk-reference.md
@@ -510,3 +510,12 @@ public:
   }
 };
 ```
+
+## Conditional field enabling (`pj_enable_when`)
+
+Declarative, host-driven enable/disable: give any widget the string dynamic
+property `pj_enable_when` = `"<comboObjectName>:<index>[,<index>...]"` and it
+stays enabled only while that combo sits on one of the listed indices. Works
+inside modal sub-dialogs (where the plugin cannot push widget data); rules
+re-assert after every widget-data apply. Malformed/unresolvable rules are
+ignored. See dialog-plugin-guide.md → "Optional: conditional field enabling".

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -153,6 +153,7 @@ if(PJ_BUILD_TESTS)
     tests/parser_module_manifest_test.cpp
     tests/data_processors_api_test.cpp
     tests/playback_viewport_api_test.cpp
+    tests/plot_tabs_api_test.cpp
     tests/settings_store_host_test.cpp
     tests/parser_runtime_host_test.cpp
     tests/data_source_protocol_test.cpp

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -152,6 +152,7 @@ if(PJ_BUILD_TESTS)
     tests/parser_module_abi_test.cpp
     tests/parser_module_manifest_test.cpp
     tests/data_processors_api_test.cpp
+    tests/playback_viewport_api_test.cpp
     tests/settings_store_host_test.cpp
     tests/parser_runtime_host_test.cpp
     tests/data_source_protocol_test.cpp

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -154,7 +154,7 @@ if(PJ_BUILD_TESTS)
     tests/data_processors_api_test.cpp
     tests/playback_viewport_api_test.cpp
     tests/plot_tabs_api_test.cpp
-    tests/dataset_qualified_name_test.cpp
+    tests/dataset_qualified_name_api_test.cpp
     tests/settings_store_host_test.cpp
     tests/parser_runtime_host_test.cpp
     tests/data_source_protocol_test.cpp

--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -154,6 +154,7 @@ if(PJ_BUILD_TESTS)
     tests/data_processors_api_test.cpp
     tests/playback_viewport_api_test.cpp
     tests/plot_tabs_api_test.cpp
+    tests/dataset_qualified_name_test.cpp
     tests/settings_store_host_test.cpp
     tests/parser_runtime_host_test.cpp
     tests/data_source_protocol_test.cpp

--- a/pj_base/include/pj_base/builtin/plot_markers_codec.hpp
+++ b/pj_base/include/pj_base/builtin/plot_markers_codec.hpp
@@ -20,7 +20,10 @@ inline constexpr std::string_view kSchemaPlotMarkers = "PJ.PlotMarkers";
 
 /// Decodes canonical PJ.PlotMarkers wire bytes into sdk::PlotMarkers.
 ///
-/// Returns an error for null, empty, truncated, or malformed payloads.
+/// An EMPTY buffer decodes to an empty set — the canonical "no markers"
+/// tombstone a producer publishes to clear its output (the object store is
+/// replace-only; markers are overwritten, never deleted). Returns an error for
+/// null-with-size, truncated, or malformed payloads.
 [[nodiscard]] Expected<sdk::PlotMarkers> deserializePlotMarkers(const uint8_t* data, size_t size);
 
 }  // namespace PJ

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -249,6 +249,15 @@ typedef struct {
  * Every populator (see sdk::fillError) MUST clear both new slots when
  * writing to avoid stale pointers in reused error structs.
  */
+/* Shared host-service error-code convention. Codes are domain-specific in
+ * general, but every PJ host service distinguishes at least these two classes,
+ * and aggregators (e.g. a kind router probing multiple backends) rely on the
+ * distinction: REJECTED means "this request is not mine / not valid" (safe to
+ * try another backend), INTERNAL means a real failure on a request the backend
+ * owns (must be surfaced, never masked by a fallback). */
+#define PJ_ERROR_CODE_REJECTED 1
+#define PJ_ERROR_CODE_INTERNAL 2
+
 typedef struct {
   int32_t code;                          /* 0 = success; otherwise domain-specific */
   char domain[PJ_ERROR_DOMAIN_MAX];      /* null-terminated; truncated if too long */

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -1120,23 +1120,38 @@ typedef struct {
 /**
  * Viewport host service ("pj.viewport.v1", protocol_version 1).
  *
- * Optional zoom control over the host's open time-series plots. All slots are
- * [main-thread]. Times are display-axis seconds (same convention as
- * "pj.playback.v1"). ABI-APPENDABLE: new slots may be added at the tail;
+ * Optional zoom control, SCOPED to the tabs the calling plugin owns (see
+ * "pj.plot_tabs.v1"). A host that grants a plugin its own tabs must confine
+ * these slots to them: the user's plots are not a plugin's to reframe. A
+ * plugin owning no tab therefore has nothing to zoom, which is an error, not a
+ * silent no-op.
+ *
+ * That makes this service dependent on the other in practice, even though the
+ * registry treats the two as independently optional: a host offering this one
+ * WITHOUT "pj.plot_tabs.v1" leaves every plugin with nothing it may zoom, so
+ * these two are registered together or not at all.
+ *
+ * Note the boundary is the VIEW, not the transport: "pj.playback.v1" stays
+ * global by nature, since one time cursor is shared by every plot.
+ *
+ * All slots are [main-thread]. Times are display-axis seconds (same convention
+ * as "pj.playback.v1"). ABI-APPENDABLE: new slots may be added at the tail;
  * struct_size gates read.
  */
 typedef struct PJ_viewport_host_vtable_t {
   uint32_t protocol_version; /* = 1 */
   uint32_t struct_size;      /* = sizeof(PJ_viewport_host_vtable_t) */
 
-  /* [main-thread] Set every open time-series plot's visible X window to
-   * [t0_s, t1_s] (display-axis seconds). Each plot keeps its own Y range;
-   * XY plots and empty plots are untouched. Requires finite t0_s < t1_s;
-   * no open time plot to act on is an error. */
+  /* [main-thread] Set the visible X window of every time-series plot the
+   * calling plugin owns to [t0_s, t1_s] (display-axis seconds). Each plot keeps
+   * its own Y range; XY plots and empty plots are untouched. Requires finite
+   * t0_s < t1_s. Owning no such plot is an error, and the host is expected to
+   * say which kind — no tab at all, or a tab with nothing to zoom — since the
+   * caller's remedy differs. */
   bool (*zoom_to_time_range)(void* ctx, double t0_s, double t1_s, PJ_error_t* out_error) PJ_NOEXCEPT;
 
-  /* [main-thread] Reset every open plot to fit its data (the host's
-   * "zoom out all" action). */
+  /* [main-thread] Reset every plot the calling plugin owns to fit its data.
+   * Like zoom_to_time_range, owning nothing is an error. */
   bool (*zoom_reset)(void* ctx, PJ_error_t* out_error) PJ_NOEXCEPT;
 } PJ_viewport_host_vtable_t;
 
@@ -1144,6 +1159,98 @@ typedef struct {
   void* ctx;
   const PJ_viewport_host_vtable_t* vtable;
 } PJ_viewport_host_t;
+
+/**
+ * Plot-tab host service ("pj.plot_tabs.v1", protocol_version 1).
+ *
+ * Lets a plugin compose plotting tabs OF ITS OWN: create one, place and remove
+ * curves in it, read back what it holds, close it. Every slot is scoped to the
+ * calling binding — a tab this plugin did not create is rejected exactly as an
+ * unknown id is, so the service never discloses, mutates or even confirms the
+ * existence of the user's tabs. That scoping is the host's job, not the
+ * plugin's: it is enforced where ownership is known, and ownership is derived
+ * from `ctx`, never passed in.
+ *
+ * Ids are chosen by the plugin and namespaced per plugin by the host (the
+ * "pj.data_processors.v1" discipline), so an id is unique within this binding
+ * and cannot collide with another plugin's. The resemblance stops there, and
+ * the difference matters: a data processor's id survives a session reload
+ * because the host replays it from a persisted recipe, whereas a tab is a VIEW
+ * and this service promises nothing of the sort. Treat an id as live only for
+ * as long as `list_tab_ids` still returns it, and re-read rather than assume
+ * after anything that could have rebuilt the workspace.
+ *
+ * A tab created here is the host's to present: it carries whatever permanent
+ * mark the host uses for model-authored views, and the plugin cannot suppress
+ * it. Whether such a tab is saved with the workspace is likewise the host's
+ * policy, not this service's contract.
+ *
+ * All slots are [main-thread]. ABI-APPENDABLE: new slots may be added at the
+ * tail; struct_size gates read.
+ */
+typedef struct PJ_plot_tab_host_vtable_t {
+  uint32_t protocol_version; /* = 1 */
+  uint32_t struct_size;      /* = sizeof(PJ_plot_tab_host_vtable_t) */
+
+  /* [main-thread] Create (or replace, upsert by id) a tab owned by this plugin,
+   * holding one empty plot. An empty `title` lets the host name it. All string
+   * arguments are borrowed for the duration of the call. */
+  bool (*create_tab)(void* ctx, PJ_string_view_t id, PJ_string_view_t title, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Close one of this plugin's tabs. Unknown id is an error.
+   * Closing a tab discards the VIEW only: any derived series or markers drawn
+   * in it are data and outlive it. */
+  bool (*close_tab)(void* ctx, PJ_string_view_t id, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Enumerate the ids of THIS plugin's live tabs.
+   * Count-then-fill: pass capacity 0 to read *out_count, then call again with a
+   * buffer of that size. On success the first min(capacity, *out_count) entries
+   * of out_ids are filled and point into host storage valid only until the next
+   * call on this vtable. Owning no tab is success with *out_count == 0. */
+  bool (*list_tab_ids)(
+      void* ctx, PJ_string_view_t* out_ids, uint64_t capacity, uint64_t* out_count,
+      PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Read back what a tab actually holds, as JSON
+   * {"title":"...","curves":[{"topic":"...","field":"...","dataset":"..."}]}.
+   * This is how a caller reports what was drawn instead of what it asked for:
+   * a curve the host could not resolve is simply absent. "dataset" is always
+   * the RESOLVED source name, even where the caller left it empty, so the
+   * report says which run a curve actually came from. The host emits valid
+   * JSON: any character needing escaping in a topic or field is escaped here.
+   * *out_config_json is borrowed, valid only until the next call on this
+   * vtable. Unknown id is an error. */
+  bool (*tab_config)(
+      void* ctx, PJ_string_view_t id, PJ_string_view_t* out_config_json, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Draw one curve in a tab of this plugin's. The series is named
+   * by its parts, not a joined path, because field paths legitimately contain
+   * '/' and dataset names contain ':' — splitting a joined form is guesswork the
+   * host should not have to do. An empty `dataset_source` means the topic/field
+   * must be unique across loaded datasets; the host refuses an ambiguous one
+   * with the qualified candidates rather than picking. Adding a curve already
+   * present is not an error. */
+  bool (*add_curve)(
+      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field,
+      PJ_string_view_t dataset_source, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Take one curve back out. `dataset_source` resolves by the
+   * same rule as in add_curve — empty means "the topic/field must be unique" —
+   * so a curve can be removed with whatever form was used to add it, or with
+   * the resolved name tab_config reports. A curve that is not there is an
+   * error, so a mistaken path is visible rather than silently accepted. */
+  bool (*remove_curve)(
+      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field,
+      PJ_string_view_t dataset_source, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Remove every curve from a tab, keeping the tab itself. */
+  bool (*clear_tab)(void* ctx, PJ_string_view_t id, PJ_error_t* out_error) PJ_NOEXCEPT;
+} PJ_plot_tab_host_vtable_t;
+
+typedef struct {
+  void* ctx;
+  const PJ_plot_tab_host_vtable_t* vtable;
+} PJ_plot_tab_host_t;
 
 #ifdef __cplusplus
 }

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -1046,6 +1046,96 @@ typedef struct {
   const PJ_settings_store_vtable_t* vtable;
 } PJ_settings_store_t;
 
+/**
+ * Playback host service ("pj.playback.v1", protocol_version 1).
+ *
+ * Optional programmatic control of the host's playback cursor (the vertical
+ * time tracker the playback slider drives). All slots are [main-thread].
+ *
+ * TIME UNIT: every time in this service is DISPLAY-AXIS SECONDS — the numbers
+ * the plot X axes and the playback slider show — NOT absolute nanoseconds.
+ * Display time is derived from absolute time via per-dataset, user-editable
+ * offsets, so any converted value is valid for the CURRENT frame only:
+ * re-query after the user edits a source offset or the time reference.
+ *
+ * ABI-APPENDABLE: new slots may be added at the tail; struct_size gates read.
+ */
+
+/* ABI-FROZEN: layout permanent; changes = ABI break (add a get_state_v2 slot instead). */
+typedef struct {
+  bool is_playing;
+  double current_time_s; /* display-axis seconds */
+  double range_min_s;    /* playback range in display-axis seconds */
+  double range_max_s;
+  double playback_rate; /* speed multiplier; 1.0 = real time */
+} PJ_playback_state_t;
+
+typedef struct PJ_playback_host_vtable_t {
+  uint32_t protocol_version; /* = 1 */
+  uint32_t struct_size;      /* = sizeof(PJ_playback_host_vtable_t) */
+
+  /* [main-thread] Start advancing the playback cursor. Idempotent. */
+  bool (*play)(void* ctx, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Stop advancing the playback cursor. Idempotent. */
+  bool (*pause)(void* ctx, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Move the cursor to `time_s` (display-axis seconds); the host
+   * clamps into [range_min_s, range_max_s]. Play/pause state is unchanged.
+   * Non-finite time is an error. */
+  bool (*seek)(void* ctx, double time_s, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Set the playback-speed multiplier (> 0; the host may clamp).
+   * Non-finite or non-positive rate is an error. */
+  bool (*set_playback_rate)(void* ctx, double rate, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Snapshot the current playback state. During live streaming
+   * the range (and a cursor glued to its tip) advances on every ingest tick. */
+  bool (*get_state)(void* ctx, PJ_playback_state_t* out_state, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Convert an ABSOLUTE nanosecond timestamp (the unit the data
+   * read/write surfaces speak) into display-axis seconds, using the display
+   * offset of the dataset that owns `topic`. An empty topic uses the host's
+   * representative dataset. Current-frame semantics (see the service
+   * doc-comment). An unknown topic is an error. */
+  bool (*to_display_time)(
+      void* ctx, PJ_string_view_t topic, int64_t absolute_ns, double* out_display_s, PJ_error_t* out_error)
+      PJ_NOEXCEPT;
+} PJ_playback_host_vtable_t;
+
+typedef struct {
+  void* ctx;
+  const PJ_playback_host_vtable_t* vtable;
+} PJ_playback_host_t;
+
+/**
+ * Viewport host service ("pj.viewport.v1", protocol_version 1).
+ *
+ * Optional zoom control over the host's open time-series plots. All slots are
+ * [main-thread]. Times are display-axis seconds (same convention as
+ * "pj.playback.v1"). ABI-APPENDABLE: new slots may be added at the tail;
+ * struct_size gates read.
+ */
+typedef struct PJ_viewport_host_vtable_t {
+  uint32_t protocol_version; /* = 1 */
+  uint32_t struct_size;      /* = sizeof(PJ_viewport_host_vtable_t) */
+
+  /* [main-thread] Set every open time-series plot's visible X window to
+   * [t0_s, t1_s] (display-axis seconds). Each plot keeps its own Y range;
+   * XY plots and empty plots are untouched. Requires finite t0_s < t1_s;
+   * no open time plot to act on is an error. */
+  bool (*zoom_to_time_range)(void* ctx, double t0_s, double t1_s, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Reset every open plot to fit its data (the host's
+   * "zoom out all" action). */
+  bool (*zoom_reset)(void* ctx, PJ_error_t* out_error) PJ_NOEXCEPT;
+} PJ_viewport_host_vtable_t;
+
+typedef struct {
+  void* ctx;
+  const PJ_viewport_host_vtable_t* vtable;
+} PJ_viewport_host_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -947,9 +947,12 @@ typedef struct {
  * qualifier "dataset_source:topic/field" — the same form hosts print as a series
  * identity (shared parser/composer: sdk/dataset_qualified_name.hpp). The qualifier
  * is matched against the LOADED source names (longest match wins), never split
- * blindly at ':', so source names need no escaping. The host MUST enforce:
- *   - a qualifier matching no loaded dataset is an error — no fallback to reading
- *     the whole string as a bare name;
+ * blindly at ':'. This is a catalog-dependent lookup syntax: an unmatched prefix
+ * leaves the ENTIRE string as a bare name; the host must never guess by stripping
+ * it. Colons are legal in both source and bare names, so composition round-trips
+ * only when the intended source remains the longest loaded matching prefix.
+ * The host MUST enforce:
+ *   - an unknown whole name is an error;
  *   - a bare name that exists in SEVERAL loaded datasets is refused, reporting the
  *     qualified candidates — NEVER resolved by load order;
  *   - all qualified inputs of one processor agree on a single dataset.
@@ -1124,9 +1127,20 @@ typedef struct PJ_playback_host_vtable_t {
    * read/write surfaces speak) into display-axis seconds, using the display
    * offset of the dataset that owns `topic`. An empty topic uses the host's
    * representative dataset. Current-frame semantics (see the service
-   * doc-comment). An unknown topic is an error. */
+   * doc-comment). A nonempty topic must identify exactly one loaded dataset;
+   * unknown or ambiguous topics are errors. Use to_display_time_for_source to
+   * select a dataset explicitly when topic names repeat. */
   bool (*to_display_time)(
       void* ctx, PJ_string_view_t topic, int64_t absolute_ns, double* out_display_s, PJ_error_t* out_error) PJ_NOEXCEPT;
+
+  /* [main-thread] Convert absolute nanoseconds using the display offset of
+   * `source`, a data-source handle obtained from this host's catalog. Invalid
+   * (id == 0) or unloaded handles are errors; no representative-dataset fallback.
+   * The result has the same current-frame semantics as to_display_time.
+   * Optional tail slot: test struct_size and the function pointer before use. */
+  bool (*to_display_time_for_source)(
+      void* ctx, PJ_data_source_handle_t source, int64_t absolute_ns, double* out_display_s,
+      PJ_error_t* out_error) PJ_NOEXCEPT;
 } PJ_playback_host_vtable_t;
 
 typedef struct {
@@ -1188,6 +1202,8 @@ typedef struct {
  * plugin's: it is enforced where ownership is known, and ownership is derived
  * from `ctx`, never passed in.
  *
+ * Ids are independent of visible titles: titles may repeat or be renamed
+ * without changing an id. Tab indices are presentation order, not identity.
  * Ids are chosen by the plugin and namespaced per plugin by the host (the
  * "pj.data_processors.v1" discipline), so an id is unique within this binding
  * and cannot collide with another plugin's. The resemblance stops there, and

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -1126,8 +1126,7 @@ typedef struct PJ_playback_host_vtable_t {
    * representative dataset. Current-frame semantics (see the service
    * doc-comment). An unknown topic is an error. */
   bool (*to_display_time)(
-      void* ctx, PJ_string_view_t topic, int64_t absolute_ns, double* out_display_s, PJ_error_t* out_error)
-      PJ_NOEXCEPT;
+      void* ctx, PJ_string_view_t topic, int64_t absolute_ns, double* out_display_s, PJ_error_t* out_error) PJ_NOEXCEPT;
 } PJ_playback_host_vtable_t;
 
 typedef struct {
@@ -1226,8 +1225,7 @@ typedef struct PJ_plot_tab_host_vtable_t {
    * of out_ids are filled and point into host storage valid only until the next
    * call on this vtable. Owning no tab is success with *out_count == 0. */
   bool (*list_tab_ids)(
-      void* ctx, PJ_string_view_t* out_ids, uint64_t capacity, uint64_t* out_count,
-      PJ_error_t* out_error) PJ_NOEXCEPT;
+      void* ctx, PJ_string_view_t* out_ids, uint64_t capacity, uint64_t* out_count, PJ_error_t* out_error) PJ_NOEXCEPT;
 
   /* [main-thread] Read back what a tab actually holds, as JSON
    * {"title":"...","curves":[{"topic":"...","field":"...","dataset":"..."}]}.
@@ -1238,8 +1236,8 @@ typedef struct PJ_plot_tab_host_vtable_t {
    * JSON: any character needing escaping in a topic or field is escaped here.
    * *out_config_json is borrowed, valid only until the next call on this
    * vtable. Unknown id is an error. */
-  bool (*tab_config)(
-      void* ctx, PJ_string_view_t id, PJ_string_view_t* out_config_json, PJ_error_t* out_error) PJ_NOEXCEPT;
+  bool (*tab_config)(void* ctx, PJ_string_view_t id, PJ_string_view_t* out_config_json, PJ_error_t* out_error)
+      PJ_NOEXCEPT;
 
   /* [main-thread] Draw one curve in a tab of this plugin's. The series is named
    * by its parts, not a joined path, because field paths legitimately contain
@@ -1249,8 +1247,8 @@ typedef struct PJ_plot_tab_host_vtable_t {
    * with the qualified candidates rather than picking. Adding a curve already
    * present is not an error. */
   bool (*add_curve)(
-      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field,
-      PJ_string_view_t dataset_source, PJ_error_t* out_error) PJ_NOEXCEPT;
+      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field, PJ_string_view_t dataset_source,
+      PJ_error_t* out_error) PJ_NOEXCEPT;
 
   /* [main-thread] Take one curve back out. `dataset_source` resolves by the
    * same rule as in add_curve — empty means "the topic/field must be unique" —
@@ -1258,8 +1256,8 @@ typedef struct PJ_plot_tab_host_vtable_t {
    * the resolved name tab_config reports. A curve that is not there is an
    * error, so a mistaken path is visible rather than silently accepted. */
   bool (*remove_curve)(
-      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field,
-      PJ_string_view_t dataset_source, PJ_error_t* out_error) PJ_NOEXCEPT;
+      void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field, PJ_string_view_t dataset_source,
+      PJ_error_t* out_error) PJ_NOEXCEPT;
 
   /* [main-thread] Remove every curve from a tab, keeping the tab itself. */
   bool (*clear_tab)(void* ctx, PJ_string_view_t id, PJ_error_t* out_error) PJ_NOEXCEPT;

--- a/pj_base/include/pj_base/plugin_data_api.h
+++ b/pj_base/include/pj_base/plugin_data_api.h
@@ -922,7 +922,8 @@ typedef struct {
  *   - language    : script backend, "luau" today; the host rejects anything else.
  *   - inputs      : topic OR topic-field names ("pose/orientation" or
  *                   "pose/orientation/x") the script reads; the host resolves them
- *                   and exact-joins co-timestamped inputs.
+ *                   and exact-joins co-timestamped inputs. A name MAY carry the
+ *                   dataset qualifier, see DATASET-QUALIFIED NAMES below.
  *   - outputs     : target topic key(s). MAY be empty for an ephemeral preview
  *                   (flags & PJ_DATA_PROCESSOR_FLAG_EPHEMERAL), in which case the host
  *                   names the sink(s) and returns the resolved names in out_topics.
@@ -939,6 +940,23 @@ typedef struct {
  *                   absent = active dataset.
  *   - flags       : bitset; PJ_DATA_PROCESSOR_FLAG_EPHEMERAL marks a preview (never
  *                   persisted, dropped on remove). Reserved bits must be 0.
+ *
+ * DATASET-QUALIFIED NAMES — a series' full identity is (dataset, topic, field); a
+ * bare "topic/field" name is an abbreviation that stops being unique the moment
+ * two loaded datasets share topic names. An input MAY therefore carry the
+ * qualifier "dataset_source:topic/field" — the same form hosts print as a series
+ * identity (shared parser/composer: sdk/dataset_qualified_name.hpp). The qualifier
+ * is matched against the LOADED source names (longest match wins), never split
+ * blindly at ':', so source names need no escaping. The host MUST enforce:
+ *   - a qualifier matching no loaded dataset is an error — no fallback to reading
+ *     the whole string as a bare name;
+ *   - a bare name that exists in SEVERAL loaded datasets is refused, reporting the
+ *     qualified candidates — NEVER resolved by load order;
+ *   - all qualified inputs of one processor agree on a single dataset.
+ * Marker output keys (per-series, see markerSeriesKey) accept the qualifier the
+ * same way; transform outputs name NEW topics and are never qualified. Addressing
+ * two datasets that share one source name is outside this contract (ambiguous ->
+ * error); that needs a typed dataset id, which would be a tail-appended addition.
  *
  * FORWARD-COMPAT — the native door is WASM, not a C++ kernel. Because the script
  * slot is a binary-safe blob the host owns and runs (today Luau; tomorrow a

--- a/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
+++ b/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
@@ -21,7 +21,7 @@ namespace PJ::sdk {
 
 /// Result of splitting a series name that may carry the dataset qualifier,
 /// "dataset_source:topic/field".
-/// @since 0.26.0
+/// @since 0.28.0
 struct DatasetQualifierSplit {
   bool qualified = false;
   std::string dataset_source;  ///< the matched source name; empty when unqualified
@@ -32,7 +32,7 @@ struct DatasetQualifierSplit {
 /// Matching against known names instead of parsing at ':' means source names
 /// need no escaping — "[stream] UDP Server:/udp/data" works as-is — and a ':'
 /// inside an ordinary name can never be misread as a qualifier.
-/// @since 0.26.0
+/// @since 0.28.0
 [[nodiscard]] inline DatasetQualifierSplit splitDatasetQualifier(
     std::string_view name, Span<const std::string> source_names) {
   DatasetQualifierSplit out;
@@ -52,7 +52,7 @@ struct DatasetQualifierSplit {
 
 /// The canonical dataset-qualified form, "dataset_source:bare" — the inverse of
 /// splitDatasetQualifier for a loaded source name.
-/// @since 0.26.0
+/// @since 0.28.0
 [[nodiscard]] inline std::string qualifiedSeriesName(std::string_view dataset_source, std::string_view bare) {
   std::string out;
   out.reserve(dataset_source.size() + 1 + bare.size());

--- a/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
+++ b/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
@@ -6,10 +6,9 @@
 // string across the plugin boundary (normative statement in plugin_data_api.h,
 // DATASET-QUALIFIED NAMES). A series' full identity is (dataset, topic, field);
 // a bare "topic/field" name is an abbreviation that stops being unique the
-// moment two loaded datasets share topic names. The canonical serialized
-// identity is "dataset_source:topic/field" — the same form hosts print — and
-// this header is the shared parser/composer for it, so hosts and plugins never
-// drift.
+// moment two loaded datasets share topic names. The catalog-dependent lookup
+// form is "dataset_source:topic/field". This helper splits that form; the host
+// still validates the resulting name and rejects ambiguous dataset matches.
 
 #include <cstddef>
 #include <string>
@@ -29,9 +28,11 @@ struct DatasetQualifierSplit {
 };
 
 /// Split `name` against the KNOWN dataset source names (longest match wins).
-/// Matching against known names instead of parsing at ':' means source names
-/// need no escaping — "[stream] UDP Server:/udp/data" works as-is — and a ':'
-/// inside an ordinary name can never be misread as a qualifier.
+/// Source names may contain ':' or spaces, e.g. "[stream] UDP Server".
+/// With no matching prefix the entire input stays bare, including any colons;
+/// an unknown qualifier cannot be distinguished from a colon in a bare name.
+/// A matching loaded prefix takes precedence over a bare interpretation.
+/// This does not validate existence or uniqueness of the resolved dataset/series.
 /// @since 0.28.0
 [[nodiscard]] inline DatasetQualifierSplit splitDatasetQualifier(
     std::string_view name, Span<const std::string> source_names) {
@@ -50,8 +51,10 @@ struct DatasetQualifierSplit {
   return out;
 }
 
-/// The canonical dataset-qualified form, "dataset_source:bare" — the inverse of
-/// splitDatasetQualifier for a loaded source name.
+/// Compose "dataset_source:bare". This round-trips through splitDatasetQualifier
+/// only while dataset_source is the longest loaded matching prefix. For example,
+/// ("a", "b:/t/f") and ("a:b", "/t/f") compose identically; with both sources
+/// loaded the splitter chooses "a:b". This string is not a persistent identity.
 /// @since 0.28.0
 [[nodiscard]] inline std::string qualifiedSeriesName(std::string_view dataset_source, std::string_view bare) {
   std::string out;

--- a/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
+++ b/pj_base/include/pj_base/sdk/dataset_qualified_name.hpp
@@ -1,0 +1,65 @@
+#pragma once
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+// Dataset-qualified series names — the naming contract for series addressed by
+// string across the plugin boundary (normative statement in plugin_data_api.h,
+// DATASET-QUALIFIED NAMES). A series' full identity is (dataset, topic, field);
+// a bare "topic/field" name is an abbreviation that stops being unique the
+// moment two loaded datasets share topic names. The canonical serialized
+// identity is "dataset_source:topic/field" — the same form hosts print — and
+// this header is the shared parser/composer for it, so hosts and plugins never
+// drift.
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+#include "pj_base/span.hpp"
+
+namespace PJ::sdk {
+
+/// Result of splitting a series name that may carry the dataset qualifier,
+/// "dataset_source:topic/field".
+/// @since 0.26.0
+struct DatasetQualifierSplit {
+  bool qualified = false;
+  std::string dataset_source;  ///< the matched source name; empty when unqualified
+  std::string bare;            ///< the name with the qualifier removed
+};
+
+/// Split `name` against the KNOWN dataset source names (longest match wins).
+/// Matching against known names instead of parsing at ':' means source names
+/// need no escaping — "[stream] UDP Server:/udp/data" works as-is — and a ':'
+/// inside an ordinary name can never be misread as a qualifier.
+/// @since 0.26.0
+[[nodiscard]] inline DatasetQualifierSplit splitDatasetQualifier(
+    std::string_view name, Span<const std::string> source_names) {
+  DatasetQualifierSplit out;
+  std::size_t best = 0;
+  for (const std::string& src : source_names) {
+    if (src.empty() || src.size() <= best || name.size() <= src.size() || name[src.size()] != ':' ||
+        name.compare(0, src.size(), src) != 0) {
+      continue;
+    }
+    best = src.size();
+    out.dataset_source = src;
+  }
+  out.qualified = best != 0;
+  out.bare = std::string(out.qualified ? name.substr(best + 1) : name);
+  return out;
+}
+
+/// The canonical dataset-qualified form, "dataset_source:bare" — the inverse of
+/// splitDatasetQualifier for a loaded source name.
+/// @since 0.26.0
+[[nodiscard]] inline std::string qualifiedSeriesName(std::string_view dataset_source, std::string_view bare) {
+  std::string out;
+  out.reserve(dataset_source.size() + 1 + bare.size());
+  out.append(dataset_source);
+  out.push_back(':');
+  out.append(bare);
+  return out;
+}
+
+}  // namespace PJ::sdk

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1042,6 +1042,9 @@ template <class ListSlot>
   if (count != 0 && !slot(ctx, borrowed.data(), borrowed.size(), &filled, &err)) {
     return unexpected(errorToString(err));
   }
+  if (filled > borrowed.size()) {
+    return unexpected("host string list grew during enumeration; retry the call");
+  }
   std::vector<std::string> out;
   out.reserve(filled);
   for (uint64_t i = 0; i < filled; ++i) {
@@ -1889,7 +1892,8 @@ class PlotTabHostView {
   }
 
   /// Enumerate the ids of this plugin's live tabs (owned copies). Owning none is
-  /// success with an empty vector.
+  /// success with an empty vector. If the list grows between the count and fill
+  /// calls, returns an error so the caller can retry instead of reading a partial list.
   [[nodiscard]] Expected<std::vector<std::string>> list() const {
     if (!valid() || host_.vtable->list_tab_ids == nullptr) {
       return unexpected("plot tab host is not bound");

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1654,6 +1654,164 @@ class DataProcessorsHostView {
 };
 
 // ---------------------------------------------------------------------------
+// PlaybackHostView — typed C++ view over PJ_playback_host_t
+// ---------------------------------------------------------------------------
+
+/// Snapshot of the host's playback state. All times are display-axis seconds
+/// (the numbers on the plot X axes and the playback slider).
+struct PlaybackState {
+  bool is_playing = false;
+  double current_time_s = 0.0;
+  double range_min_s = 0.0;
+  double range_max_s = 0.0;
+  double playback_rate = 1.0;
+};
+
+/// C++ wrapper around PJ_playback_host_t — optional programmatic control of
+/// the host's playback cursor (service "pj.playback.v1"). Empty-constructible;
+/// `valid()` tells whether the host exposed the service. All calls are
+/// main-thread. Times are display-axis seconds; conversions from absolute
+/// nanoseconds (`toDisplayTime`) hold for the current frame only — display
+/// offsets are per-dataset and user-editable (see the C ABI doc-comment).
+class PlaybackHostView {
+ public:
+  PlaybackHostView() = default;
+  explicit PlaybackHostView(PJ_playback_host_t host) : host_(host) {}
+
+  [[nodiscard]] bool valid() const noexcept {
+    return host_.vtable != nullptr && host_.ctx != nullptr;
+  }
+
+  /// Start advancing the playback cursor. Idempotent.
+  [[nodiscard]] Status play() const {
+    if (!valid() || host_.vtable->play == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->play(host_.ctx, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Stop advancing the playback cursor. Idempotent.
+  [[nodiscard]] Status pause() const {
+    if (!valid() || host_.vtable->pause == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->pause(host_.ctx, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Move the cursor to `time_s` (display-axis seconds); the host clamps into
+  /// the playback range. Play/pause state is unchanged.
+  [[nodiscard]] Status seek(double time_s) const {
+    if (!valid() || host_.vtable->seek == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->seek(host_.ctx, time_s, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Set the playback-speed multiplier (> 0; the host may clamp).
+  [[nodiscard]] Status setPlaybackRate(double rate) const {
+    if (!valid() || host_.vtable->set_playback_rate == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->set_playback_rate(host_.ctx, rate, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Snapshot the current playback state. During live streaming the range
+  /// (and a cursor glued to its tip) advances on every ingest tick.
+  [[nodiscard]] Expected<PlaybackState> state() const {
+    if (!valid() || host_.vtable->get_state == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    PJ_playback_state_t raw{};
+    PJ_error_t err{};
+    if (!host_.vtable->get_state(host_.ctx, &raw, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return PlaybackState{raw.is_playing, raw.current_time_s, raw.range_min_s, raw.range_max_s, raw.playback_rate};
+  }
+
+  /// Convert an ABSOLUTE nanosecond timestamp into display-axis seconds using
+  /// the display offset of the dataset owning `topic` (empty topic = the
+  /// host's representative dataset). Current-frame semantics.
+  [[nodiscard]] Expected<double> toDisplayTime(std::string_view topic, int64_t absolute_ns) const {
+    if (!valid() || host_.vtable->to_display_time == nullptr) {
+      return unexpected("playback host is not bound");
+    }
+    double display_s = 0.0;
+    PJ_error_t err{};
+    if (!host_.vtable->to_display_time(host_.ctx, toAbiString(topic), absolute_ns, &display_s, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return display_s;
+  }
+
+ private:
+  PJ_playback_host_t host_{};
+};
+
+// ---------------------------------------------------------------------------
+// ViewportHostView — typed C++ view over PJ_viewport_host_t
+// ---------------------------------------------------------------------------
+
+/// C++ wrapper around PJ_viewport_host_t — optional zoom control over the
+/// host's open time-series plots (service "pj.viewport.v1").
+/// Empty-constructible; `valid()` tells whether the host exposed the service.
+/// All calls are main-thread; times are display-axis seconds.
+class ViewportHostView {
+ public:
+  ViewportHostView() = default;
+  explicit ViewportHostView(PJ_viewport_host_t host) : host_(host) {}
+
+  [[nodiscard]] bool valid() const noexcept {
+    return host_.vtable != nullptr && host_.ctx != nullptr;
+  }
+
+  /// Set every open time-series plot's visible X window to [t0_s, t1_s].
+  /// Each plot keeps its own Y range; XY and empty plots are untouched.
+  /// Requires finite t0_s < t1_s.
+  [[nodiscard]] Status zoomToTimeRange(double t0_s, double t1_s) const {
+    if (!valid() || host_.vtable->zoom_to_time_range == nullptr) {
+      return unexpected("viewport host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->zoom_to_time_range(host_.ctx, t0_s, t1_s, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Reset every open plot to fit its data (the host's "zoom out all").
+  [[nodiscard]] Status zoomReset() const {
+    if (!valid() || host_.vtable->zoom_reset == nullptr) {
+      return unexpected("viewport host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->zoom_reset(host_.ctx, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+ private:
+  PJ_viewport_host_t host_{};
+};
+
+// ---------------------------------------------------------------------------
 // SettingsView — typed C++ view over PJ_settings_store_t
 // ---------------------------------------------------------------------------
 

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1517,7 +1517,10 @@ class DataProcessorsHostView {
   /// PJ_DATA_PROCESSOR_FLAG_EPHEMERAL), in which case the host names the sink(s).
   /// Returns the resolved physical output topic name(s) (owned copies) so the caller
   /// can read results back through the kind's read surface. `params_json` is forwarded
-  /// verbatim to the script.
+  /// verbatim to the script. Input names MAY carry the dataset qualifier
+  /// "dataset_source:topic/field" (see DATASET-QUALIFIED NAMES in plugin_data_api.h;
+  /// shared parser/composer in sdk/dataset_qualified_name.hpp) — required to address a
+  /// series whose bare name exists in several loaded datasets.
   [[nodiscard]] Expected<std::vector<std::string>> create(
       std::string_view id, std::string_view kind, std::string_view language, Span<const std::string_view> inputs,
       Span<const std::string_view> outputs, std::string_view script, std::string_view params_json,
@@ -1573,7 +1576,8 @@ class DataProcessorsHostView {
 
   /// Convenience: create a kind="transform" node (DerivedEngine timeseries). `outputs`
   /// must be non-empty. Discards the resolved topic names (the caller supplied them);
-  /// use create() directly if you need them back.
+  /// use create() directly if you need them back. Inputs MAY be dataset-qualified (see
+  /// create()); outputs name NEW topics and are never qualified.
   [[nodiscard]] Status createTransform(
       std::string_view id, Span<const std::string_view> inputs, Span<const std::string_view> outputs,
       std::string_view script, std::string_view params_json, uint32_t flags = 0) const {
@@ -1599,6 +1603,7 @@ class DataProcessorsHostView {
   /// key (kGlobalMarkerTopic or markerSeriesKey). Pass
   /// flags=PJ_DATA_PROCESSOR_FLAG_EPHEMERAL for a live preview (output may be left empty
   /// to let the host name the preview topic). Returns the resolved object topic(s).
+  /// Inputs and per-series output keys MAY be dataset-qualified (see create()).
   [[nodiscard]] Expected<std::vector<std::string>> createMarkers(
       std::string_view id, Span<const std::string_view> inputs, std::string_view output_marker_topic,
       std::string_view script, std::string_view params_json, uint32_t flags = 0) const {

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1782,7 +1782,9 @@ class PlaybackHostView {
 
   /// Convert an ABSOLUTE nanosecond timestamp into display-axis seconds using
   /// the display offset of the dataset owning `topic` (empty topic = the
-  /// host's representative dataset). Current-frame semantics.
+  /// host's representative dataset). Unknown or ambiguous nonempty topics are
+  /// errors; use toDisplayTimeForSource to select a dataset explicitly.
+  /// Current-frame semantics.
   [[nodiscard]] Expected<double> toDisplayTime(std::string_view topic, int64_t absolute_ns) const {
     if (!valid() || host_.vtable->to_display_time == nullptr) {
       return unexpected("playback host is not bound");
@@ -1790,6 +1792,21 @@ class PlaybackHostView {
     double display_s = 0.0;
     PJ_error_t err{};
     if (!host_.vtable->to_display_time(host_.ctx, toAbiString(topic), absolute_ns, &display_s, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return display_s;
+  }
+
+  /// Convert absolute nanoseconds using this catalog source's display offset.
+  /// Invalid or unloaded handles are errors. Re-query after source-offset edits.
+  /// Hosts without the optional tail slot report unsupported.
+  [[nodiscard]] Expected<double> toDisplayTimeForSource(DataSourceHandle source, int64_t absolute_ns) const {
+    if (!valid() || !PJ_HAS_TAIL_SLOT(PJ_playback_host_vtable_t, host_.vtable, to_display_time_for_source)) {
+      return unexpected("source-scoped display-time conversion is not supported by this host");
+    }
+    double display_s = 0.0;
+    PJ_error_t err{};
+    if (!host_.vtable->to_display_time_for_source(host_.ctx, source, absolute_ns, &display_s, &err)) {
       return unexpected(errorToString(err));
     }
     return display_s;
@@ -1804,7 +1821,7 @@ class PlaybackHostView {
 // ---------------------------------------------------------------------------
 
 /// C++ wrapper around PJ_viewport_host_t — optional zoom control over the
-/// host's open time-series plots (service "pj.viewport.v1").
+/// calling plugin's own plots (service "pj.viewport.v1").
 /// Empty-constructible; `valid()` tells whether the host exposed the service.
 /// All calls are main-thread; times are display-axis seconds.
 class ViewportHostView {
@@ -1816,7 +1833,7 @@ class ViewportHostView {
     return host_.vtable != nullptr && host_.ctx != nullptr;
   }
 
-  /// Set every open time-series plot's visible X window to [t0_s, t1_s].
+  /// Set every time-series plot in this plugin's tabs to the X window [t0_s, t1_s].
   /// Each plot keeps its own Y range; XY and empty plots are untouched.
   /// Requires finite t0_s < t1_s.
   [[nodiscard]] Status zoomToTimeRange(double t0_s, double t1_s) const {
@@ -1830,7 +1847,7 @@ class ViewportHostView {
     return okStatus();
   }
 
-  /// Reset every open plot to fit its data (the host's "zoom out all").
+  /// Reset every plot in this plugin's tabs to fit its data.
   [[nodiscard]] Status zoomReset() const {
     if (!valid() || host_.vtable->zoom_reset == nullptr) {
       return unexpected("viewport host is not bound");

--- a/pj_base/include/pj_base/sdk/plugin_data_api.hpp
+++ b/pj_base/include/pj_base/sdk/plugin_data_api.hpp
@@ -1022,6 +1022,33 @@ inline PrimitiveType formatToPrimitiveType(const char* fmt) noexcept {
       return PrimitiveType::kUnspecified;
   }
 }
+
+/// Two-call "count then fill" marshalling for any vtable slot that enumerates
+/// borrowed strings: ask for the count, size a buffer, ask again, copy out.
+/// The copies are made here on purpose — the views the host fills in point into
+/// its own storage, which the next call on that vtable may invalidate.
+///
+/// `slot` is the raw function pointer; the caller has already established that
+/// the host is bound, since only it knows which view is speaking.
+template <class ListSlot>
+[[nodiscard]] inline Expected<std::vector<std::string>> listBorrowedStrings(void* ctx, ListSlot slot) {
+  PJ_error_t err{};
+  uint64_t count = 0;
+  if (!slot(ctx, nullptr, 0, &count, &err)) {
+    return unexpected(errorToString(err));
+  }
+  std::vector<PJ_string_view_t> borrowed(count);
+  uint64_t filled = 0;
+  if (count != 0 && !slot(ctx, borrowed.data(), borrowed.size(), &filled, &err)) {
+    return unexpected(errorToString(err));
+  }
+  std::vector<std::string> out;
+  out.reserve(filled);
+  for (uint64_t i = 0; i < filled; ++i) {
+    out.emplace_back(toStringView(borrowed[i]));
+  }
+  return out;
+}
 }  // namespace detail
 
 /// Typed view over the two-column Arrow struct returned by
@@ -1809,6 +1836,121 @@ class ViewportHostView {
 
  private:
   PJ_viewport_host_t host_{};
+};
+
+// ---------------------------------------------------------------------------
+// PlotTabHostView — typed C++ view over PJ_plot_tab_host_t
+// ---------------------------------------------------------------------------
+
+/// C++ wrapper around PJ_plot_tab_host_t for plugins that compose plotting tabs of
+/// their own (see the C ABI doc-comment on PJ_plot_tab_host_vtable_t). Every call is
+/// scoped by the host to the tabs THIS plugin created; ids naming anything else are
+/// rejected like unknown ids. Empty-constructible; `valid()` tells whether the host
+/// exposed the service. Strings returned by `list()`/`configOf()` are owned copies, so
+/// they stay valid past the next vtable call.
+class PlotTabHostView {
+ public:
+  PlotTabHostView() = default;
+  explicit PlotTabHostView(PJ_plot_tab_host_t host) : host_(host) {}
+
+  [[nodiscard]] bool valid() const noexcept {
+    return host_.vtable != nullptr && host_.ctx != nullptr;
+  }
+
+  /// Create (or replace, upsert by id) a tab holding one empty plot. An empty
+  /// `title` lets the host name it.
+  [[nodiscard]] Status create(std::string_view id, std::string_view title = {}) const {
+    if (!valid() || host_.vtable->create_tab == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->create_tab(host_.ctx, toAbiString(id), toAbiString(title), &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Close one of this plugin's tabs. Any derived series or markers drawn in it
+  /// are data and outlive the view.
+  [[nodiscard]] Status close(std::string_view id) const {
+    if (!valid() || host_.vtable->close_tab == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->close_tab(host_.ctx, toAbiString(id), &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Enumerate the ids of this plugin's live tabs (owned copies). Owning none is
+  /// success with an empty vector.
+  [[nodiscard]] Expected<std::vector<std::string>> list() const {
+    if (!valid() || host_.vtable->list_tab_ids == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    return detail::listBorrowedStrings(host_.ctx, host_.vtable->list_tab_ids);
+  }
+
+  /// Read back what a tab actually holds, as JSON (owned copy) — the way to
+  /// report what was drawn rather than what was asked for.
+  [[nodiscard]] Expected<std::string> configOf(std::string_view id) const {
+    if (!valid() || host_.vtable->tab_config == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    PJ_string_view_t out{};
+    if (!host_.vtable->tab_config(host_.ctx, toAbiString(id), &out, &err)) {
+      return unexpected(errorToString(err));
+    }
+    return std::string(toStringView(out));
+  }
+
+  /// Draw one curve. An empty `dataset_source` requires the topic/field to be
+  /// unique across loaded datasets; an ambiguous one is refused by the host with
+  /// the qualified candidates rather than guessed.
+  [[nodiscard]] Status addCurve(
+      std::string_view id, std::string_view topic, std::string_view field, std::string_view dataset_source = {}) const {
+    if (!valid() || host_.vtable->add_curve == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->add_curve(
+            host_.ctx, toAbiString(id), toAbiString(topic), toAbiString(field), toAbiString(dataset_source), &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Take one curve back out, resolved by the same rule as addCurve. A curve
+  /// that is not there is an error.
+  [[nodiscard]] Status removeCurve(
+      std::string_view id, std::string_view topic, std::string_view field, std::string_view dataset_source = {}) const {
+    if (!valid() || host_.vtable->remove_curve == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->remove_curve(
+            host_.ctx, toAbiString(id), toAbiString(topic), toAbiString(field), toAbiString(dataset_source), &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+  /// Remove every curve from a tab, keeping the tab itself.
+  [[nodiscard]] Status clear(std::string_view id) const {
+    if (!valid() || host_.vtable->clear_tab == nullptr) {
+      return unexpected("plot tab host is not bound");
+    }
+    PJ_error_t err{};
+    if (!host_.vtable->clear_tab(host_.ctx, toAbiString(id), &err)) {
+      return unexpected(errorToString(err));
+    }
+    return okStatus();
+  }
+
+ private:
+  PJ_plot_tab_host_t host_{};
 };
 
 // ---------------------------------------------------------------------------

--- a/pj_base/include/pj_base/sdk/service_traits.hpp
+++ b/pj_base/include/pj_base/sdk/service_traits.hpp
@@ -213,6 +213,19 @@ struct ViewportHostService {
   static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
 };
 
+/// "pj.plot_tabs.v1" — compose plotting tabs of the plugin's own: create, place
+/// and remove curves, read back what they hold, close. Scoped by the host to
+/// this plugin's tabs, which is also what bounds "pj.viewport.v1". Hosts with
+/// no plot workspace (headless) simply do not register it.
+struct PlotTabHostService {
+  static constexpr const char* kName = "pj.plot_tabs.v1";
+  static constexpr uint32_t kMinVersion = 1;
+  using Raw = PJ_plot_tab_host_t;
+  using Vtable = PJ_plot_tab_host_vtable_t;
+  using View = PlotTabHostView;
+  static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
+};
+
 /// Optional QSettings-like key/value persistence exposed to any plugin family.
 /// Host-backed (QSettings in the GUI app, JSON in a headless host); keys are
 /// namespaced per plugin by the host.

--- a/pj_base/include/pj_base/sdk/service_traits.hpp
+++ b/pj_base/include/pj_base/sdk/service_traits.hpp
@@ -201,8 +201,8 @@ struct PlaybackHostService {
   static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
 };
 
-/// Optional viewport control: zoom every open time-series plot to a
-/// display-seconds X window, or reset all plots to fit their data. Hosts
+/// Optional viewport control: zoom the calling plugin's own time-series plots to
+/// a display-seconds X window, or reset its own plots to fit their data. Hosts
 /// without plots (headless) simply do not register it.
 struct ViewportHostService {
   static constexpr const char* kName = "pj.viewport.v1";

--- a/pj_base/include/pj_base/sdk/service_traits.hpp
+++ b/pj_base/include/pj_base/sdk/service_traits.hpp
@@ -187,6 +187,32 @@ struct DataProcessorsHostService {
   static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
 };
 
+/// Optional playback control for any plugin family: play/pause/seek/rate and
+/// a state snapshot over the host's playback cursor, plus absolute-ns ->
+/// display-seconds conversion. All times are display-axis seconds (the numbers
+/// the plot X axes and the playback slider show); see the C ABI doc-comment on
+/// PJ_playback_host_vtable_t for the current-frame caveat.
+struct PlaybackHostService {
+  static constexpr const char* kName = "pj.playback.v1";
+  static constexpr uint32_t kMinVersion = 1;
+  using Raw = PJ_playback_host_t;
+  using Vtable = PJ_playback_host_vtable_t;
+  using View = PlaybackHostView;
+  static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
+};
+
+/// Optional viewport control: zoom every open time-series plot to a
+/// display-seconds X window, or reset all plots to fit their data. Hosts
+/// without plots (headless) simply do not register it.
+struct ViewportHostService {
+  static constexpr const char* kName = "pj.viewport.v1";
+  static constexpr uint32_t kMinVersion = 1;
+  using Raw = PJ_viewport_host_t;
+  using Vtable = PJ_viewport_host_vtable_t;
+  using View = ViewportHostView;
+  static_assert(detail::isValidServiceName(kName), "kName must match the pj naming rule");
+};
+
 /// Optional QSettings-like key/value persistence exposed to any plugin family.
 /// Host-backed (QSettings in the GUI app, JSON in a headless host); keys are
 /// namespaced per plugin by the host.

--- a/pj_base/src/builtin/plot_markers_codec.cpp
+++ b/pj_base/src/builtin/plot_markers_codec.cpp
@@ -273,8 +273,14 @@ std::vector<uint8_t> serializePlotMarkers(const sdk::PlotMarkers& markers) {
 }
 
 Expected<sdk::PlotMarkers> deserializePlotMarkers(const uint8_t* data, size_t size) {
-  if (data == nullptr || size == 0) {
-    return unexpected(std::string("PlotMarkers wire: empty buffer"));
+  // An empty buffer IS the canonical encoding of an empty set (proto semantics:
+  // empty message = all defaults) — the "clear my markers" tombstone a producer
+  // publishes, since the store is replace-only and markers are never deleted.
+  if (size == 0) {
+    return sdk::PlotMarkers{};
+  }
+  if (data == nullptr) {
+    return unexpected(std::string("PlotMarkers wire: null buffer"));
   }
 
   Reader reader(data, size);

--- a/pj_base/tests/abi_layout_sentinels_test.cpp
+++ b/pj_base/tests/abi_layout_sentinels_test.cpp
@@ -66,6 +66,17 @@ static_assert(offsetof(PJ_error_t, message) == 36, "PJ_error_t layout pinned");
 static_assert(offsetof(PJ_error_t, extended) == 264, "PJ_error_t layout pinned");
 static_assert(offsetof(PJ_error_t, extended_kind) == 272, "PJ_error_t layout pinned");
 
+// --- PJ_playback_state_t (ABI-FROZEN) -----------------------------------------
+// bool + 7 padding bytes + 4 doubles: the alignment-hole shape this test exists
+// to pin. Growth goes through a get_state_v2 tail slot, never through this struct.
+static_assert(sizeof(PJ_playback_state_t) == 40, "PJ_playback_state_t size pinned at introduction (0.16.0)");
+static_assert(alignof(PJ_playback_state_t) == 8, "PJ_playback_state_t alignment pinned");
+static_assert(offsetof(PJ_playback_state_t, is_playing) == 0, "PJ_playback_state_t layout pinned");
+static_assert(offsetof(PJ_playback_state_t, current_time_s) == 8, "PJ_playback_state_t layout pinned");
+static_assert(offsetof(PJ_playback_state_t, range_min_s) == 16, "PJ_playback_state_t layout pinned");
+static_assert(offsetof(PJ_playback_state_t, range_max_s) == 24, "PJ_playback_state_t layout pinned");
+static_assert(offsetof(PJ_playback_state_t, playback_rate) == 32, "PJ_playback_state_t layout pinned");
+
 // --- Service registry (fat pointer types) ------------------------------------
 static_assert(sizeof(PJ_service_t) == 16, "PJ_service_t fat pointer pinned");
 static_assert(sizeof(PJ_service_registry_t) == 16, "PJ_service_registry_t fat pointer pinned");

--- a/pj_base/tests/abi_layout_sentinels_test.cpp
+++ b/pj_base/tests/abi_layout_sentinels_test.cpp
@@ -77,6 +77,11 @@ static_assert(offsetof(PJ_playback_state_t, range_min_s) == 16, "PJ_playback_sta
 static_assert(offsetof(PJ_playback_state_t, range_max_s) == 24, "PJ_playback_state_t layout pinned");
 static_assert(offsetof(PJ_playback_state_t, playback_rate) == 32, "PJ_playback_state_t layout pinned");
 
+// Playback vtable: source selection extends the existing topic-based prefix.
+static_assert(offsetof(PJ_playback_host_vtable_t, to_display_time) == 48, "topic conversion slot stays fixed");
+static_assert(offsetof(PJ_playback_host_vtable_t, to_display_time_for_source) == 56, "source conversion is appended");
+static_assert(sizeof(PJ_playback_host_vtable_t) == 64, "playback vtable size in 0.28.0");
+
 // --- Service registry (fat pointer types) ------------------------------------
 static_assert(sizeof(PJ_service_t) == 16, "PJ_service_t fat pointer pinned");
 static_assert(sizeof(PJ_service_registry_t) == 16, "PJ_service_registry_t fat pointer pinned");

--- a/pj_base/tests/abi_layout_sentinels_test.cpp
+++ b/pj_base/tests/abi_layout_sentinels_test.cpp
@@ -69,7 +69,7 @@ static_assert(offsetof(PJ_error_t, extended_kind) == 272, "PJ_error_t layout pin
 // --- PJ_playback_state_t (ABI-FROZEN) -----------------------------------------
 // bool + 7 padding bytes + 4 doubles: the alignment-hole shape this test exists
 // to pin. Growth goes through a get_state_v2 tail slot, never through this struct.
-static_assert(sizeof(PJ_playback_state_t) == 40, "PJ_playback_state_t size pinned at introduction (0.16.0)");
+static_assert(sizeof(PJ_playback_state_t) == 40, "PJ_playback_state_t size pinned at introduction (0.28.0)");
 static_assert(alignof(PJ_playback_state_t) == 8, "PJ_playback_state_t alignment pinned");
 static_assert(offsetof(PJ_playback_state_t, is_playing) == 0, "PJ_playback_state_t layout pinned");
 static_assert(offsetof(PJ_playback_state_t, current_time_s) == 8, "PJ_playback_state_t layout pinned");

--- a/pj_base/tests/dataset_qualified_name_api_test.cpp
+++ b/pj_base/tests/dataset_qualified_name_api_test.cpp
@@ -1,12 +1,12 @@
 // Copyright 2026 Davide Faconti
 // SPDX-License-Identifier: Apache-2.0
 
-#include "pj_base/sdk/dataset_qualified_name.hpp"
-
 #include <gtest/gtest.h>
 
 #include <string>
 #include <vector>
+
+#include "pj_base/sdk/dataset_qualified_name.hpp"
 
 namespace PJ::sdk {
 namespace {
@@ -65,6 +65,32 @@ TEST(QualifiedSeriesName, RoundTripsThroughSplit) {
   EXPECT_TRUE(split.qualified);
   EXPECT_EQ(split.dataset_source, "session 12.mcap");
   EXPECT_EQ(split.bare, "/imu/accel/x");
+}
+
+TEST(QualifiedSeriesName, OverlappingPrefixesAreCatalogDependent) {
+  const std::string name = qualifiedSeriesName("a", "b:/t/f");
+  EXPECT_EQ(name, qualifiedSeriesName("a:b", "/t/f"));
+
+  const std::vector<std::string> both = {"a", "a:b"};
+  const auto longest = splitDatasetQualifier(name, both);
+  EXPECT_EQ(longest.dataset_source, "a:b");
+  EXPECT_EQ(longest.bare, "/t/f");
+
+  const std::vector<std::string> only_a = {"a"};
+  const auto shorter = splitDatasetQualifier(name, only_a);
+  EXPECT_EQ(shorter.dataset_source, "a");
+  EXPECT_EQ(shorter.bare, "b:/t/f");
+}
+
+TEST(SplitDatasetQualifier, ColonsStayBareUnlessALoadedPrefixMatches) {
+  const std::vector<std::string> sources = {"run"};
+  const auto bare = splitDatasetQualifier("sensor:status/value", sources);
+  EXPECT_FALSE(bare.qualified);
+  EXPECT_EQ(bare.bare, "sensor:status/value");
+
+  const auto qualified = splitDatasetQualifier("run:sensor:status/value", sources);
+  EXPECT_EQ(qualified.dataset_source, "run");
+  EXPECT_EQ(qualified.bare, "sensor:status/value");
 }
 
 }  // namespace

--- a/pj_base/tests/dataset_qualified_name_test.cpp
+++ b/pj_base/tests/dataset_qualified_name_test.cpp
@@ -1,0 +1,71 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pj_base/sdk/dataset_qualified_name.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace PJ::sdk {
+namespace {
+
+TEST(SplitDatasetQualifier, MatchesOnlyKnownSourceNames) {
+  const std::vector<std::string> sources = {"run_a.mcap", "run_b.mcap"};
+  const auto hit = splitDatasetQualifier("run_a.mcap:/speed/value", sources);
+  EXPECT_TRUE(hit.qualified);
+  EXPECT_EQ(hit.dataset_source, "run_a.mcap");
+  EXPECT_EQ(hit.bare, "/speed/value");
+
+  // A ':' whose prefix is no loaded source is part of the name, not a qualifier.
+  const std::vector<std::string> other = {"other.mcap"};
+  const auto miss = splitDatasetQualifier("run_a.mcap:/speed/value", other);
+  EXPECT_FALSE(miss.qualified);
+  EXPECT_TRUE(miss.dataset_source.empty());
+  EXPECT_EQ(miss.bare, "run_a.mcap:/speed/value");
+}
+
+TEST(SplitDatasetQualifier, StreamStyleNamesNeedNoEscaping) {
+  const std::vector<std::string> sources = {"[stream] UDP Server"};
+  const auto split = splitDatasetQualifier("[stream] UDP Server:/udp/data/value", sources);
+  EXPECT_TRUE(split.qualified);
+  EXPECT_EQ(split.dataset_source, "[stream] UDP Server");
+  EXPECT_EQ(split.bare, "/udp/data/value");
+}
+
+TEST(SplitDatasetQualifier, LongestKnownNameWins) {
+  const std::vector<std::string> sources = {"a", "a:b"};
+  const auto split = splitDatasetQualifier("a:b:/t/f", sources);
+  EXPECT_TRUE(split.qualified);
+  EXPECT_EQ(split.dataset_source, "a:b");
+  EXPECT_EQ(split.bare, "/t/f");
+}
+
+TEST(SplitDatasetQualifier, EmptyAndDegenerateInputs) {
+  const std::vector<std::string> sources = {"", "run_a.mcap"};
+  // An empty source name never qualifies anything.
+  EXPECT_FALSE(splitDatasetQualifier(":/speed/value", sources).qualified);
+  // The bare name alone (no ':' after a known source) stays bare.
+  EXPECT_FALSE(splitDatasetQualifier("run_a.mcap", sources).qualified);
+  // A qualifier with nothing after the ':' splits to an empty bare name.
+  const auto empty_bare = splitDatasetQualifier("run_a.mcap:", sources);
+  EXPECT_TRUE(empty_bare.qualified);
+  EXPECT_EQ(empty_bare.bare, "");
+  // No datasets loaded: nothing can qualify.
+  EXPECT_FALSE(splitDatasetQualifier("run_a.mcap:/speed/value", {}).qualified);
+}
+
+TEST(QualifiedSeriesName, RoundTripsThroughSplit) {
+  const std::vector<std::string> sources = {"run_a.mcap", "session 12.mcap"};
+  const std::string qualified = qualifiedSeriesName("session 12.mcap", "/imu/accel/x");
+  EXPECT_EQ(qualified, "session 12.mcap:/imu/accel/x");
+
+  const auto split = splitDatasetQualifier(qualified, sources);
+  EXPECT_TRUE(split.qualified);
+  EXPECT_EQ(split.dataset_source, "session 12.mcap");
+  EXPECT_EQ(split.bare, "/imu/accel/x");
+}
+
+}  // namespace
+}  // namespace PJ::sdk

--- a/pj_base/tests/playback_viewport_api_test.cpp
+++ b/pj_base/tests/playback_viewport_api_test.cpp
@@ -1,0 +1,268 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "pj_base/plugin_data_api.h"
+#include "pj_base/sdk/plugin_data_api.hpp"
+
+namespace PJ {
+namespace {
+
+// Fake host for pj.playback.v1: records the last call and serves a settable
+// state snapshot. to_display_time applies a fixed offset so the args-to-result
+// path is observable.
+struct FakePlaybackHost {
+  bool play_called = false;
+  bool pause_called = false;
+  double last_seek_s = 0.0;
+  double last_rate = 0.0;
+  bool should_fail = false;
+
+  PJ_playback_state_t state{};
+
+  std::string last_topic;
+  int64_t last_absolute_ns = 0;
+  int64_t display_offset_ns = 0;
+};
+
+bool pbFail(FakePlaybackHost* self, PJ_error_t* out_error) noexcept {
+  if (self->should_fail) {
+    sdk::fillError(out_error, 1, "playback", "playback boom");
+    return true;
+  }
+  return false;
+}
+
+bool pbPlay(void* ctx, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->play_called = true;
+  return true;
+}
+
+bool pbPause(void* ctx, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->pause_called = true;
+  return true;
+}
+
+bool pbSeek(void* ctx, double time_s, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->last_seek_s = time_s;
+  return true;
+}
+
+bool pbSetRate(void* ctx, double rate, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->last_rate = rate;
+  return true;
+}
+
+bool pbGetState(void* ctx, PJ_playback_state_t* out_state, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  *out_state = self->state;
+  return true;
+}
+
+bool pbToDisplayTime(
+    void* ctx, PJ_string_view_t topic, int64_t absolute_ns, double* out_display_s, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->last_topic = std::string(sdk::toStringView(topic));
+  self->last_absolute_ns = absolute_ns;
+  *out_display_s = static_cast<double>(absolute_ns - self->display_offset_ns) * 1e-9;
+  return true;
+}
+
+PJ_playback_host_vtable_t makePlaybackVtable() {
+  return PJ_playback_host_vtable_t{
+      .protocol_version = 1,
+      .struct_size = sizeof(PJ_playback_host_vtable_t),
+      .play = pbPlay,
+      .pause = pbPause,
+      .seek = pbSeek,
+      .set_playback_rate = pbSetRate,
+      .get_state = pbGetState,
+      .to_display_time = pbToDisplayTime,
+  };
+}
+
+// Fake host for pj.viewport.v1: records the last zoom call.
+struct FakeViewportHost {
+  double last_t0_s = 0.0;
+  double last_t1_s = 0.0;
+  bool reset_called = false;
+  bool should_fail = false;
+};
+
+bool vpZoom(void* ctx, double t0_s, double t1_s, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakeViewportHost*>(ctx);
+  if (self->should_fail) {
+    sdk::fillError(out_error, 1, "viewport", "zoom boom");
+    return false;
+  }
+  self->last_t0_s = t0_s;
+  self->last_t1_s = t1_s;
+  return true;
+}
+
+bool vpReset(void* ctx, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakeViewportHost*>(ctx);
+  if (self->should_fail) {
+    sdk::fillError(out_error, 1, "viewport", "reset boom");
+    return false;
+  }
+  self->reset_called = true;
+  return true;
+}
+
+PJ_viewport_host_vtable_t makeViewportVtable() {
+  return PJ_viewport_host_vtable_t{
+      .protocol_version = 1,
+      .struct_size = sizeof(PJ_viewport_host_vtable_t),
+      .zoom_to_time_range = vpZoom,
+      .zoom_reset = vpReset,
+  };
+}
+
+// --- PlaybackHostView --------------------------------------------------------
+
+TEST(PlaybackApiTest, PlayPauseForwardToHost) {
+  FakePlaybackHost host;
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.play());
+  EXPECT_TRUE(host.play_called);
+  ASSERT_TRUE(view.pause());
+  EXPECT_TRUE(host.pause_called);
+}
+
+TEST(PlaybackApiTest, SeekAndRateForwardValues) {
+  FakePlaybackHost host;
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.seek(42.25));
+  EXPECT_DOUBLE_EQ(host.last_seek_s, 42.25);
+  ASSERT_TRUE(view.setPlaybackRate(0.5));
+  EXPECT_DOUBLE_EQ(host.last_rate, 0.5);
+}
+
+TEST(PlaybackApiTest, StateMarshalsAllFields) {
+  FakePlaybackHost host;
+  host.state = PJ_playback_state_t{
+      .is_playing = true, .current_time_s = 12.5, .range_min_s = 1.0, .range_max_s = 99.0, .playback_rate = 2.0};
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto state = view.state();
+  ASSERT_TRUE(state) << state.error();
+  EXPECT_TRUE(state->is_playing);
+  EXPECT_DOUBLE_EQ(state->current_time_s, 12.5);
+  EXPECT_DOUBLE_EQ(state->range_min_s, 1.0);
+  EXPECT_DOUBLE_EQ(state->range_max_s, 99.0);
+  EXPECT_DOUBLE_EQ(state->playback_rate, 2.0);
+}
+
+TEST(PlaybackApiTest, ToDisplayTimeForwardsTopicAndConverts) {
+  FakePlaybackHost host;
+  host.display_offset_ns = 1'000'000'000;  // 1 s
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto display_s = view.toDisplayTime("imu/accel", 3'500'000'000);
+  ASSERT_TRUE(display_s) << display_s.error();
+  EXPECT_EQ(host.last_topic, "imu/accel");
+  EXPECT_EQ(host.last_absolute_ns, 3'500'000'000);
+  EXPECT_DOUBLE_EQ(*display_s, 2.5);
+}
+
+TEST(PlaybackApiTest, HostFailureSurfacesError) {
+  FakePlaybackHost host;
+  host.should_fail = true;
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto status = view.play();
+  EXPECT_FALSE(status);
+  EXPECT_NE(status.error().find("playback boom"), std::string::npos);
+}
+
+TEST(PlaybackApiTest, UnboundViewReportsNotBound) {
+  sdk::PlaybackHostView view;  // default-constructed = not bound
+  EXPECT_FALSE(view.valid());
+
+  EXPECT_FALSE(view.play());
+  EXPECT_FALSE(view.pause());
+  EXPECT_FALSE(view.seek(0.0));
+  EXPECT_FALSE(view.setPlaybackRate(1.0));
+  EXPECT_FALSE(view.state());
+  auto converted = view.toDisplayTime("t", 0);
+  EXPECT_FALSE(converted);
+  EXPECT_NE(converted.error().find("not bound"), std::string::npos);
+}
+
+// --- ViewportHostView --------------------------------------------------------
+
+TEST(ViewportApiTest, ZoomForwardsRange) {
+  FakeViewportHost host;
+  const auto vtable = makeViewportVtable();
+  sdk::ViewportHostView view(PJ_viewport_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.zoomToTimeRange(2.0, 8.5));
+  EXPECT_DOUBLE_EQ(host.last_t0_s, 2.0);
+  EXPECT_DOUBLE_EQ(host.last_t1_s, 8.5);
+}
+
+TEST(ViewportApiTest, ResetForwards) {
+  FakeViewportHost host;
+  const auto vtable = makeViewportVtable();
+  sdk::ViewportHostView view(PJ_viewport_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.zoomReset());
+  EXPECT_TRUE(host.reset_called);
+}
+
+TEST(ViewportApiTest, HostFailureSurfacesError) {
+  FakeViewportHost host;
+  host.should_fail = true;
+  const auto vtable = makeViewportVtable();
+  sdk::ViewportHostView view(PJ_viewport_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto status = view.zoomToTimeRange(0.0, 1.0);
+  EXPECT_FALSE(status);
+  EXPECT_NE(status.error().find("zoom boom"), std::string::npos);
+}
+
+TEST(ViewportApiTest, UnboundViewReportsNotBound) {
+  sdk::ViewportHostView view;
+  EXPECT_FALSE(view.valid());
+
+  auto status = view.zoomReset();
+  EXPECT_FALSE(status);
+  EXPECT_NE(status.error().find("not bound"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace PJ

--- a/pj_base/tests/playback_viewport_api_test.cpp
+++ b/pj_base/tests/playback_viewport_api_test.cpp
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstring>
+#include <memory>
 #include <string>
 
 #include "pj_base/plugin_data_api.h"
@@ -25,6 +27,7 @@ struct FakePlaybackHost {
   PJ_playback_state_t state{};
 
   std::string last_topic;
+  PJ_data_source_handle_t last_source{};
   int64_t last_absolute_ns = 0;
   int64_t display_offset_ns = 0;
 };
@@ -94,6 +97,19 @@ bool pbToDisplayTime(
   return true;
 }
 
+bool pbToDisplayTimeForSource(
+    void* ctx, PJ_data_source_handle_t source, int64_t absolute_ns, double* out_display_s,
+    PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlaybackHost*>(ctx);
+  if (pbFail(self, out_error)) {
+    return false;
+  }
+  self->last_source = source;
+  self->last_absolute_ns = absolute_ns;
+  *out_display_s = static_cast<double>(absolute_ns - self->display_offset_ns) * 1e-9;
+  return true;
+}
+
 PJ_playback_host_vtable_t makePlaybackVtable() {
   return PJ_playback_host_vtable_t{
       .protocol_version = 1,
@@ -104,6 +120,7 @@ PJ_playback_host_vtable_t makePlaybackVtable() {
       .set_playback_rate = pbSetRate,
       .get_state = pbGetState,
       .to_display_time = pbToDisplayTime,
+      .to_display_time_for_source = pbToDisplayTimeForSource,
   };
 }
 
@@ -207,6 +224,47 @@ TEST(PlaybackApiTest, HostFailureSurfacesError) {
   auto status = view.play();
   EXPECT_FALSE(status);
   EXPECT_NE(status.error().find("playback boom"), std::string::npos);
+}
+
+TEST(PlaybackApiTest, SourceConversionForwardsHandleTimestampAndHostError) {
+  FakePlaybackHost host;
+  host.display_offset_ns = 1'000'000'000;
+  const auto vtable = makePlaybackVtable();
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+
+  const auto result = view.toDisplayTimeForSource({42}, 3'500'000'000);
+  ASSERT_TRUE(result) << result.error();
+  EXPECT_EQ(host.last_source.id, 42u);
+  EXPECT_EQ(host.last_absolute_ns, 3'500'000'000);
+  EXPECT_DOUBLE_EQ(*result, 2.5);
+
+  host.should_fail = true;
+  const auto failed = view.toDisplayTimeForSource({42}, 0);
+  ASSERT_FALSE(failed);
+  EXPECT_NE(failed.error().find("playback boom"), std::string::npos);
+}
+
+TEST(PlaybackApiTest, SourceConversionIsOptionalOnLegacyHosts) {
+  FakePlaybackHost host;
+  auto vtable = makePlaybackVtable();
+  vtable.to_display_time_for_source = nullptr;
+  sdk::PlaybackHostView view(PJ_playback_host_t{.ctx = &host, .vtable = &vtable});
+  EXPECT_FALSE(view.toDisplayTimeForSource({42}, 0));
+  EXPECT_TRUE(view.toDisplayTime("topic", 0));
+
+  // The allocation ends at the legacy vtable boundary, so ASAN detects a tail
+  // read performed before checking struct_size.
+  constexpr auto legacy_size = offsetof(PJ_playback_host_vtable_t, to_display_time_for_source);
+  vtable.struct_size = legacy_size;
+  auto legacy = std::make_unique<unsigned char[]>(legacy_size);
+  std::memcpy(legacy.get(), &vtable, legacy_size);
+  const sdk::PlaybackHostView old_view(
+      PJ_playback_host_t{.ctx = &host, .vtable = reinterpret_cast<const PJ_playback_host_vtable_t*>(legacy.get())});
+  const auto result = old_view.toDisplayTimeForSource({42}, 0);
+  ASSERT_FALSE(result);
+  EXPECT_NE(result.error().find("not supported"), std::string::npos);
+  EXPECT_TRUE(old_view.toDisplayTime("topic", 0));
+  EXPECT_FALSE(sdk::PlaybackHostView{}.toDisplayTimeForSource({42}, 0));
 }
 
 TEST(PlaybackApiTest, UnboundViewReportsNotBound) {

--- a/pj_base/tests/plot_markers_codec_test.cpp
+++ b/pj_base/tests/plot_markers_codec_test.cpp
@@ -46,10 +46,20 @@ TEST(PlotMarkersCodecTest, EmptySetProducesEmptyBytes) {
   EXPECT_TRUE(serializePlotMarkers(markers).empty());
 }
 
-TEST(PlotMarkersCodecTest, NullOrEmptyBufferIsError) {
-  EXPECT_FALSE(deserializePlotMarkers(nullptr, 0).has_value());
+// An empty buffer is the canonical encoding of an empty set (the replace-only
+// store's "clear" tombstone), so it round-trips instead of erroring.
+TEST(PlotMarkersCodecTest, EmptyBufferDecodesToEmptySet) {
+  const Expected<PlotMarkers> null_empty = deserializePlotMarkers(nullptr, 0);
+  ASSERT_TRUE(null_empty.has_value());
+  EXPECT_TRUE(null_empty->markers.empty());
   const uint8_t byte = 0;
-  EXPECT_FALSE(deserializePlotMarkers(&byte, 0).has_value());
+  const Expected<PlotMarkers> ptr_empty = deserializePlotMarkers(&byte, 0);
+  ASSERT_TRUE(ptr_empty.has_value());
+  EXPECT_TRUE(ptr_empty->markers.empty());
+}
+
+TEST(PlotMarkersCodecTest, NullBufferWithSizeIsError) {
+  EXPECT_FALSE(deserializePlotMarkers(nullptr, 4).has_value());
 }
 
 // -----------------------------------------------------------------------------

--- a/pj_base/tests/plot_tabs_api_test.cpp
+++ b/pj_base/tests/plot_tabs_api_test.cpp
@@ -95,7 +95,7 @@ bool ptListTabIds(
   for (uint64_t i = 0; i < filled; ++i) {
     out_ids[i] = sdk::toAbiString(self->tabs[i].id);
   }
-  *out_count = filled;
+  *out_count = total;
   return true;
 }
 
@@ -223,6 +223,26 @@ TEST(PlotTabApiTest, ListOnAnEmptyHostSucceedsWithNoTabs) {
   auto ids = view.list();
   ASSERT_TRUE(ids) << ids.error();
   EXPECT_TRUE(ids->empty());
+}
+
+TEST(PlotTabApiTest, ListGrowthReturnsAnErrorWithoutReadingPastCapacity) {
+  int calls = 0;
+  auto vtable = makePlotTabVtable();
+  vtable.list_tab_ids = [](void* ctx, PJ_string_view_t* out_ids, uint64_t capacity, uint64_t* out_count,
+                           PJ_error_t*) noexcept {
+    ++*static_cast<int*>(ctx);
+    *out_count = capacity == 0 ? 1 : 2;
+    if (capacity != 0) {
+      out_ids[0] = sdk::toAbiString("tab-a");
+    }
+    return true;
+  };
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &calls, .vtable = &vtable});
+
+  auto ids = view.list();
+  ASSERT_FALSE(ids);
+  EXPECT_NE(ids.error().find("retry"), std::string::npos);
+  EXPECT_EQ(calls, 2);
 }
 
 TEST(PlotTabApiTest, ConfigReadsBackWhatWasActuallyAdded) {

--- a/pj_base/tests/plot_tabs_api_test.cpp
+++ b/pj_base/tests/plot_tabs_api_test.cpp
@@ -1,0 +1,375 @@
+// Copyright 2026 Davide Faconti
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "pj_base/plugin_data_api.h"
+#include "pj_base/sdk/plugin_data_api.hpp"
+
+namespace PJ {
+namespace {
+
+// Fake host for pj.plot_tabs.v1: a small model of tabs-with-curves, not a bare
+// recorder, so the round-trip tests below can assert on what a read-back
+// actually contains rather than merely that a call was forwarded.
+struct FakePlotTabHost {
+  struct Curve {
+    std::string topic;
+    std::string field;
+    std::string dataset;
+  };
+  struct Tab {
+    std::string id;
+    std::string title;
+    std::vector<Curve> curves;
+  };
+
+  std::vector<Tab> tabs;
+  bool should_fail = false;
+  std::string last_config_json;  // storage backing the borrowed tab_config out-string
+
+  Tab* find(std::string_view id) {
+    auto it = std::find_if(tabs.begin(), tabs.end(), [&](const Tab& t) { return t.id == id; });
+    return it == tabs.end() ? nullptr : &(*it);
+  }
+};
+
+bool ptFail(FakePlotTabHost* self, PJ_error_t* out_error) noexcept {
+  if (self->should_fail) {
+    sdk::fillError(out_error, 1, "plot_tabs", "tab boom");
+    return true;
+  }
+  return false;
+}
+
+bool ptCreateTab(void* ctx, PJ_string_view_t id, PJ_string_view_t title, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  const auto id_sv = sdk::toStringView(id);
+  auto* existing = self->find(id_sv);
+  if (existing != nullptr) {
+    existing->curves.clear();
+    existing->title = std::string(sdk::toStringView(title));
+    return true;
+  }
+  self->tabs.push_back(
+      FakePlotTabHost::Tab{.id = std::string(id_sv), .title = std::string(sdk::toStringView(title)), .curves = {}});
+  return true;
+}
+
+bool ptCloseTab(void* ctx, PJ_string_view_t id, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  const auto id_sv = sdk::toStringView(id);
+  auto it = std::find_if(self->tabs.begin(), self->tabs.end(), [&](const auto& t) { return t.id == id_sv; });
+  if (it == self->tabs.end()) {
+    sdk::fillError(out_error, 2, "plot_tabs", "unknown tab id");
+    return false;
+  }
+  self->tabs.erase(it);
+  return true;
+}
+
+bool ptListTabIds(
+    void* ctx, PJ_string_view_t* out_ids, uint64_t capacity, uint64_t* out_count, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  const auto total = static_cast<uint64_t>(self->tabs.size());
+  if (capacity == 0) {
+    *out_count = total;
+    return true;
+  }
+  const uint64_t filled = std::min(capacity, total);
+  for (uint64_t i = 0; i < filled; ++i) {
+    out_ids[i] = sdk::toAbiString(self->tabs[i].id);
+  }
+  *out_count = filled;
+  return true;
+}
+
+bool ptTabConfig(void* ctx, PJ_string_view_t id, PJ_string_view_t* out_config_json, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  auto* tab = self->find(sdk::toStringView(id));
+  if (tab == nullptr) {
+    sdk::fillError(out_error, 2, "plot_tabs", "unknown tab id");
+    return false;
+  }
+  std::string json = "{\"title\":\"" + tab->title + "\",\"curves\":[";
+  for (size_t i = 0; i < tab->curves.size(); ++i) {
+    if (i != 0) {
+      json += ",";
+    }
+    const auto& curve = tab->curves[i];
+    json +=
+        "{\"topic\":\"" + curve.topic + "\",\"field\":\"" + curve.field + "\",\"dataset\":\"" + curve.dataset + "\"}";
+  }
+  json += "]}";
+  self->last_config_json = std::move(json);
+  *out_config_json = sdk::toAbiString(self->last_config_json);
+  return true;
+}
+
+bool ptAddCurve(
+    void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field, PJ_string_view_t dataset_source,
+    PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  auto* tab = self->find(sdk::toStringView(id));
+  if (tab == nullptr) {
+    sdk::fillError(out_error, 2, "plot_tabs", "unknown tab id");
+    return false;
+  }
+  tab->curves.push_back(
+      FakePlotTabHost::Curve{
+          .topic = std::string(sdk::toStringView(topic)),
+          .field = std::string(sdk::toStringView(field)),
+          .dataset = std::string(sdk::toStringView(dataset_source))});
+  return true;
+}
+
+bool ptRemoveCurve(
+    void* ctx, PJ_string_view_t id, PJ_string_view_t topic, PJ_string_view_t field, PJ_string_view_t dataset_source,
+    PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  auto* tab = self->find(sdk::toStringView(id));
+  if (tab == nullptr) {
+    sdk::fillError(out_error, 2, "plot_tabs", "unknown tab id");
+    return false;
+  }
+  const auto topic_sv = sdk::toStringView(topic);
+  const auto field_sv = sdk::toStringView(field);
+  const auto dataset_sv = sdk::toStringView(dataset_source);
+  auto it = std::find_if(tab->curves.begin(), tab->curves.end(), [&](const auto& c) {
+    return c.topic == topic_sv && c.field == field_sv && c.dataset == dataset_sv;
+  });
+  if (it == tab->curves.end()) {
+    sdk::fillError(out_error, 3, "plot_tabs", "curve not present");
+    return false;
+  }
+  tab->curves.erase(it);
+  return true;
+}
+
+bool ptClearTab(void* ctx, PJ_string_view_t id, PJ_error_t* out_error) noexcept {
+  auto* self = static_cast<FakePlotTabHost*>(ctx);
+  if (ptFail(self, out_error)) {
+    return false;
+  }
+  auto* tab = self->find(sdk::toStringView(id));
+  if (tab == nullptr) {
+    sdk::fillError(out_error, 2, "plot_tabs", "unknown tab id");
+    return false;
+  }
+  tab->curves.clear();
+  return true;
+}
+
+PJ_plot_tab_host_vtable_t makePlotTabVtable() {
+  return PJ_plot_tab_host_vtable_t{
+      .protocol_version = 1,
+      .struct_size = sizeof(PJ_plot_tab_host_vtable_t),
+      .create_tab = ptCreateTab,
+      .close_tab = ptCloseTab,
+      .list_tab_ids = ptListTabIds,
+      .tab_config = ptTabConfig,
+      .add_curve = ptAddCurve,
+      .remove_curve = ptRemoveCurve,
+      .clear_tab = ptClearTab,
+  };
+}
+
+// --- PlotTabHostView --------------------------------------------------------
+
+TEST(PlotTabApiTest, CreateAndListRoundTrip) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a", "First"));
+  ASSERT_TRUE(view.create("tab-b", "Second"));
+
+  auto ids = view.list();
+  ASSERT_TRUE(ids) << ids.error();
+  ASSERT_EQ(ids->size(), 2u);
+  EXPECT_EQ((*ids)[0], "tab-a");
+  EXPECT_EQ((*ids)[1], "tab-b");
+}
+
+TEST(PlotTabApiTest, ListOnAnEmptyHostSucceedsWithNoTabs) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto ids = view.list();
+  ASSERT_TRUE(ids) << ids.error();
+  EXPECT_TRUE(ids->empty());
+}
+
+TEST(PlotTabApiTest, ConfigReadsBackWhatWasActuallyAdded) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a", "My Tab"));
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/accel", "x", "bag1"));
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/gyro", "y", "bag1"));
+
+  auto config = view.configOf("tab-a");
+  ASSERT_TRUE(config) << config.error();
+  EXPECT_NE(config->find("My Tab"), std::string::npos);
+  EXPECT_NE(config->find("imu/accel"), std::string::npos);
+  EXPECT_NE(config->find("imu/gyro"), std::string::npos);
+
+  const auto grown_size = config->size();
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/mag", "z", "bag1"));
+  auto config2 = view.configOf("tab-a");
+  ASSERT_TRUE(config2) << config2.error();
+  EXPECT_NE(config2->find("imu/mag"), std::string::npos);
+  EXPECT_GT(config2->size(), grown_size);
+}
+
+TEST(PlotTabApiTest, RemoveCurveThatIsNotThereIsAnError) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a"));
+  auto status = view.removeCurve("tab-a", "imu/accel", "x", "bag1");
+  EXPECT_FALSE(status);
+}
+
+TEST(PlotTabApiTest, ClearKeepsTheTab) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a", "My Tab"));
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/accel", "x", "bag1"));
+  ASSERT_TRUE(view.clear("tab-a"));
+
+  auto ids = view.list();
+  ASSERT_TRUE(ids) << ids.error();
+  ASSERT_EQ(ids->size(), 1u);
+  EXPECT_EQ((*ids)[0], "tab-a");
+
+  auto config = view.configOf("tab-a");
+  ASSERT_TRUE(config) << config.error();
+  EXPECT_EQ(config->find("imu/accel"), std::string::npos);
+}
+
+TEST(PlotTabApiTest, CloseRemovesTheTab) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a"));
+  ASSERT_TRUE(view.close("tab-a"));
+
+  auto ids = view.list();
+  ASSERT_TRUE(ids) << ids.error();
+  EXPECT_TRUE(ids->empty());
+
+  auto config = view.configOf("tab-a");
+  EXPECT_FALSE(config);
+}
+
+TEST(PlotTabApiTest, UnknownIdIsAnError) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  EXPECT_FALSE(view.addCurve("nope", "imu/accel", "x"));
+  EXPECT_FALSE(view.configOf("nope"));
+  EXPECT_FALSE(view.close("nope"));
+}
+
+TEST(PlotTabApiTest, HostFailureSurfacesTheMessage) {
+  FakePlotTabHost host;
+  host.should_fail = true;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  auto create_status = view.create("tab-a");
+  EXPECT_FALSE(create_status);
+  EXPECT_NE(create_status.error().find("tab boom"), std::string::npos);
+
+  auto add_status = view.addCurve("tab-a", "imu/accel", "x");
+  EXPECT_FALSE(add_status);
+  EXPECT_NE(add_status.error().find("tab boom"), std::string::npos);
+
+  auto list_status = view.list();
+  EXPECT_FALSE(list_status);
+  EXPECT_NE(list_status.error().find("tab boom"), std::string::npos);
+}
+
+TEST(PlotTabApiTest, UnboundViewReportsNotBound) {
+  sdk::PlotTabHostView view;  // default-constructed = not bound
+  EXPECT_FALSE(view.valid());
+
+  auto create_status = view.create("tab-a");
+  EXPECT_FALSE(create_status);
+  EXPECT_NE(create_status.error().find("not bound"), std::string::npos);
+
+  auto close_status = view.close("tab-a");
+  EXPECT_FALSE(close_status);
+  EXPECT_NE(close_status.error().find("not bound"), std::string::npos);
+
+  auto list_status = view.list();
+  EXPECT_FALSE(list_status);
+  EXPECT_NE(list_status.error().find("not bound"), std::string::npos);
+
+  auto config_status = view.configOf("tab-a");
+  EXPECT_FALSE(config_status);
+  EXPECT_NE(config_status.error().find("not bound"), std::string::npos);
+
+  auto add_status = view.addCurve("tab-a", "imu/accel", "x");
+  EXPECT_FALSE(add_status);
+  EXPECT_NE(add_status.error().find("not bound"), std::string::npos);
+
+  auto remove_status = view.removeCurve("tab-a", "imu/accel", "x");
+  EXPECT_FALSE(remove_status);
+  EXPECT_NE(remove_status.error().find("not bound"), std::string::npos);
+
+  auto clear_status = view.clear("tab-a");
+  EXPECT_FALSE(clear_status);
+  EXPECT_NE(clear_status.error().find("not bound"), std::string::npos);
+}
+
+TEST(PlotTabApiTest, DatasetQualifierReachesTheHost) {
+  FakePlotTabHost host;
+  const auto vtable = makePlotTabVtable();
+  sdk::PlotTabHostView view(PJ_plot_tab_host_t{.ctx = &host, .vtable = &vtable});
+
+  ASSERT_TRUE(view.create("tab-a"));
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/accel", "x", "bag1"));
+  ASSERT_TRUE(view.addCurve("tab-a", "imu/gyro", "y"));
+
+  auto* tab = host.find("tab-a");
+  ASSERT_NE(tab, nullptr);
+  ASSERT_EQ(tab->curves.size(), 2u);
+  EXPECT_EQ(tab->curves[0].dataset, "bag1");
+  EXPECT_TRUE(tab->curves[1].dataset.empty());
+}
+
+}  // namespace
+}  // namespace PJ

--- a/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/host/widget_event_builder.hpp
@@ -168,6 +168,15 @@ struct WidgetEventBuilder {
     return j.dump();
   }
 
+  /// QListWidget: a row's context menu (declared via the widget's
+  /// pj_context_actions .ui property, not part of this protocol) fired one of
+  /// its actions.
+  [[nodiscard]] static std::string itemContextAction(int index, std::string_view action_id) {
+    nlohmann::json j;
+    j["item_context_action"] = {{"index", index}, {"action", action_id}};
+    return j.dump();
+  }
+
   /// QTableWidget: a horizontal-header section was clicked (column index).
   /// Lets a plugin own column sorting — it re-sorts its row model and re-emits
   /// rows, keeping index-based selection/visibility consistent.

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/dialog_plugin_typed.hpp
@@ -73,6 +73,14 @@ class DialogPluginTyped : public DialogPluginBase {
     return false;
   }
 
+  /// A QListWidget row's context menu fired one of its actions. The action set
+  /// itself is not part of this protocol — it is a `.ui` dynamic property
+  /// (`pj_context_actions`) the host reads, the same way `pj_enable_when` is;
+  /// this only reports that one fired. `index` is the delivered-order row.
+  virtual bool onItemContextAction(std::string_view /*widget_name*/, int /*index*/, std::string_view /*action_id*/) {
+    return false;
+  }
+
   /// QTableWidget: a horizontal-header section (column) was clicked. Plugins
   /// that drive their own column sorting override this, re-order their row
   /// model, and re-emit — index-based selection/visibility stays consistent.
@@ -276,6 +284,13 @@ class DialogPluginTyped : public DialogPluginBase {
       return onStackedPageChanged(widget_name, *index, *page);
     }
 
+    // Ahead of the selection/double-click chain below (first-match-wins): a
+    // context-menu action and a selection/double-click event are never
+    // reported together, so ordering only matters for which optional a
+    // malformed payload could spuriously satisfy.
+    if (auto v = event.itemContextAction()) {
+      return onItemContextAction(widget_name, v->first, v->second);
+    }
     if (auto v = event.chartViewChanged()) {
       return onChartViewChanged(widget_name, v->x_min, v->x_max, v->y_min, v->y_max);
     }

--- a/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
+++ b/pj_plugins/dialog_protocol/include/pj_plugins/sdk/widget_event.hpp
@@ -10,6 +10,7 @@
 #include <pj_plugins/sdk/widget_data.hpp>  // TimelineMark, TreeCheckState
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace PJ {
@@ -294,6 +295,26 @@ class WidgetEvent {
   }
   std::optional<int> itemDeleteRequestedIndex() const {
     return getInt("item_delete_index");
+  }
+
+  /// QListWidget: a row's context menu fired one of its actions. The pair is
+  /// (delivered-order row index, the .ui-declared action id).
+  std::optional<std::pair<int, std::string>> itemContextAction() const {
+    auto it = data_.find("item_context_action");
+    if (it == data_.end() || !it->is_object()) {
+      return std::nullopt;
+    }
+    auto index = it->find("index");
+    auto action = it->find("action");
+    if (index == it->end() || action == it->end() || !action->is_string() ||
+        action->get_ref<const std::string&>().empty()) {
+      return std::nullopt;
+    }
+    auto decoded_index = decodeInt(*index);
+    if (!decoded_index.has_value() || *decoded_index < 0) {
+      return std::nullopt;
+    }
+    return std::make_pair(*decoded_index, action->get<std::string>());
   }
 
   /// QTableWidget: horizontal-header section clicked (returns column index)

--- a/pj_plugins/docs/ARCHITECTURE.md
+++ b/pj_plugins/docs/ARCHITECTURE.md
@@ -256,6 +256,16 @@ service registry, error out-params, and typed borrowed-dialog patterns):
   non-blocking diagnostics channel. Parsers report severity, a machine-stable
   code, representative text, and an occurrence count; the host aggregates by
   parser identity and bound schema/type without changing parse success.
+  `"pj.playback.v1"` (optional) gives a plugin programmatic control of the
+  host's playback cursor — play/pause/seek/rate plus a state snapshot and an
+  absolute-ns → display-seconds conversion — via a Qt-free
+  `sdk::PlaybackHostView`; every time in the service is display-axis seconds
+  (the numbers the plot X axes and the playback slider show), valid for the
+  current frame only because display offsets are per-dataset and user-editable.
+  `"pj.viewport.v1"` (optional) zooms every open time-series plot to a
+  display-seconds X window or resets all plots to fit
+  (`sdk::ViewportHostView`); hosts without plots (headless) simply do not
+  register it.
 - **Structured errors everywhere.** All fallible ABI calls take a
   `PJ_error_t* out_error` out-parameter. The old per-plugin `get_last_error`
   slot is gone.

--- a/pj_plugins/docs/ARCHITECTURE.md
+++ b/pj_plugins/docs/ARCHITECTURE.md
@@ -266,10 +266,16 @@ service registry, error out-params, and typed borrowed-dialog patterns):
   `sdk::PlaybackHostView`; every time in the service is display-axis seconds
   (the numbers the plot X axes and the playback slider show), valid for the
   current frame only because display offsets are per-dataset and user-editable.
+  `toDisplayTime(topic, ns)` rejects ambiguous nonempty topics; an empty topic
+  explicitly selects the representative dataset. The optional tail slot
+  `to_display_time_for_source`, wrapped by `toDisplayTimeForSource(handle, ns)`,
+  selects a catalog data-source handle directly and rejects unloaded handles.
+  Its wrapper checks `struct_size` and returns unsupported on older hosts.
   `"pj.plot_tabs.v1"` (optional) lets a plugin compose plotting tabs **of its
   own** — create one, place and remove curves by (topic, field, dataset),
   read back what it actually holds, close it (`sdk::PlotTabHostView`). Ids are
-  plugin-chosen and namespaced per plugin, as in `"pj.data_processors.v1"`, and
+  plugin-chosen and namespaced per plugin, as in `"pj.data_processors.v1"`.
+  They are independent of titles (which may repeat or be renamed) and tab order;
   every slot is scoped to the caller's own tabs: a tab the plugin did not create
   is rejected exactly as an unknown id, so the user's tabs are never disclosed
   or touched. `"pj.viewport.v1"` (optional) zooms to a display-seconds X window
@@ -277,6 +283,9 @@ service registry, error out-params, and typed borrowed-dialog patterns):
   tabs** — the boundary is the view, not the transport, which is why
   `"pj.playback.v1"` stays global. Hosts without plots (headless) simply do not
   register either.
+  Examples, handle selection, and the catalog-dependent qualifier limitations
+  are in `toolbox-guide.md` under "Playback, viewport, and owned tabs" and
+  "Dataset-qualified processor inputs".
 - **Structured errors everywhere.** All fallible ABI calls take a
   `PJ_error_t* out_error` out-parameter. The old per-plugin `get_last_error`
   slot is gone.

--- a/pj_plugins/docs/ARCHITECTURE.md
+++ b/pj_plugins/docs/ARCHITECTURE.md
@@ -239,7 +239,11 @@ service registry, error out-params, and typed borrowed-dialog patterns):
   `pj_base/descriptor_import_protocol.h`. `"pj.data_processors.v1"` (optional) lets a toolbox create
   catalog-resident transform nodes in the host by data — a script plus
   input/output names and a params JSON blob; nothing executable crosses the
-  boundary (the host owns execution). The script payload is **binary-safe**
+  boundary (the host owns execution). Input names may carry the dataset
+  qualifier `dataset_source:topic/field`, so a name several loaded datasets
+  share is addressed rather than guessed — rules are normative in
+  `plugin_data_api.h` (DATASET-QUALIFIED NAMES), shared parser/composer in
+  `pj_base/sdk/dataset_qualified_name.hpp`. The script payload is **binary-safe**
   (`PJ_string_view_t {data,size}`), so the native "door" is WASM bytes through
   this same data-only surface (a future host-owned WASM/Python backend is purely
   additive and survives plugin unload) — deliberately *not* a C++ kernel vtable

--- a/pj_plugins/docs/ARCHITECTURE.md
+++ b/pj_plugins/docs/ARCHITECTURE.md
@@ -262,10 +262,17 @@ service registry, error out-params, and typed borrowed-dialog patterns):
   `sdk::PlaybackHostView`; every time in the service is display-axis seconds
   (the numbers the plot X axes and the playback slider show), valid for the
   current frame only because display offsets are per-dataset and user-editable.
-  `"pj.viewport.v1"` (optional) zooms every open time-series plot to a
-  display-seconds X window or resets all plots to fit
-  (`sdk::ViewportHostView`); hosts without plots (headless) simply do not
-  register it.
+  `"pj.plot_tabs.v1"` (optional) lets a plugin compose plotting tabs **of its
+  own** — create one, place and remove curves by (topic, field, dataset),
+  read back what it actually holds, close it (`sdk::PlotTabHostView`). Ids are
+  plugin-chosen and namespaced per plugin, as in `"pj.data_processors.v1"`, and
+  every slot is scoped to the caller's own tabs: a tab the plugin did not create
+  is rejected exactly as an unknown id, so the user's tabs are never disclosed
+  or touched. `"pj.viewport.v1"` (optional) zooms to a display-seconds X window
+  or resets to fit (`sdk::ViewportHostView`), **bounded to those same owned
+  tabs** — the boundary is the view, not the transport, which is why
+  `"pj.playback.v1"` stays global. Hosts without plots (headless) simply do not
+  register either.
 - **Structured errors everywhere.** All fallible ABI calls take a
   `PJ_error_t* out_error` out-parameter. The old per-plugin `get_last_error`
   slot is gone.

--- a/pj_plugins/docs/dialog-plugin-guide.md
+++ b/pj_plugins/docs/dialog-plugin-guide.md
@@ -25,6 +25,25 @@ compile-time error.
 | The `QDialogButtonBox` MUST set the `standardButtons` property in the XML | Without it, the box instantiates with no buttons even when found by name. |
 | Every interactive widget MUST have a unique `objectName` | All `WidgetData` setters and event handlers address widgets by name. |
 
+### Optional: conditional field enabling (`pj_enable_when`)
+
+Any widget may carry a string **dynamic property** `pj_enable_when` with the
+value `"<comboObjectName>:<index>[,<index>...]"`. The host keeps the widget
+enabled only while the named `QComboBox` (looked up in the same widget tree)
+sits on one of those indices, applying the initial state at load and tracking
+index changes live — including inside modal sub-dialogs, whose nested event
+loop blocks the plugin from pushing `setEnabled` updates itself. Rules
+re-assert after every widget-data apply, so a rule always wins over a
+plugin-pushed `enabled` on the same widget. Malformed values or unknown combo
+names are ignored (the widget stays as authored). Typical use: a backend
+selector combo greying out the fields of the non-selected backend.
+
+```xml
+<widget class="QLineEdit" name="ollamaUrlEdit">
+ <property name="pj_enable_when" stdset="0"><string>backendCombo:0</string></property>
+</widget>
+```
+
 ## What is a Dialog Plugin?
 
 A dialog plugin is a shared library (`.so` / `.dylib` / `.dll`) that drives a

--- a/pj_plugins/docs/dialog-plugin-guide.md
+++ b/pj_plugins/docs/dialog-plugin-guide.md
@@ -25,22 +25,34 @@ compile-time error.
 | The `QDialogButtonBox` MUST set the `standardButtons` property in the XML | Without it, the box instantiates with no buttons even when found by name. |
 | Every interactive widget MUST have a unique `objectName` | All `WidgetData` setters and event handlers address widgets by name. |
 
-### Optional: conditional field enabling (`pj_enable_when`)
+### Optional: conditional field enabling and visibility (`pj_enable_when`, `pj_visible_when`)
 
-Any widget may carry a string **dynamic property** `pj_enable_when` with the
-value `"<comboObjectName>:<index>[,<index>...]"`. The host keeps the widget
-enabled only while the named `QComboBox` (looked up in the same widget tree)
-sits on one of those indices, applying the initial state at load and tracking
-index changes live — including inside modal sub-dialogs, whose nested event
-loop blocks the plugin from pushing `setEnabled` updates itself. Rules
-re-assert after every widget-data apply, so a rule always wins over a
-plugin-pushed `enabled` on the same widget. Malformed values or unknown combo
-names are ignored (the widget stays as authored). Typical use: a backend
-selector combo greying out the fields of the non-selected backend.
+Any widget may carry a string **dynamic property** `pj_enable_when` or
+`pj_visible_when` with the value `"<comboObjectName>:<index>[,<index>...]"`.
+The host keeps the widget enabled (or visible) only while the named
+`QComboBox` (looked up in the same widget tree) sits on one of those indices,
+applying the initial state at load and tracking index changes live —
+including inside modal sub-dialogs, whose nested event loop blocks the plugin
+from pushing `setEnabled`/`setVisible` updates itself. Several clauses may be
+joined with `;`; the widget is enabled/visible only while ALL of them hold
+(`"backendCombo:0;modelCombo:1"`: the custom-model field of backend 0, shown
+only when its model combo says "Custom"). Rules re-assert after every
+widget-data apply, so a rule always wins over a plugin-pushed
+`enabled`/`visible` on the same widget. Malformed values or unknown combo
+names are ignored (the widget stays as authored).
+
+Use `pj_visible_when` for sections that belong to one choice: a hidden widget
+leaves its layout, so tagging both the label and the editor of a
+`QFormLayout` row makes the whole row disappear and the dialog compact.
+`pj_enable_when` keeps the row in place, greyed — for a field that exists in
+every mode but only applies in some.
 
 ```xml
+<widget class="QLabel" name="ollamaUrlLabel">
+ <property name="pj_visible_when" stdset="0"><string>backendCombo:0</string></property>
+</widget>
 <widget class="QLineEdit" name="ollamaUrlEdit">
- <property name="pj_enable_when" stdset="0"><string>backendCombo:0</string></property>
+ <property name="pj_visible_when" stdset="0"><string>backendCombo:0</string></property>
 </widget>
 ```
 

--- a/pj_plugins/docs/dialog-plugin-guide.md
+++ b/pj_plugins/docs/dialog-plugin-guide.md
@@ -56,6 +56,29 @@ every mode but only applies in some.
 </widget>
 ```
 
+### Optional: per-row context menu (`pj_context_actions`)
+
+A `QListWidget` may carry a string dynamic property `pj_context_actions` with
+the value `"<id>=<Label>[;<id2>=<Label 2>...]"`. The host builds a right-click
+context menu from the clauses, in declaration order, and popups only over a
+row (an empty area shows nothing). Choosing an entry dispatches
+`onItemContextAction(widget_name, index, action_id)` with the delivered-order
+row index — the same translation `onItemDoubleClicked` and
+`onItemDeleteRequested` already do, so a sorted or re-ordered list still
+reports the row the plugin expects. A malformed clause (no `=`, empty id or
+label) is skipped; the rest of the menu still builds.
+
+The action set itself is host-rendered UI, not part of this C ABI — only the
+fact that an action fired crosses the wire. `pj_context_actions` and
+`onItemContextAction` are additive: existing lists with no property keep their
+current (menu-less) behavior.
+
+```xml
+<widget class="QListWidget" name="sessionsList">
+ <property name="pj_context_actions" stdset="0"><string>rename=Rename;delete=Delete</string></property>
+</widget>
+```
+
 ## What is a Dialog Plugin?
 
 A dialog plugin is a shared library (`.so` / `.dylib` / `.dll`) that drives a

--- a/pj_plugins/docs/toolbox-guide.md
+++ b/pj_plugins/docs/toolbox-guide.md
@@ -184,7 +184,8 @@ The host guarantees the following call ordering:
 
 ## Host Services Available to Plugins
 
-Two host services are provided before the plugin becomes interactive:
+The data and runtime hosts are bound before the plugin becomes interactive.
+Additional optional services are acquired through `services().get<Service>()`.
 
 ### Toolbox host — data plane
 
@@ -213,6 +214,76 @@ Access via `runtimeHost()`. Use this for diagnostics and UI refresh.
 |---|---|
 | `reportMessage(level, text)` | Send info/warning/error to the host UI log. |
 | `notifyDataChanged()` | Tell the host that data was modified; refresh UI. Idempotent and cheap; coalesce per logical operation, not per record. |
+
+### Playback, viewport, and owned tabs (SDK 0.28.0)
+
+Include `pj_base/sdk/service_traits.hpp` and acquire the services you need:
+
+| Service trait | Methods and scope |
+|---|---|
+| `PJ::sdk::PlaybackHostService` | `play`, `pause`, `seek`, `setPlaybackRate`, `state`: the global playback cursor. `toDisplayTime` and `toDisplayTimeForSource` convert absolute nanoseconds to display-axis seconds. |
+| `PJ::sdk::PlotTabHostService` | `create`, `close`, `list`, `configOf`, `addCurve`, `removeCurve`, `clear`: only the calling plugin's tabs. |
+| `PJ::sdk::ViewportHostService` | `zoomToTimeRange`, `zoomReset`: all eligible plots in the calling plugin's tabs. |
+
+All calls run on the main thread. Services are optional; check acquisition and
+each operation's result. A host offering viewport control also offers owned tabs.
+Zoom preserves each plot's Y range, skips empty/XY plots, and fails if nothing is
+eligible. Playback and viewport coordinates use **display-axis seconds**;
+read/write timestamps use **absolute int64 nanoseconds**.
+
+Choose the source from a fresh `toolboxHost().catalogSnapshot()`: each
+`dataSources()` entry has a `handle`, and each `topics()` entry has its owning
+`source` handle. Retain that identity with the selected series instead of looking
+it up again by a potentially duplicated source or topic name. For example, in a
+toolbox callback:
+
+```cpp
+#include <pj_base/sdk/service_traits.hpp>
+
+PJ::Status MyToolbox::seekSample(PJ::sdk::DataSourceHandle source, int64_t absolute_ns) {
+  auto playback = services().require<PJ::sdk::PlaybackHostService>();
+  if (!playback) {
+    return PJ::unexpected(playback.error());
+  }
+  auto seconds = playback->toDisplayTimeForSource(source, absolute_ns);
+  if (!seconds) {
+    return PJ::unexpected(seconds.error());
+  }
+  return playback->seek(*seconds);
+}
+```
+
+`toDisplayTimeForSource` rejects invalid/unloaded handles. Its optional C tail
+slot, `to_display_time_for_source`, is guarded by `struct_size` and nullability;
+the C++ wrapper returns an unsupported error on older hosts. Do not silently
+fall back to another dataset. The existing `toDisplayTime(topic, absolute_ns)`
+requires a nonempty topic to identify exactly one loaded dataset; an empty topic
+explicitly selects the host's representative dataset. Converted values must be
+recomputed after user edits to source offsets or the time reference.
+
+Tab `id` and visible `title` are separate: `create("run-a", "Temperature")` and
+`create("run-b", "Temperature")` create two independently addressable tabs.
+Renaming or changing tab order does not change their IDs. Recreating an ID
+replaces its contents. IDs are scoped to the plugin binding and live only while
+`list()` returns them; re-read after workspace changes. `configOf(id)` reports
+the resolved curves and title. An `addCurve`/`removeCurve` call takes topic,
+field, and optional dataset source separately; an omitted dataset must resolve
+uniquely. The host prevents access to other plugins' and user-created tabs.
+
+### Dataset-qualified processor inputs
+
+`pj.data_processors.v1` accepts `dataset_source:topic/field` inputs via the shared
+`pj_base/sdk/dataset_qualified_name.hpp` helper. This is a catalog-dependent
+lookup syntax: the longest loaded source prefix wins, and an unmatched prefix
+leaves the entire string as a bare lookup, without stripping it. Unknown whole
+names and ambiguous dataset matches fail. A processor's qualified inputs must
+agree on one dataset. Marker per-series output keys follow the same rule;
+transform output names create new topics and are unqualified.
+
+Colons can occur in both parts: `(a, b:/t/f)` and `(a:b, /t/f)` compose identically,
+and with both sources loaded the parser chooses `a:b`. Composition round-trips
+only when the intended source is the longest matching prefix. Do not treat this
+string as a persistent dataset identity. Hosts still validate the split result.
 
 ### Reading a series via Arrow
 


### PR DESCRIPTION
Adds optional plugin playback, viewport, and owned-tab services, dataset-qualified processor input conventions, and dialog/marker fixes to the **unreleased 0.28.0** SDK. `VERSION` remains 0.28.0; every changelog entry is in that release. Existing service names and method signatures are preserved.

## Host services

- `pj.playback.v1`: global play/pause/seek/rate/state and absolute-ns to display-axis-seconds conversion. `toDisplayTime(topic, ns)` requires a unique dataset for a nonempty topic; empty topic explicitly selects the representative dataset.
- The optional tail slot `to_display_time_for_source`, wrapped by `PlaybackHostView::toDisplayTimeForSource(source_handle, ns)`, selects a catalog source directly. Invalid/unloaded handles fail. `struct_size` and null-slot checks let the wrapper report unsupported on older hosts without reading past the original vtable. Existing topic conversion remains available.
- `pj.plot_tabs.v1`: create/replace, close, list, read configuration, add/remove curves, and clear a plugin's own tabs. Stable plugin-scoped IDs are independent of titles and order; duplicate titles are allowed. Curves use separate topic, field, and dataset-source arguments. The list wrapper rejects a growing count rather than reading beyond its allocation.
- `pj.viewport.v1`: zoom/reset the calling plugin's own plots. Time-range zoom preserves Y and skips empty/XY plots. The three services remain separate; playback remains global.

## Dataset-qualified inputs

The shared `pj_base/sdk/dataset_qualified_name.hpp` helper defines catalog-dependent `dataset_source:topic/field` lookups. The longest loaded source prefix wins; an unmatched prefix leaves the entire string as a bare lookup, with no guessed prefix stripping. Hosts reject unknown whole names and ambiguous dataset matches; qualified inputs of one processor must agree on one dataset.

Colons in both parts can create overlapping interpretations: `(a, b:/t/f)` and `(a:b, /t/f)` compose identically. Documentation and regression tests make this limitation explicit instead of promising unconditional round trips or detection of unknown qualifiers.

## Other included changes

- Empty PlotMarkers bytes decode as an empty set; malformed nonempty data still fails.
- Named rejected/internal ABI error codes.
- Declarative dialog enable/visibility documentation and list-row context-action events.
- Toolbox authoring examples and agent entry points updated in the root `CLAUDE.md`, plugin architecture/guide, and plugin-authoring reference. The source-conversion example is syntax-checked against the SDK headers.

## Validation and companions

- `./build.sh --debug && ./test.sh`: **88/88 test executables passed with ASAN**.
- New coverage: source/timestamp forwarding, host errors, null/short legacy vtables, fixed ABI slot offsets, colon/prefix precedence, and growing tab enumeration.
- Pre-commit checks passed. `VERSION` and `abi/baseline.abi` are unchanged.
- Companion host implementation: PlotJuggler/PJ4#573. Shared naming helper adoption: PlotJuggler/PJ4#619. The SDK parser test target has a distinct name so both projects configure together.
