### PR TITLE
pj_base: drop fmt from time_format.cpp (MSVC LNK2005 in consumers)

### DIFF
--- a/pj_base/CMakeLists.txt
+++ b/pj_base/CMakeLists.txt
@@ -53,9 +53,11 @@ target_compile_options(pj_base PRIVATE
 )
 # Header-only implementation dependencies stay off installed targets so
 # downstream consumers inherit neither their include paths nor link requirements.
+# Header-only fmt is deliberately NOT linked here: even header-only, its
+# implementation symbols land in the installed static archive and collide
+# with a consumer's own fmt under MSVC (see test_sdk_install.sh guard).
 target_link_libraries(pj_base PRIVATE
   $<BUILD_INTERFACE:FastFloat::fast_float>
-  $<BUILD_INTERFACE:pj_internal_fmt>
 )
 set_target_properties(pj_base PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/pj_base/src/time_format.cpp
+++ b/pj_base/src/time_format.cpp
@@ -3,10 +3,9 @@
 
 #include "pj_base/time_format.hpp"
 
-#include <fmt/format.h>
-
 #include <cctype>
 #include <chrono>
+#include <cstdio>
 
 #include "pj_base/time_math.hpp"
 
@@ -38,13 +37,23 @@ UtcTime utcFromNanoseconds(int64_t ts_ns) {
       static_cast<int>(time.seconds().count())};
 }
 
+// Plain snprintf, deliberately: linking fmt here would embed fmt
+// implementation symbols in the installed pj_base archive, which collide
+// (LNK2005) with any consumer that links its own fmt on MSVC.
 std::string formatDate(const UtcTime& utc, char separator, bool day_first) {
-  return day_first ? fmt::format("{:02}{}{:02}{}{:04}", utc.day, separator, utc.month, separator, utc.year)
-                   : fmt::format("{:04}{}{:02}{}{:02}", utc.year, separator, utc.month, separator, utc.day);
+  char buffer[32];
+  if (day_first) {
+    std::snprintf(buffer, sizeof buffer, "%02d%c%02d%c%04d", utc.day, separator, utc.month, separator, utc.year);
+  } else {
+    std::snprintf(buffer, sizeof buffer, "%04d%c%02d%c%02d", utc.year, separator, utc.month, separator, utc.day);
+  }
+  return buffer;
 }
 
 std::string formatTime(const UtcTime& utc) {
-  return fmt::format("{:02}:{:02}:{:02}", utc.hour, utc.minute, utc.second);
+  char buffer[16];
+  std::snprintf(buffer, sizeof buffer, "%02d:%02d:%02d", utc.hour, utc.minute, utc.second);
+  return buffer;
 }
 
 bool isDigit(char character) {
@@ -70,7 +79,12 @@ bool parseFixedDigits(std::string_view text, std::size_t offset, std::size_t cou
 
 std::string formatTimestamp(int64_t ts_ns, bool long_format) {
   const auto utc = utcFromNanoseconds(ts_ns);
-  return long_format ? fmt::format("{:02}/{:02} {}", utc.day, utc.month, formatTime(utc)) : formatTime(utc);
+  if (!long_format) {
+    return formatTime(utc);
+  }
+  char day_month[16];
+  std::snprintf(day_month, sizeof day_month, "%02d/%02d ", utc.day, utc.month);
+  return day_month + formatTime(utc);
 }
 
 std::string formatDuration(int64_t duration_ns) {

--- a/test_sdk_install.sh
+++ b/test_sdk_install.sh
@@ -123,5 +123,22 @@ if [[ $LEAKED -ne 0 ]]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# 6. Verify pj_base ships no fmt implementation symbols
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- Step 6: Verify libpj_base.a defines no fmt symbols ---"
+
+# fmt is a private, header-only implementation detail. If its implementation
+# symbols land in the installed archive (weak on ELF, so Linux links fine),
+# the MSVC build of the same code collides (LNK2005) with any consumer that
+# links its own fmt — this check makes the Windows failure visible on Linux.
+if nm -C "$STAGING_DIR/lib/libpj_base.a" | grep -E " [TWuVvW] " | grep -q "fmt::"; then
+  echo "ERROR: installed libpj_base.a defines fmt symbols (collides with a consumer's fmt on MSVC):"
+  nm -C "$STAGING_DIR/lib/libpj_base.a" | grep -E " [TWuVvW] " | grep "fmt::" | head -10
+  exit 1
+fi
+
 echo ""
 echo "=== plotjuggler_sdk install test PASSED ==="


### PR DESCRIPTION
## Problem

0.31.0's new `pj_base/src/time_format.cpp` formats via the private header-only fmt (`pj_internal_fmt`). Header-only mode still emits fmt's implementation symbols (`vformat`, `format_facet<locale>::do_put`, `detail::is_printable`, `detail::write_loc`, …) into `time_format.o`:

- **ELF (Linux/macOS)**: they are weak — the linker silently prefers the consumer's `libfmt`, so nothing failed.
- **MSVC**: they are COMDATs, and a consumer that links its own `fmt.lib` (strong, non-COMDAT `format.cc.obj`) gets **LNK2005 "already defined" → LNK1169**. This broke pj-official-plugins PR #291's Windows build (`toolbox_mosaico_plugin.dll` links both `pj_base.lib` and `fmt.lib`).

The 0.31.0 "no fmt in installed exports" validation was true at the CMake-interface level; the archive *contents* were the gap. The released `libpj_base.a` carries **92 defined fmt:: symbols**.

## Fix

`time_format.cpp` only zero-pads small integers — `snprintf` does that. Rewrite the three format helpers with `snprintf` and remove the `pj_internal_fmt` link from `pj_base` entirely. Output is byte-identical (the existing 24 formatter test vectors pin it).

`pj_plugins` (`plugin_catalog.cpp`) still uses `pj_internal_fmt`; that archive is linked by the **host**, not by plugins, so it is not part of this collision surface — left as is.

## Regression guard

`test_sdk_install.sh` Step 6: fail if the installed `libpj_base.a` defines any `fmt::` symbol (`nm -C | grep`). Verified it trips on the released 0.31.0 package archive (92 matches) and passes on this branch (0).

## Validation

- `./build.sh` + `./test.sh`: 95/95
- `./test_sdk_install.sh`: PASSED incl. the new Step 6
- `nm -C build/pj_base/libpj_base.a | grep -c fmt::` → 0

No tag/release here — a 0.31.1 patch release is the maintainer's call; pj-official-plugins #291 then just bumps its pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTJvEsHX26rG4cHmqppvQg