### PR TITLE
Remove dangling references and environment-specific paths

### DIFF
--- a/.claude/commands/test-and-commit.md
+++ b/.claude/commands/test-and-commit.md
@@ -2,6 +2,6 @@ Validate and commit staged/unstaged changes. Run these steps in order, stopping 
 
 1. `./build.sh --debug` — Debug+ASAN build must succeed
 2. `./test.sh` — all tests must pass
-3. `./run_clang_tidy.sh` — no clang-tidy warnings
+3. `git ls-files -z '*.cpp' | xargs -0 clang-tidy-22 -p build` — no clang-tidy warnings
 
 If all three pass, create a git commit following the repo's commit conventions (see git log for style). If any step fails, fix the issue and re-run from step 1.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,22 +138,24 @@ jobs:
           # Anonymous read is enabled on the remote, so no login is needed here.
           conan remote add plotjuggler-conan "${JFROG_CONAN_URL}" --force
 
+          remote_revs="$(mktemp "${RUNNER_TEMP}/remote_revs.XXXXXX.json")"
+          trap 'rm -f "${remote_revs}"' EXIT
           conan list "plotjuggler_sdk/${version}#*" -r plotjuggler-conan --format=json \
-            > /tmp/remote_revs.json 2>/dev/null || true
+            > "${remote_revs}" 2>/dev/null || true
 
           # Artifactory reports an unknown recipe as a plain "404: Not Found";
           # conan_server / Cloudsmith use RECIPEUNKNOWN. Accept both.
-          if grep -q -E "RECIPEUNKNOWN|404: Not Found" /tmp/remote_revs.json; then
+          if grep -q -E "RECIPEUNKNOWN|404: Not Found" "${remote_revs}"; then
             echo "Version ${version} is not yet published — first release, proceeding."
-          elif grep -q '"error"' /tmp/remote_revs.json; then
+          elif grep -q '"error"' "${remote_revs}"; then
             # Fail closed: proceeding blind could publish changed sources under an
             # already-released version. The later authenticated upload would
             # succeed even if this anonymous read hit a 401/403/5xx.
             echo "::error::Could not read the published revisions of ${version} from the remote:"
-            cat /tmp/remote_revs.json
+            cat "${remote_revs}"
             echo "::error::Refusing to publish without the re-publish guard. Re-run once the remote is reachable, or use workflow_dispatch with allow_republish=true if you have verified the state by hand."
             exit 1
-          elif grep -q "${local_rrev}" /tmp/remote_revs.json; then
+          elif grep -q "${local_rrev}" "${remote_revs}"; then
             echo "Recipe revision ${local_rrev} is already published for ${version} — idempotent re-run, proceeding."
           else
             echo "::error::plotjuggler_sdk/${version} is already published with a different recipe revision."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ else()
   # -Werror only when explicitly requested (default ON, see option above) and
   # never on wasm32: there size_t is 32-bit, so many uint64_t->size_t
   # conversions trip -Wshorten-64-to-32 / -Wsign-conversion that never fire on
-  # 64-bit desktop (see SUSTAINABILITY.md T0-3). TODO: make the ABI/size types
-  # 32-bit-clean, then wasm can opt back into -Werror.
+  # 64-bit desktop. TODO: make the ABI/size types 32-bit-clean, then wasm can
+  # opt back into -Werror.
   if(PJ_WARNINGS_AS_ERRORS AND NOT EMSCRIPTEN)
     list(APPEND PJ_WARNING_FLAGS -Werror)
   endif()

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd plotjuggler_sdk
 ./build.sh              # RelWithDebInfo (build/)
 ./build.sh --debug      # Debug + ASAN (build/debug_asan)
 ./test.sh               # runs tests in all discovered build dirs
-./run_clang_tidy.sh     # clang-tidy via clangd-22
+git ls-files -z '*.cpp' | xargs -0 clang-tidy-22 -p build   # clang-tidy
 ```
 
 ## Project Layout

--- a/pj_plugins/docs/dialog-plugin-guide.md
+++ b/pj_plugins/docs/dialog-plugin-guide.md
@@ -773,7 +773,7 @@ PJ::FilePickerOptions options;
 options.mode = PJ::FilePickerMode::OpenFiles;
 options.title = "Select ROS bag files";
 options.accept_label = "Open";
-options.initial_directory = "/data/bags";
+options.initial_directory = {};  // host picks; set only if you have a real one
 options.filters = {
     {"bags", "ROS bag files", {"*.bag", "*.db3", "*.mcap"}},
     {"all", "All files", {"*"}},

--- a/pj_plugins/tests/source_dialog_integration_test.cpp
+++ b/pj_plugins/tests/source_dialog_integration_test.cpp
@@ -197,7 +197,7 @@ TEST(SourceDialogIntegration, BorrowedDialogHandleWorks) {
   EXPECT_FALSE(j.is_discarded());
 
   // sendEvent should work
-  bool refresh = dialog.sendEvent("host_input", R"({"text": "10.0.0.1"})");
+  bool refresh = dialog.sendEvent("host_input", R"({"text": "192.0.2.1"})");
   EXPECT_TRUE(refresh);
 
   // save_config should return valid JSON


### PR DESCRIPTION
An audit of the tracked tree turned up references that either **cannot resolve on a clean clone** or **assume one machine's environment**. Companion PRs exist for `PJ4` and `pj-official-plugins`.

This is the **public SDK**, so a reference that only resolves on a maintainer's machine reaches the widest audience of the three repositories — an external contributor hits it on their first `git clone`.

Scope rule applied: fix only what breaks or exposes a machine. **Genuine author/copyright attribution is deliberately untouched** — the 329 `Davide Faconti` copyright sites, `LICENSE`, `LICENSE-APACHE` and the upstream dependency URLs are all unchanged.

## Broken on a clean clone

| Cited from | Problem |
|---|---|
| `README.md:38` and `.claude/commands/test-and-commit.md:5` | Both instruct the reader to run **`./run_clang_tidy.sh`, which is not tracked**. It is step 3 of the documented getting-started flow, so every external contributor following the README hits it. Replaced with the equivalent `git ls-files … \| xargs clang-tidy` command in both places, kept in sync. |
| `CMakeLists.txt:58` | Cites **`SUSTAINABILITY.md` T0-3** for the wasm `-Werror` carve-out; no such file is tracked anywhere. The adjacent comment already explains the reason, so the dangling cross-reference is dropped and the comment stands on its own. |

## Environment-specific

- `pj_plugins/tests/source_dialog_integration_test.cpp:200` used `10.0.0.1` — RFC 1918 space that can overlap a contributor's real LAN. Now `192.0.2.1` (TEST-NET-1), the documentation-only equivalent, with identical test semantics.
- `pj_plugins/docs/dialog-plugin-guide.md:776` offered a **copyable** example with `initial_directory = "/data/bags"`, a root-level mount an arbitrary machine will not have. Now `{}`, letting the host pick.
- `.github/workflows/release.yml` wrote `/tmp/remote_revs.json` in five places rather than the runner-allocated temp dir, bypassing GitHub's temp-path abstraction and giving concurrent or local runs a fixed collision target. Now one `mktemp` under `$RUNNER_TEMP` with a cleanup trap, quoted at all five uses.

## Verification

- `release.yml` re-parsed as YAML after the edit.
- `clang-format --dry-run -Werror` clean on the changed test.
- **Not compiled.** The only C++ change is a string literal in a test; the rest is docs, CMake comments and CI shell.

## Deliberately not fixed

`pj_base/abi/baseline.abi` embeds `/home/runner/work/plotjuggler_core/...` on lines 1 and 100 — CI checkout paths baked into a **distributed** artifact. Regenerating it properly means re-running `abidw` with `--no-corpus-path --no-comp-dir-path --short-locs` (or a `-ffile-prefix-map` build) and diffing the result against the current ABI contract. That needs a build, so hand-editing the baseline would be worse than leaving it. Flagged for a follow-up.

Also left alone under the scope rule, since neither breaks nor exposes a machine: `CHANGELOG.md:748,766` names a person for the `pj.data_processors.v1` contract, and `pj_plugins/CMakeLists.txt:677` uses a "Keystone" codename that appears exactly once and is defined nowhere.

https://claude.ai/code/session_01JHCjCjntYefq2QyDagb8Dh
